### PR TITLE
Generation of graphviz graphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
+Catlab = "0.7.2"
 Latexify = "0.13.5"
 MacroTools = "0.5"
 ModelingToolkit = "3.14"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
 version = "5.0.1"
 
 [deps]
+Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -25,4 +25,6 @@ export dependants, dependents
 # for Latex printing of ReactionSystems
 include("latexify_recipes.jl")
 
+include("graphs.jl")
+
 end # module

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -25,6 +25,11 @@ export dependants, dependents
 # for Latex printing of ReactionSystems
 include("latexify_recipes.jl")
 
+# for making and saving graphs
+import Base.Iterators: flatten
+using Catlab.Graphics.Graphviz
+import Catlab.Graphics.Graphviz: Graph, Edge
 include("graphs.jl")
+export savegraph
 
 end # module

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -1,0 +1,38 @@
+import Base.Iterators: flatten
+using Catlab.Graphics.Graphviz
+import Catlab.Graphics.Graphviz: Graph, Edge
+
+graph_attrs = Attributes(:rankdir=>"LR")
+node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")
+edge_attrs  = Attributes(:splines=>"splines")
+
+function edgify(δ, i, reverse::Bool)
+    attr = Attributes()
+    return map(δ) do p
+        val = String(p[1].op.name)
+      weight = "$(p[2])"
+      attr = Attributes(:label=>weight, :labelfontsize=>"6")
+      return Edge(reverse ? ["rx_$i", "$val"] :
+                            ["$val", "rx_$i"], attr)
+    end
+end
+
+"""
+    Graph(model::Model)
+
+convert a Model into a GraphViz Graph. Transition are green boxes and states are blue circles. Arrows go from the input states to the output states for each transition.
+"""
+function Graph(model::ReactionSystem)
+    rxs = reactions(model)
+    statenodes = [Node(string(s.name), Attributes(:shape=>"circle", :color=>"#6C9AC3")) for s in species(model)]
+    transnodes = [Node(string("rx_$i"), Attributes(:shape=>"square", :color=>"#E28F41")) for (i,r) in enumerate(rxs)]
+
+    stmts = vcat(statenodes, transnodes)
+    edges = map(enumerate(rxs)) do (i,r)
+      vcat(edgify(zip(r.substrates,r.substoich), i, false),
+           edgify(zip(r.products,r.prodstoich), i, true))
+    end |> flatten |> collect
+    stmts = vcat(stmts, edges)
+    g = Graphviz.Graph("G", true, stmts, graph_attrs, node_attrs,edge_attrs)
+    return g
+end

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -1,6 +1,3 @@
-import Base.Iterators: flatten
-using Catlab.Graphics.Graphviz
-import Catlab.Graphics.Graphviz: Graph, Edge
 
 graph_attrs = Attributes(:rankdir=>"LR")
 node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")
@@ -25,7 +22,7 @@ convert a Model into a GraphViz Graph. Transition are green boxes and states are
 function Graph(model::ReactionSystem)
     rxs = reactions(model)
     statenodes = [Node(string(s.name), Attributes(:shape=>"circle", :color=>"#6C9AC3")) for s in species(model)]
-    transnodes = [Node(string("rx_$i"), Attributes(:shape=>"square", :color=>"#E28F41")) for (i,r) in enumerate(rxs)]
+    transnodes = [Node(string("rx_$i"), Attributes(:shape=>"point", :color=>"#E28F41", :width=>".1")) for (i,r) in enumerate(rxs)]
 
     stmts = vcat(statenodes, transnodes)
     edges = map(enumerate(rxs)) do (i,r)
@@ -35,4 +32,12 @@ function Graph(model::ReactionSystem)
     stmts = vcat(stmts, edges)
     g = Graphviz.Graph("G", true, stmts, graph_attrs, node_attrs,edge_attrs)
     return g
+end
+
+
+function savegraph(g::Graph, fname, fmt="png")
+    open(fname, "w") do io
+        run_graphviz(io, g, format=fmt)
+    end 
+    nothing
 end

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -1,3 +1,5 @@
+# adapted from Petri.jl
+# https://github.com/mehalter/Petri.jl
 
 graph_attrs = Attributes(:rankdir=>"LR")
 node_attrs  = Attributes(:shape=>"plain", :style=>"filled", :color=>"white")


### PR DESCRIPTION
Some caveats:
1. Adds Catlab dependency since `GraphViz.jl` is no longer maintained. This means users must separately install the `GraphViz` command line tools.
2. Of the Lightgraph plotting tools very few seem to be actively maintained. Maybe we could use `GraphPlot.jl` instead.
3. Like all the graph libraries it does not generate graph windows with figures from the REPL, only saveable text. Figures can be saved, or generated within Jupyter.
Ex:
```julia
using Catalyst, Catlab.Graphics.Graphviz
rn = @reaction_network begin
           α, S + I --> 2I
           β, I --> R
       end α β
Graph(rn)
```
in Jupyter gives:
![myfile2](https://user-images.githubusercontent.com/9385167/88070153-5e614580-cb40-11ea-9f75-4917863933b6.png)

Here orange nodes denote reactions and the labels on edges give the stoichiometry. Connections coming through the `rate` won't appear (i.e. Hill functions or such). We should think about how to visualize such non-constant rate expressions.

To save a graph one can just say:
```julia
savegraph(Graph(rn), filename, format)
```
where format is something like "png" (the default).
