### PR TITLE
Add documentation mentions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ The generated models can then be used with solvers throughout the broader
 packages (e.g. for sensitivity analysis, parameter estimation,
 machine learning applications, etc).
 
+For information on using the package,
+[see the stable documentation](https://catalyst.sciml.ai/stable/). Use the
+[in-development documentation](https://catalyst.sciml.ai/dev/) for the version of
+the documentation which contains the unreleased features.
+
 ## Features
 
 - DSL provides a simple and readable format for manually specifying chemical reactions.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The generated models can then be used with solvers throughout the broader
 packages (e.g. for sensitivity analysis, parameter estimation,
 machine learning applications, etc).
 
+## Tutorials and Documentation
+
 For information on using the package,
 [see the stable documentation](https://catalyst.sciml.ai/stable/). Use the
 [in-development documentation](https://catalyst.sciml.ai/dev/) for the version of


### PR DESCRIPTION
Gotten comments before from non-Github users and non-Julia folk that they couldn't find the docs because they didn't know to look for the blue badges, so it's always good to put these few lines.