### PR TITLE
Add edges for rate deps

### DIFF
--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -35,19 +35,17 @@ end
 
 Converts a [`ReactionSystem`](@ref) into a
 [Catlab.jl](https://github.com/AlgebraicJulia/Catlab.jl/) Graphviz graph.
-Reactions correspond to small green circles, and species to blue circles. Black
-arrows from species to reactions indicate reactants, and are labelled with their
-input stoichiometry. Black arrows from reactions to species indicate products,
-and are labelled with their output stoichiometry. Red arrows from species to
-reactions indicate that species is used within the rate expression, but is not a
-reactant with defined stoichiometry. For example in the reaction `k*A, B --> C`,
-there would be a red arrow from `A` to the reaction node.
+Reactions correspond to small green circles, and species to blue circles. 
 
-*Note*, arrows only indicate species with defined input or output stoichiometry
-within a given `Reaction` in the `ReactionSystem`. The do not account for
-species that appear only in a rate. i.e., for `k*A*C, A --> B` the arrow from
-`A` to the reaction would have stoichiometry one, and there would be no arrow
-from `C` to the reaction. 
+Notes:
+- Black arrows from species to reactions indicate reactants, and are labelled
+  with their input stoichiometry. 
+- Black arrows from reactions to species indicate products, and are labelled
+  with their output stoichiometry. 
+- Red arrows from species to reactions indicate that species is used within the
+  rate expression. For example in the reaction `k*A, B --> C`, there would be a
+  red arrow from `A` to the reaction node. In `k*A, A+B --> C` there would be
+  red and black arrows from `A` to the reaction node.
 """
 function Graph(rn::ReactionSystem)
     rxs = reactions(rn)

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -58,8 +58,6 @@ function Graph(rn::ReactionSystem)
            edgify(zip(r.products,r.prodstoich), i, true))
     end
     es = edgifyrates(rn)
-    @show es
-    println(typeof(es))
     (!isempty(es)) && push!(edges, edgifyrates(rn))
 
     stmts = vcat(stmts, collect(flatten(edges)))


### PR DESCRIPTION
```julia
rn = @reaction_network begin
           hillr(P₃,α,K,n), ∅ --> m₁
           hillr(P₁,α,K,n), ∅ --> m₂
           hillr(P₂,α,K,n), ∅ --> m₃
           (δ,γ), m₁ ↔ ∅
           (δ,γ), m₂ ↔ ∅
           (δ,γ), m₃ ↔ ∅
           β, m₁ --> m₁ + P₁
           β, m₂ --> m₂ + P₂
           β, m₃ --> m₃ + P₃
           μ, P₁ --> ∅
           μ, P₂ --> ∅
           μ, P₃ --> ∅
       end α K n δ γ β μ;
savegraph(Graph(rn),fname,"png")
```
gives
![repressilator](https://user-images.githubusercontent.com/9385167/88302318-b7adae00-ccd3-11ea-9d1a-eca35f8f8963.png)
with red dashed arrows for species that appear within the rate, but do not technically have stoichiometric coefficients.