### PR TITLE
Supporting decimal stoichiometric coefficients

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -279,12 +279,6 @@ struct ReactionStruct
         # check if stoichiometric constants are true Floats or Integers in disguise.
         # substrates do not support decimal coefficients due to the ambiguity in
         # definition for the reaction rates. but production should not be a problem
-        # caveat: mass kinetics are disabled if this route is proceeded
-        # we verify the constants based on ns ReactantStructs
-        if count(rs -> rs.stoichiometry > 0 && !isinteger(rs.stoichiometry), ns) > 0
-            use_mass_kin = false
-        end
-
         if count(rs -> rs.stoichiometry < 0 && !isinteger(rs.stoichiometry), ns) > 0
             # fail: we do not support true "Float64" in stoichiometric coeffs
             # in reactants


### PR DESCRIPTION
This is a (very rough) Float-based implementation of: https://github.com/JuliaDiffEq/DiffEqBiological.jl/issues/161

It works for my particular ODE-based case but tests need to be run to ensure it does not break anything else. Alternate implementations using `Rational` or other methods are likely better suited to the problem, see #161 for discussion.