### PR TITLE
don't run Latexify tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ using SafeTestsets
 
 # Miscellaneous tests
 #@time @safetestset "Basic Plotting" begin include("plotting.jl") end
-@time @safetestset "Latexify" begin include("latexify.jl") end
+#@time @safetestset "Latexify" begin include("latexify.jl") end
 
 # the following can't really be run until there is an artifact for Graphviz
 #@time @safetestset "Graphs" begin include("graphs.jl") end


### PR DESCRIPTION
Let's turn these off temporarily until we can figure out how to make them more robust to differences that arise between OSes...