### PR TITLE
Fixed error message for @reaction_network with no reactions

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -87,7 +87,7 @@ end
 
 #Returns a empty network (with, or without, parameters declared)
 macro reaction_network(parameters...)
-    !isempty(intersect(forbidden_symbols,parameters)) && error("The following symbol(s) are used as reactants or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,reactants,parameters))...))*"this is not permited.")
+    !isempty(intersect(forbidden_symbols,parameters)) && error("The following symbol(s) are used as parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,parameters))...))*"this is not permited.")
     return Expr(:block,:(@parameters $((:t,parameters...)...)),
                 :(ReactionSystem(Reaction[],
                                  t,


### PR DESCRIPTION
Currently when using `@reaction_network` with no reactions and one of the parameters is reserved Julia throws an error before the desired error message is printed out. This is due to the code trying to access a nonexistent variable which has been removed in this version.