### PR TITLE
Add :⇌, :⇋ to double_arrows

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -57,7 +57,7 @@ Example systems:
 empty_set = Set{Symbol}([:∅])
 fwd_arrows = Set{Symbol}([:>, :→, :↣, :↦, :⇾, :⟶, :⟼, :⥟, :⥟, :⇀, :⇁, :⇒, :⟾])
 bwd_arrows = Set{Symbol}([:<, :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :↼, :↽, :⇐, :⟽])
-double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇔, :⟺])
+double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇌, :⇋, :⇔, :⟺])
 pure_rate_arrows = Set{Symbol}([:⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
 
 # Declares symbols which may neither be used as paraemters not varriables.


### PR DESCRIPTION
This is how I write it on the paper. Maybe even `:⥋` and `:⥊` can be useful.

The idea comes from https://github.com/zdroid/ChemEquations.jl, as some people suggested me to try integrate it with reaction networks from this repository.