### PR TITLE
add bifurcation docs link

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,7 +48,8 @@ makedocs(
             "tutorials/basic_examples.md",
             "tutorials/advanced.md",
             "tutorials/generated_systems.md",
-            "tutorials/advanced_examples.md"
+            "tutorials/advanced_examples.md",
+            "tutorials/bifurcation_diagram.md"
         ],
         "API" => Any[
             "api/catalyst_api.md"


### PR DESCRIPTION
Modified the `docs/make.jl` file
```
makedocs(
    sitename = "Catalyst.jl",
    authors = "Samuel Isaacson",
    format = Documenter.HTML(mathengine=Documenter.Writers.HTMLWriter.MathJax(), prettyurls = (get(ENV, "CI", nothing) == "true")),
    modules = [Catalyst,ModelingToolkit],
    doctest = false,
    clean = true,
    pages = Any[
        "Home" => "index.md",
        "Tutorials" => Any[
            "tutorials/using_catalyst.md",
            "tutorials/basics.md",
            "tutorials/models.md",
            "tutorials/basic_examples.md",
            "tutorials/advanced.md",
            "tutorials/generated_systems.md",
            "tutorials/advanced_examples.md",
            "tutorials/bifurcation_diagram.md"
        ],
        "API" => Any[
            "api/catalyst_api.md"
        ]
    ]
)
```