### PR TITLE
Allow sys names and other API fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "6.9.0"
+version = "6.10.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -17,7 +17,7 @@ DataStructures = "0.18"
 DocStringExtensions = "0.8"
 Latexify = "0.14"
 MacroTools = "0.5.5"
-ModelingToolkit = "5.12.0"
+ModelingToolkit = "5.13.0"
 Parameters = "0.12"
 Reexport = "0.2, 1.0"
 Requires = "1.0"

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -11,8 +11,9 @@ be converted to other `ModelingToolkit.AbstractSystem`s, including a
 `ModelingToolkit.ODESystem`, `ModelingToolkit.SDESystem`, or
 `ModelingToolkit.JumpSystem`.
 
-An empty network can be generated using [`@reaction_network`](@ref) with no arguments or
-the [`make_empty_network`](@ref) function. These can then be extended
+An empty network can be generated using [`@reaction_network`](@ref) with no
+arguments (or one argument to name the system), or the
+[`make_empty_network`](@ref) function. These can then be extended
 programmatically using [`addspecies!`](@ref), [`addparam!`](@ref), and
 [`addreaction!`](@ref).
 

--- a/docs/src/tutorials/generated_systems.md
+++ b/docs/src/tutorials/generated_systems.md
@@ -33,7 +33,7 @@ Each `Reaction` within `reactions(rn)` has a number of subfields. For `rx` a
   non-filled arrows and should ignore mass action kinetics. `false` by default.
 
 Empty `ReactionSystem`s can be generated via [`make_empty_network`](@ref) or
-[`@reaction_network`](@ref) with no arguments. `ReactionSystem`s can be
-programmatically extended using [`addspecies!`](@ref), [`addparam!`](@ref),
-[`addreaction!`](@ref), [`@add_reactions`](@ref), or composed using `merge` and
-`merge!`.
+[`@reaction_network`](@ref) with no arguments (giving one argument to the latter
+will specify a system name). `ReactionSystem`s can be programmatically extended
+using [`addspecies!`](@ref), [`addparam!`](@ref), [`addreaction!`](@ref),
+[`@add_reactions`](@ref), or composed using `merge` and `merge!`.

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -69,7 +69,7 @@ Return the number of species within the given [`ReactionSystem`](@ref).
 function numspecies(network)
     ns = length(ModelingToolkit.ModelingToolkit.get_states(network))
     for sys in ModelingToolkit.get_systems(network)
-        ns += numspecies(ns)
+        ns += numspecies(sys)
     end
     ns
 end
@@ -95,7 +95,7 @@ Return the number of parameters within the given [`ReactionSystem`](@ref).
 function numparams(network)
     np = length(ModelingToolkit.get_ps(network))
     for sys in ModelingToolkit.get_systems(network)
-        np += numparams(ns)
+        np += numparams(sys)
     end
     np
 end

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -219,10 +219,11 @@ end
 ######################## functions to extend a network ####################
 
 """
-    make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t), name=gensym(:ReactionSystem))
+    make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t), 
+                         name=gensym(:ReactionSystem))
 
 Construct an empty [`ReactionSystem`](@ref). `iv` is the independent variable,
-usually time.
+usually time, and `name` is the name to give the `ReactionSystem`.
 """
 function make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t), name=gensym(:ReactionSystem))
     ReactionSystem(Reaction[], iv, [], [], Equation[], name, ReactionSystem[])

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -219,13 +219,13 @@ end
 ######################## functions to extend a network ####################
 
 """
-    make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t))
+    make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t), name=gensym(:ReactionSystem))
 
 Construct an empty [`ReactionSystem`](@ref). `iv` is the independent variable,
 usually time.
 """
-function make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t))
-    ReactionSystem(Reaction[], iv, [], [], Equation[], gensym(:ReactionSystem), ReactionSystem[])
+function make_empty_network(; iv=Sym{ModelingToolkit.Parameter{Real}}(:t), name=gensym(:ReactionSystem))
+    ReactionSystem(Reaction[], iv, [], [], Equation[], name, ReactionSystem[])
 end
 
 """
@@ -244,10 +244,10 @@ Notes:
 function addspecies!(network::ReactionSystem, s::Symbolic; disablechecks=false)
 
     # we don't check subsystems since we will add it to the top-level system...
-    curidx = disablechecks ? nothing : findfirst(S -> isequal(S, s), ModelingToolkit.ModelingToolkit.get_states(network))
+    curidx = disablechecks ? nothing : findfirst(S -> isequal(S, s), ModelingToolkit.get_states(network))
     if curidx === nothing
-        push!(ModelingToolkit.ModelingToolkit.get_states(network), s)
-        return length(ModelingToolkit.ModelingToolkit.get_states(network))
+        push!(ModelingToolkit.get_states(network), s)
+        return length(ModelingToolkit.get_states(network))
     else
         return curidx
     end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -65,6 +65,14 @@ bwd_arrows = Set{Symbol}([:<, :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :�
 double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇌, :⇋, :⇔, :⟺])
 pure_rate_arrows = Set{Symbol}([:⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
 
+# unfortunately the following doesn't seem to work on 1.5, so supporting these 
+# operators seems to require us to only support 1.6 and up...
+# @static if VERSION >= v"1.6.0"
+#     push!(bwd_arrows, :<--)
+#     push!(double_arrows, :<-->)
+# end
+
+
 # Declares symbols which may neither be used as parameters not varriables.
 forbidden_symbols = [:t, :π, :pi, :ℯ, :im, :nothing, :∅]
 
@@ -78,6 +86,27 @@ network.
 
 See the [Catalyst.jl for Reaction Models](@ref) documentation for details on
 parameters to the macro.
+
+Examples:
+```julia
+# a basic SIR model, with name SIR
+sir_model = @reaction_network SIR begin
+    c1, s + i --> 2i
+    c2, i --> r
+end c1 c2
+
+# a basic SIR model, with random generated name
+sir_model = @reaction_network begin
+    c1, s + i --> 2i
+    c2, i --> r
+end c1 c2
+
+# an empty network with name empty
+emptyrn = @reaction_network empty
+
+# an empty network with random generated name
+emptyrn = @reaction_network 
+```
 """
 macro reaction_network(name::Symbol, ex::Expr, parameters...)
     make_reaction_system(MacroTools.striplines(ex), parameters; name=name)
@@ -87,10 +116,7 @@ macro reaction_network(ex::Expr, parameters...)
     make_reaction_system(MacroTools.striplines(ex), parameters)
 end
 
-
-### Macros used for manipulating, and successively builing up, reaction systems. ###
-
-#Returns a empty network (with, or without, parameters declared)
+#Returns a empty network (with, or without, a declared name)
 macro reaction_network(name::Symbol=gensym(:ReactionSystem))
     return Expr(:block,:(@parameters t),
                 :(ReactionSystem(Reaction[],
@@ -101,6 +127,8 @@ macro reaction_network(name::Symbol=gensym(:ReactionSystem))
                                  $(QuoteNode(name)),
                                  ReactionSystem[])))
 end
+
+### Macros used for manipulating, and successively builing up, reaction systems. ###
 
 """
     @add_reactions

--- a/test/make_model.jl
+++ b/test/make_model.jl
@@ -8,10 +8,8 @@ rng = StableRNG(12345)
 include("test_networks.jl")
 
 
-### Debugg functions ###
-
+### Debug functions ###
 opname(x) = istree(x) ? nameof(operation(x)) : nameof(x)
-
 alleq(xs,ys) = all(isequal(x,y) for (x, y) in zip(xs, ys))
 
 # Gets all the reactants in a set of equations.
@@ -405,3 +403,13 @@ rn = @reaction_network begin
     k2, I --> R
 end k1 k2
 @test isequal(opname(species(rn)[2]),:I)
+
+
+# test names work
+rn = @reaction_network SIR1 begin
+    k1, S + I --> 2I
+    k2, I --> R
+end k1 k2
+@test nameof(rn) == :SIR1
+
+


### PR DESCRIPTION
Closes https://github.com/SciML/Catalyst.jl/issues/317

Seems to work for non-empty networks. Empty networks would require a breaking change to drop allowing an empty network that has parameters defined (which seems reasonable to me since parameters can be subsequently added if needed). @TorkelE do you remember why we allowed `@reaction_network k1 k2 k3` to work and make an empty system with parameters `k1`, `k2`, `k3`? 

- [x] Needs doc updates.
- [x] Handle empty network.