### PR TITLE
Switch Catlab to imports

### DIFF
--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -27,8 +27,7 @@ include("latexify_recipes.jl")
 
 # for making and saving graphs
 import Base.Iterators: flatten
-using Catlab.Graphics.Graphviz
-import Catlab.Graphics.Graphviz: Graph, Edge
+import Catlab.Graphics.Graphviz: Graph, Edge, Attributes, Node, Digraph, run_graphviz
 include("graphs.jl")
 export Graph, savegraph
 

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -63,7 +63,7 @@ function Graph(rn::ReactionSystem)
     (!isempty(es)) && push!(edges, es)
 
     stmts = vcat(stmts, collect(flatten(edges)))
-    g = Graphviz.Digraph("G", stmts; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
+    g = Digraph("G", stmts; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
     return g
 end
 

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -45,9 +45,6 @@ function chemical_arrows(rn::ModelingToolkit.ReactionSystem;
     eol = double_linebreak ? "\\\\\\\\\n" : "\\\\\n"
 
     mathjax && (str *= "\\require{mhchem}\n")
-
-    println(kwargs)
-
     backwards_reaction = false
     rxs = ModelingToolkit.equations(rn)
     @variables t


### PR DESCRIPTION
When the Graphviz jll works more widely (it apparently doesn't currently work for many formats on Macs), we can switch to using it directly.