### PR TITLE
Add Double Hill Activator/Repressor function

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -232,30 +232,36 @@ end
 
 ### Functionality for expanding function call to custom and specific functions ###
 
-#Recursively traverses an expression and replaces special function call like "hill(...)" with the actual corresponding expression.
+# Recursively traverses an expression and replaces special function call like "hill(...)" with the actual corresponding expression.
 function recursive_expand_functions!(expr::ExprValues)
     (typeof(expr)!=Expr) && (return expr)
     foreach(i -> expr.args[i] = recursive_expand_functions!(expr.args[i]), 1:length(expr.args))
     if expr.head == :call
         in(expr.args[1],hill_name) && return hill(expr)
         in(expr.args[1],hillR_name) && return hillR(expr)
+        in(expr.args[1],hillC_name) && return hillC(expr)
         in(expr.args[1],mm_name) && return mm(expr)
         in(expr.args[1],mmR_name) && return mmR(expr)
+        in(expr.args[1],mmC_name) && return mmC(expr)
 
         !isdefined(Catalyst,expr.args[1]) && (expr.args[1] = esc(expr.args[1]))
     end
     return expr
 end
 
-#Hill function made avaiable (activation and repression).
+# Hill function made avaiable (activation, repression, and combined).
 hill_name = Set{Symbol}([:hill, :Hill, :h, :H, :HILL])
 hill(expr::Expr) = :($(expr.args[3])*($(expr.args[2])^$(expr.args[5]))/($(expr.args[4])^$(expr.args[5])+$(expr.args[2])^$(expr.args[5])))
 hillR_name = Set{Symbol}([:hill_repressor, :hillr, :hillR, :HillR, :hR, :hR, :Hr, :HR, :HILLR])
 hillR(expr::Expr) = :($(expr.args[3])*($(expr.args[4])^$(expr.args[5]))/($(expr.args[4])^$(expr.args[5])+$(expr.args[2])^$(expr.args[5])))
+hillC_name = Set{Symbol}([:hillC, :HillC, :hC, :HC, :HILLC, :hillAR, :HillAR, :hAR, :HAR, :HILLAR]) 
+hillC(expr::Expr) = :($(expr.args[4])*($(expr.args[2])^$(expr.args[6]))/($(expr.args[5])^$(expr.args[6])+$(expr.args[2])^$(expr.args[6]+$(expr.args[3])^$(expr.args[6])))
 
-#Michaelis-Menten function made available (activation and repression).
+# Michaelis-Menten function made available (activation, repression, and combined).
 mm_name = Set{Symbol}([:MM, :mm, :Mm, :mM, :M, :m])
 mm(expr::Expr) = :($(expr.args[3])*$(expr.args[2])/($(expr.args[4])+$(expr.args[2])))
 mmR_name = Set{Symbol}([:mm_repressor, :MMR, :mmr, :mmR, :MmR, :mMr, :MR, :mr, :Mr, :mR])
 mmR(expr::Expr) = :($(expr.args[3])*$(expr.args[4])/($(expr.args[4])+$(expr.args[2])))
+mmC_name = Set{Symbol}([:MMC, :mmC, :MmC, :mMC, :MC, :mAR, :MMAR, :mmAR, :MmAR, :mMAR, :MAR, :mAR])
+mmC(expr::Expr) = :($(expr.args[4])*$(expr.args[2])/($(expr.args[5])+$(expr.args[2])+$(expr.args[3])))
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -255,7 +255,7 @@ hill(expr::Expr) = :($(expr.args[3])*($(expr.args[2])^$(expr.args[5]))/($(expr.a
 hillR_name = Set{Symbol}([:hill_repressor, :hillr, :hillR, :HillR, :hR, :hR, :Hr, :HR, :HILLR])
 hillR(expr::Expr) = :($(expr.args[3])*($(expr.args[4])^$(expr.args[5]))/($(expr.args[4])^$(expr.args[5])+$(expr.args[2])^$(expr.args[5])))
 hillC_name = Set{Symbol}([:hillC, :HillC, :hC, :HC, :HILLC, :hillAR, :HillAR, :hAR, :HAR, :HILLAR]) 
-hillC(expr::Expr) = :($(expr.args[4])*($(expr.args[2])^$(expr.args[6]))/($(expr.args[5])^$(expr.args[6])+$(expr.args[2])^$(expr.args[6]+$(expr.args[3])^$(expr.args[6])))
+hillC(expr::Expr) = :($(expr.args[4])*($(expr.args[2])^$(expr.args[6]))/($(expr.args[5])^$(expr.args[6])+$(expr.args[2])^$(expr.args[6])+$(expr.args[3])^$(expr.args[6])))
 
 # Michaelis-Menten function made available (activation, repression, and combined).
 mm_name = Set{Symbol}([:MM, :mm, :Mm, :mM, :M, :m])

--- a/test/custom_functions.jl
+++ b/test/custom_functions.jl
@@ -16,7 +16,9 @@ custom_function_network_1 = @reaction_network begin
     exp(-p3*Y), X + Y --> Z4
     hillR(X,v3,K3,2), X + Y --> Z5
     mmR(X,v4,K4), X + Y --> Z6
-end v1 K1 v2 K2 p1 p2 p3 v3 K3 v4 K4
+    hillC(X,Y,v5,K5,2), X + Y --> Z7
+    mmC(X,Y,v6,K6), X + Y --> Z8
+end v1 K1 v2 K2 p1 p2 p3 v3 K3 v4 K4 v5 K5 v6 K6
 
 custom_function_network_2 = @reaction_network begin
     new_hill(X,v1,K1,2), X + Y --> Z1
@@ -25,7 +27,9 @@ custom_function_network_2 = @reaction_network begin
     new_exp(Y,p3), X + Y --> Z4
     v3*(K3^2)/(K3^2+X^2), X + Y --> Z5
     v4*K4/(X+K4), X + Y --> Z6
-end v1 K1 v2 K2 p1 p2 p3 v3 K3 v4 K4
+    v5*(X^2)/(K5^2+X^2+Y^2), X + Y --> Z7
+    v6*(X)/(K6+X+Y), X + Y --> Z8
+end v1 K1 v2 K2 p1 p2 p3 v3 K3 v4 K4 v5 K5 v6 K6
 
 f1 = ODEFunction(convert(ODESystem,custom_function_network_1),jac=true)
 f2 = ODEFunction(convert(ODESystem,custom_function_network_2),jac=true)


### PR DESCRIPTION
This predefines a function `HillC` (all alternative names: `[:hillC, :HillC, :hC, :HC, :HILLC, :hillAR, :HillAR, :hAR, :HAR, :HILLAR]`), which acts as both a repressor and activator, e.g.:
_HillC(X,Y,v,K,n) = v * (X^n) / (X^n + Y^n + K^n)_
where _X_ acts as the activator and _Y_ as the repressor.

This is useful under some circumstances (when it prevents a very long rate expression).
(Will also help since I used this in a paper plot, where the code can be made a lot less messy)