### PR TITLE
A simple interface for general spatial reaction networks

### DIFF
--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -32,6 +32,10 @@ include("reaction_network.jl")
 # reaction network macro
 export @reaction_network, @add_reactions
 
+include("spatial_network.jl")
+export @spatial_reaction_network
+export graph_iterator
+
 # functions to query network properties
 include("networkapi.jl")
 export species, params, reactions, speciesmap, paramsmap, numspecies, numreactions, numparams

--- a/src/spatial_network.jl
+++ b/src/spatial_network.jl
@@ -1,0 +1,210 @@
+
+
+# This function takes a graph and a set of indices
+# and returns an iterator over assignments
+# i -> e[1], j -> e[2], k -> e[3], ...
+# for all n-edges of the graph, where n is the
+# number of indices. The assignments should be
+# of type Dict{Symbol,Symbol}.
+#
+# For an ordinary graph, the 1-edges are the vertices
+# and the 2-edges are the edges in the usual sense.
+#
+# Important: as the order of the indices is not
+# defined, this function should assign elements
+# to all permutations of the edges, ie. for
+# i => 4, j => 5 it should also return i => 5, j => 4
+function graph_iterator end
+
+struct BasicGraph{T}
+    verts::AbstractVector{T}
+    edges::AbstractVector{Pair{T,T}}
+end
+    
+function graph_iterator(graph::BasicGraph{T}, idcs::Set{Symbol}) where {T}
+    if length(idcs) == 1
+        i = first(idcs)
+        return ( Dict(i => vert) for vert in graph.verts )
+    elseif length(idcs) == 2
+        i, j = collect(idcs)
+        edges_r = ( edge.second => edge.first for edge in graph.edges )
+        edges_sym = union(graph.edges, edges_r)
+        
+        return ( Dict(i => edge.first, j => edge.second) for edge in edges_sym )
+    end
+    
+    return nothing
+end
+
+struct PeriodicGrid{N} 
+    size::NTuple{N, Int64}
+end
+
+PeriodicGrid(sizes...) = PeriodicGrid(sizes)
+
+function get_neighbour(coords, dim::Int64, amt::Int64, size::NTuple{N,Int64})::Vector{Int64} where N
+    ret = collect(coords)
+    ret[dim] += amt
+    ret[dim] = mod(ret[dim] - 1, size[dim]) + 1    # transform to lie in 1:size[dim]
+    ret
+end
+
+coord_to_str(coords) = "(" * join(coords, ",") * ")"
+grid_coords(grid::PeriodicGrid{N}) where N = Iterators.product([ 1:grid.size[i] for i in 1:N ]...)
+    
+function get_edge_iter(i::Symbol, j::Symbol, dim::Int64, grid::PeriodicGrid)
+    return Iterators.flatten(( Dict(i => coord_to_str(coords), 
+                                      j => coord_to_str(get_neighbour(coords, dim, sgn, grid.size))) 
+                               for coords in grid_coords(grid) ) 
+                               for sgn in [-1,+1])
+end
+
+function graph_iterator(grid::PeriodicGrid, idcs::Set{Symbol})
+    if length(idcs) == 1
+        idx = first(idcs)
+        return ( Dict(idx => coord_to_str(coords)) for coords in grid_coords(grid) ) 
+    elseif length(idcs) == 2
+        i, j = collect(idcs)
+        return Iterators.flatten(get_edge_iter(i, j, dim, graph) for dim in 1:N)
+    end
+    
+    return nothing
+end
+
+# Convert a list of expressions of the form
+# G[i], H[j,k] into a dictionary 
+# of the form Dict(i => G, j => H, k => H)
+function get_idx_dict(exprs)::Dict{Symbol,Any}
+    ret = Dict{Symbol,Any}()
+    
+    for idx_map in exprs
+        (isa(idx_map, Expr) && idx_map.head == :ref) || throw("malformed index assignment: $(idx_map)")
+        graph_name = idx_map.args[1]
+        graph = Base.MainInclude.eval(graph_name)
+        idcs = idx_map.args[2:end]
+        
+        for idx in idcs
+            idx isa Symbol || throw("index not a symbol: $(idx)")
+            idx in keys(ret) && throw("multiple index assignment: $(idx)")
+            ret[idx] = graph
+        end
+    end
+    
+    return ret
+end
+
+# Iterate over all valid combinations of indices for a spatial reaction
+function iterate_idcs(idcs::Set{Symbol}, idx_dict::AbstractDict)
+    isempty(idcs) && return (Dict{Symbol,Any}(),)
+    
+    iterators = []
+    for graph in unique(values(idx_dict))
+        idcs_graph = filter(idx -> idx_dict[idx] == graph, idcs)
+        isempty(idcs_graph) && continue
+        iterator = graph_iterator(graph, idcs_graph)
+        iterator === nothing && throw("graph iteration not implemented for $(length(idcs_graph)) indices")
+        push!(iterators, iterator)
+    end
+    
+    return (merge(dicts...) for dicts in Iterators.product(iterators...))
+end
+
+# Get indices occurring in a reaction
+function get_idcs(ex::ExprValues)::Set{Symbol}
+    if ex isa Expr
+        if ex.head == :ref
+            return Set(ex.args[2:end])
+        end
+        
+        return mapreduce(get_idcs, union, ex.args)
+    end
+    
+    return Set{Symbol}()
+end
+        
+# Expand spatial reactants of the form X[i] with the given assignment of
+# vertices to indices
+function expand_reactant_idcs(ex::ExprValues, idx_map::AbstractDict)
+    if ex isa Expr
+        if ex.head == :ref
+            name = ex.args[1]
+            name isa Symbol || throw("only species can be indexed")
+                    
+            length(ex.args) == 2 || throw("species $(ex.args[1]) can only have one index")
+            
+            idx = ex.args[2]
+            idx_mapped = idx_map[idx]
+            
+            return Symbol(name, "_", idx_mapped)
+        end
+        
+        return Expr(ex.head, map(arg -> expand_reactant_idcs(arg, idx_map), ex.args)...)
+    end
+    
+    ex
+end
+
+# Expand reaction rates of the form a[i,j] with the given assignment of
+# vertices to indices
+function expand_rate_idcs(ex::ExprValues, idx_map::AbstractDict)
+    if ex isa Expr
+        if ex.head == :ref
+            name = ex.args[1]
+            name isa Symbol || throw("only constant parameters can be indexed")
+            
+            idcs = ex.args[2:end]
+            idcs_mapped = map(x -> idx_map[x], idcs)
+            if length(idcs) == 1
+                return Symbol(name, "_", idcs_mapped[1])
+            else
+                return Symbol(name, "_(", join(idcs_mapped, ","), ")")
+            end
+        end
+        
+        return Expr(ex.head, map(arg -> expand_rate_idcs(arg, idx_map), ex.args)...)
+    end
+    
+    ex
+end
+        
+function expand_spatial_reactions!(reactions::AbstractVector{Expr}, rate::ExprValues, sub_line::ExprValues, prod_line::ExprValues, arrow::Symbol, 
+                                   idx_dict::AbstractDict)
+    idcs_sub = get_idcs(sub_line)
+    idcs_prod = get_idcs(prod_line)
+    idcs = union(idcs_sub, idcs_prod)
+    
+    issubset(idcs, keys(idx_dict)) || throw("invalid index in reaction")
+    
+    idcs_rates = get_idcs(rate)
+    issubset(idcs_rates, idcs) || throw("invalid index in reaction rate")
+    
+    for idx_map in iterate_idcs(idcs, idx_dict)
+        rate_mapped = expand_rate_idcs(rate, idx_map)
+        sub_line_mapped = expand_reactant_idcs(sub_line, idx_map)
+        prod_line_mapped = expand_reactant_idcs(prod_line, idx_map)
+        
+        r_line = Expr(:call, arrow, sub_line_mapped, prod_line_mapped)
+
+        push!(reactions, Expr(:tuple, rate_mapped, r_line))
+    end
+end
+        
+function get_spatial_reactions(ex::Expr, idx_dict::AbstractDict)
+    reactions = Expr[]
+    
+    for line in ex.args
+        (line isa Expr && line.head == :tuple) || continue
+        
+        (rate, r_line) = line.args
+        (r_line.head  == :-->) && (r_line = Expr(:call,:→,r_line.args[1],r_line.args[2]))
+
+        expand_spatial_reactions!(reactions, rate, r_line.args[2], r_line.args[3], r_line.args[1], idx_dict)
+    end
+    
+    Expr(:block, reactions...)
+end
+        
+macro spatial_reaction_network(ex::Expr, graphs...)
+    idx_dict = get_idx_dict(graphs)
+    esc(get_spatial_reactions(MacroTools.striplines(ex), idx_dict))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,4 +32,8 @@ using SafeTestsets
 @time @safetestset "Latexify" begin include("latexify.jl") end
 @time @safetestset "Graphs" begin include("graphs.jl") end
 
+# Spatial reaction networks
+@time @safetestset "Spatial Network Backcompatibility" begin include("spatial_compat.jl") end
+@time @safetestset "Spatial Networks" begin include("spatial_systems.jl") end
+
 end # @time

--- a/test/spatial_compat.jl
+++ b/test/spatial_compat.jl
@@ -1,0 +1,250 @@
+using MacroTools, Test
+include("../src/Catalyst.jl")
+
+systems = [ 
+    # graphs.jl
+    quote
+        α, S + I --> 2I
+        β, I --> R
+        S^2, R --> 0
+    end => (:α, :β),
+            
+    # custom_functions.jl
+    quote
+        hill(X,v1,K1,2), X + Y --> Z1
+        mm(X,v2,K2), X + Y --> Z2
+        p1*X^2+p2, X + Y --> Z3
+        exp(-p3*Y), X + Y --> Z4
+        hillR(X,v3,K3,2), X + Y --> Z5
+        mmR(X,v4,K4), X + Y --> Z6
+    end => (:v1, :K1, :v2, :K2, :p1, :p2, :p3, :v3, :K3, :v4, :K4),
+         
+    # higher_order_reactions.jl
+    quote
+        p, ∅ ⟼ X1
+        r1, 2X1 ⟼ 3X2
+        mm(X1,r2,K), 3X2 ⟼ X3 + 2X4
+        r3, X3 + 2X4 ⟼ 3X5 + 3X6
+        r4*X2, 3X5 + 3X6 ⟼ 3X5 + 2X7 + 4X8
+        r5, 3X5 + 2X7 + 4X8 ⟼ 10X9
+        r6, 10X9 ⟼ X10
+        d, 2X10 ⟼ ∅
+    end => (:p, :r1, :r2, :K, :r3, :r4, :r5, :r6, :d),
+                
+    quote
+        p, ∅ ⟾ X1
+        r1*X1^2/factorial(2), 2X1 ⟾ 3X2
+        mm(X1,r2,K)*X2^3/factorial(3), 3X2 ⟾ X3 + 2X4
+        r3*X3*X4^2/factorial(2), X3 + 2X4 ⟾ 3X5 + 3X6
+        r4*X2*X5^3*X6^3/(factorial(3)*factorial(3)), 3X5 + 3X6 ⟾ 3X5 + 2X7 + 4X8
+        r5*X5^3*X7^2*X8^4/(factorial(3)*factorial(2)*factorial(4)), 3X5 + 2X7 + 4X8 ⟾ 10X9
+        r6*X9^10/factorial(10), 10X9 ⟾ X10
+        d*X10^2/factorial(2), 2X10 ⟾ ∅
+    end => (:p, :r1, :r2, :K, :r3, :r4, :r5, :r6, :d),
+    
+    # latexify.jl
+    quote
+        hillR(X2,v1,K1,n1)*hill(X4,v1,K1,n1), ∅ → X1
+        hill(X5,v2,K2,n2), ∅ → X2
+        hill(X3,v3,K3,n3), ∅ → X3
+        hillR(X1,v4,K4,n4), ∅ → X4
+        hill(X2,v5,K5,n5), ∅ → X5
+        (k1,k2), X2 ⟷ X1 + 2X4
+        (k3,k4), X4 ⟷ X3
+        (k5,k6), 3X5 + X1 ⟷ X2
+        (d1,d2,d3,d4,d5), (X1,X2,X3,X4,X5)  ⟶ ∅
+    end => (:v1, :K1, :n1, :v2, :K2, :n2, :v3, :K3, :n3, :v4, :K4, :n4, :v5, 
+            :K5, :n5, :k1, :k2, :k3, :k4, :k5, :k6, :d1, :d2, :d3, :d4, :d5),
+
+    quote
+        (hill(B, p_a, k, n), d_a), 0 ↔ A
+        (p_b, d_b), 0 ↔ B
+        (r_a, r_b), 3B ↔ A
+    end => (:p_a, :k, :n, :d_a, :p_b, :d_b, :r_a, :r_b),
+
+    # make_jacobian.jl
+    quote
+        (2.0,1.0),   ∅ ↔ X
+        (3.0,1.0),   ∅ ↔ Y
+        (5.0,2.0),   X + Y ↔ XY
+    end => (),
+
+    quote
+        (p1,1.0),   ∅ ↔ X
+        (p2,1.0),   ∅ ↔ Y
+        (p3*X,1.0), X + Y ↔ XY
+    end => (:p1, :p2, :p3),
+
+    quote
+        k1, 2A → B
+        k2, B → 2A
+        k3, A + B → C
+        k4, C → A + B
+        k5, 3C → 3A
+        k6, 0 → 2B
+        hill(A,k7,k8,2), ∅ → B
+    end => (:k1, :k2, :k3, :k4, :k5, :k6, :k7, :k8),
+    
+    # test_networks.jl              
+    quote
+        (p1,p2,p3), ∅ → (X1,X2,X3)
+        (k1,k2), X2 ⟷ X1 + 2X3
+        (k3,k4), X1 ⟷ X3
+        (d1,d2,d3), (X1,X2,X3) → ∅
+    end => (:p1, :p2, :p3, :k1, :k2, :k3, :k4, :d1, :d2, :d3),
+
+    quote
+        mmR(X2,v1,K1), ∅ → X1
+        mm(X1,v2,K2), ∅ → X2
+        d, X1+X2 → ∅
+    end => (:v1, :K1, :v2, :K2, :d),
+
+    quote
+        mm(X2,v1,K1), ∅ → X1
+        mm(X3,v2,K2), ∅ → X2
+        (k1,k2), X1 ⟷ X3
+        (k3,k4), X3 + X2 ⟷ X4 + X1
+        d, (X1,X2,X3,X4) → ∅
+    end => (:v1, :K1, :v2, :K2, :k1, :k2, :k3, :k4, :d),
+
+    quote
+        mmR(X4,v1,K1), ∅ → X1
+        mmR(X1,v2,K2), ∅ → X2
+        mmR(X2,v3,K3), ∅ → X3
+        mmR(X3,v4,K4), ∅ → X4
+        (d1,d2,d3,d4), (X1,X2,X3,X4) → ∅
+    end => (:v1, :K1, :v2, :K2, :v3, :K3, :v4, :K4, :d1, :d2, :d3, :d4),
+
+    quote
+        p, ∅ → X1
+        (k1,k2), X1 ⟷ X2
+        (k3,k4), X2 ⟷ X3
+        (k5,k6), X3 ⟷ X4
+        d, X4 → ∅
+    end => (:p, :k1, :k2, :k3, :k4, :k5, :k6, :d),
+
+    quote
+        (p1,p2), ∅ → (X1,X2)
+        (k1,k2), 2X1 ⟷ X3
+        (k3,k4), X2 + X3 ⟷ 4X4
+        (k5,k6), X4 + X1 ⟷ 2X3
+        d, (X1,X2,X3,X4) → ∅
+    end => (:p1, :p2, :k1, :k2, :k3, :k4, :k5, :k6, :d),
+
+    ### Reaction networks that are actual models that have been used ###
+
+    # Brusselator.
+    quote
+        A, ∅ → X
+        1, 2X + Y → 3X
+        B, X → Y
+        1, X → ∅
+    end => (:A, :B),
+
+    # The B.subtilis σV Lysozyme stress response.
+    quote
+        v0 + hill(σ,v,K,n), ∅ → (σ+A)
+        deg, (σ,A,Aσ) → ∅
+        (kB,kD), A + σ ↔ Aσ
+        S*kC, Aσ → σ
+    end => (:v0, :v, :K, :n, :kD, :kB, :kC, :deg, :S),
+
+    # A cell cycle model
+    quote
+      k1, 0 --> Y
+      k2p, Y --> 0
+      k2pp*P, Y --> 0
+      (k3p+k3pp*A)/(J3+Po), Po-->P
+      (k4*m)/(J4+P), Y + P --> Y + Po
+    end => (:k1, :k2p, :k2pp, :k3p, :k3pp, :A, :J3, :k4, :m, :J4),
+
+    # A bistable switch
+    quote
+        d,    (X,Y) → ∅
+        hillR(Y,v1,K1,n1), ∅ → X
+        hillR(X,v2,K2,n2), ∅ → Y
+    end => (:d, :v1, :K1, :n1, :v2, :K2, :n2),
+
+    ### Reaction networks that contain weird functions, stuff, and other oddities ###
+
+    quote
+        exp(p), ∅ → X
+        d*exp(X), X → ∅
+    end => (:p, :d),
+
+    quote
+        k1, ∅ → X
+        k2*log(12+X), X → Y
+        k3*log(3+Y), Y → Z
+        log(5,6+k4), Z → ∅
+    end => (:k1, :k2, :k3, :k4),
+
+    quote
+        d,    (X,Y) → ∅
+        hillR(hill(Y,v2,K2,n2),v1,K1,n1), ∅ → X
+        hillR(hill(X,v1,K1,n1),v2,K2,n2), ∅ → Y
+    end => (:d, :v1, :K1, :n1, :v2, :K2, :n2),
+
+    quote
+        p, ∅ → X1
+        (k1,X2^X3), X1 ⟷ X2
+        (X2/X4,k4), X2 ⟷ X3
+        (k5,X1*X2*X4), X3 ⟷ X4
+        d*X2, X4 → ∅
+    end => (:p, :k1, :k2, :k3, :k4, :k5, :k6, :d),
+
+    quote
+        (k1*tanh(X1),k2), X1 ↔ 2X1
+        (2+sin(X1),3+sin(k3)), X1 + X2 ↔ X3
+        (k5,4+cos(X3+X1)+sin(X2)), X3 ↔ X2
+    end => (:k1, :k2, :k3, :k4, :k5, :k6),
+
+    quote
+        (p,d), ∅ ↔ X1
+        (p,d), ∅ ↔ X1
+        (p,d), ∅ ↔ X1
+        (p,d), ∅ ↔ X1
+        (p,d), ∅ ↔ X1
+        (p,d), ∅ ↔ X1
+    end => (:p, :d),
+
+    quote
+        k1+X3, X1 → X2
+        k2*X4, X2 → X3
+        k3/(X5+0.01), X3 → X4
+        X6/k4, X4 → X5
+        X7^k5, X5 → X6
+        k6^X8, X6 → X7
+        sqrt(abs(k7*X9)), X7 → X8
+        cbrt(abs(k8+X1)), X8 → X9
+        X2^3+2X2^2+k9, X9 → X1
+    end => (:k1, :k2, :k3, :k4, :k5, :k6, :k7, :k8, :k9),
+
+    quote
+        p, ∅ → X1
+        hill(hill(hill(hill(X1,v1,K1,n1),v2,K2,n2),v3,K3,n3),v4,K4,n4), X1 → ∅
+    end => (:p, :v1, :K1, :n1, :v2, :K2, :n2, :v3, :K3, :n3, :v4, :K4, :n4),
+                                                                                                            
+    # solve_ODEs.jl
+    quote
+        (k1,k2), X1 ↔ X2
+        (k3,k4), X3+ X4 ↔ X5
+        (k5,k6), 2X6 ↔ 3X7
+        (k7,k8), ∅ ↔ X8
+    end => (:k1, :k2, :k3, :k4, :k5, :k6, :k7, :k8),
+
+
+    quote
+        (1.2,5), X1 ↔ X2
+    end => (),
+]
+            
+for (expr, params) in systems
+    expr = MacroTools.striplines(expr)
+    expr_spatial = Catalyst.make_spatial_reaction_network(expr, [])
+            
+    rn = Catalyst.make_reaction_system(expr, params)
+    rn_copy = Catalyst.make_reaction_system(expr_spatial, params)
+
+    @test rn == rn_copy
+end

--- a/test/spatial_systems.jl
+++ b/test/spatial_systems.jl
@@ -1,0 +1,69 @@
+using MacroTools, Test
+include("../src/Catalyst.jl")
+
+G = Catalyst.PeriodicGrid(3)
+H = Catalyst.PeriodicGrid(2)
+
+systems = [ 
+(quote
+    sigma[i], 0 --> X[i]
+    D, X[i] --> X[j]
+    delta, 2X[i]-->0
+end, 
+[Meta.parse("PeriodicGrid(3)[i,j,k]")],  
+quote
+    var"sigma_(1)", 0 → var"X_(1)"
+    var"sigma_(2)", 0 → var"X_(2)"
+    var"sigma_(3)", 0 → var"X_(3)"
+    D, var"X_(3)" → var"X_(1)"
+    D, var"X_(1)" → var"X_(2)"
+    D, var"X_(2)" → var"X_(3)"
+    D, var"X_(2)" → var"X_(1)"
+    D, var"X_(3)" → var"X_(2)"
+    D, var"X_(1)" → var"X_(3)"
+    delta, 2var"X_(1)" → 0
+    delta, 2var"X_(2)" → 0
+    delta, 2var"X_(3)" → 0
+end       
+),
+(quote
+    sigma, 0 --> X[i]
+    D, X[i] --> X[j]
+    delta, 2X[i]-->0
+    kappa[k], 0 --> Y[k]
+    iota[i], X[i] + Y[k] --> 0
+end, 
+[Meta.parse("PeriodicGrid(3)[i,j]"), Meta.parse("PeriodicGrid(2)[k]")],  
+quote
+    sigma, 0 → var"X_(1)"
+    sigma, 0 → var"X_(2)"
+    sigma, 0 → var"X_(3)"
+    D, var"X_(3)" → var"X_(1)"
+    D, var"X_(1)" → var"X_(2)"
+    D, var"X_(2)" → var"X_(3)"
+    D, var"X_(2)" → var"X_(1)"
+    D, var"X_(3)" → var"X_(2)"
+    D, var"X_(1)" → var"X_(3)"
+    delta, 2var"X_(1)" → 0
+    delta, 2var"X_(2)" → 0
+    delta, 2var"X_(3)" → 0
+    var"kappa_(1)", 0 → var"Y_(1)"
+    var"kappa_(2)", 0 → var"Y_(2)"
+    var"iota_(1)", var"X_(1)" + var"Y_(1)" → 0
+    var"iota_(2)", var"X_(2)" + var"Y_(1)" → 0
+    var"iota_(3)", var"X_(3)" + var"Y_(1)" → 0
+    var"iota_(1)", var"X_(1)" + var"Y_(2)" → 0
+    var"iota_(2)", var"X_(2)" + var"Y_(2)" → 0
+    var"iota_(3)", var"X_(3)" + var"Y_(2)" → 0
+end   
+)
+]
+
+for (expr, graphs, target) in systems
+    expr = MacroTools.striplines(expr)
+    target = MacroTools.striplines(target)
+    graphs = MacroTools.striplines.(graphs)
+    expr_spatial = Catalyst.make_spatial_reaction_network(expr, graphs)
+                    
+    @test target == expr_spatial
+end


### PR DESCRIPTION
**Motivation**

Many modellers work with spatial reaction networks, e.g. ones defined on a graph or on a spatial grid, which can be seen as a special type of graph. These can be represented straightforwardly by "normal" reaction networks where each species is split up into multiple sub-species corresponding to each node of the graph, but doing this by hand is very tedious an error-prone. This issue has been brought up previously in #229 and I have attempted to augment Catalyst.jl by extending the reaction network language.

**Implementation**

In order not to break anything I implemented this as an experimental macro whose output can be sent to @reaction_network; this should prevent any code-breaking changes and retain full backwards compatibility.

Species are indexed by vertices in arbitrary graphs, and multiple graphs for one system are supported. Since I am a relative newcomer to Julia I am not sure if there are any standard tools for dealing with graphs, so I've hacked my own for demonstration purposes.

Each species can have an index into a graph, denoted using indexing: `X` becomes `X[i]`, `Y` becomes `Y[j]`, etc. Every index is declared to belong to one graph as macro parameters of the form `G[i] H[j,k]`, which says that `i` is a vertex of `G` and `j`,`k` are vertices of `H`. The species `X[i]` is then expanded to a set of species `X_i` for every vertex `i` of `G`. Constants in reaction rates can be extended similarly, but they can depend on multiple indices, e.g. if a is a constant then `a[i,j]` mapping to `a_(i,j)` can be defined for each `i` in G, `j` in H. Every line using indexing is thus expanded into multiple lines for every valid combination of indices, e.g. 

`d, X[i] -> 0`
`c[i], 0 -> X[i]`
`D[j,k], Y[j] -> Y[k]`
`a, X[i] + Y[j] + Y[k] -> X[i]`

become

`d, X_i -> 0` (for each i in G)
`c_i, 0 -> X_i` (for each i in G)
`D_(j,k), Y_j -> Y_k` (for each edge j<->k in H)
`a, X_i + Y_j + Y_k -> Y_j` (for each i in G, edge j<->k in H)

**Example:**
```
# Cyclic graph on 4 elements
G = BasicGraph([ 1, 2, 3, 4 ], [ 1=>2, 2=>3, 3=>4, 4=>1 ]) 

@spatial_reaction_network begin
  sigma[i] --> X[i]
  D, X[i] --> X[j]
  delta, 2X[i]-->0
  a, 0 -> Z
  b, Z + X[i] -> 2X[i]
end G[i,j]
```

returns

```
quote                                               
    (sigma, 0 → X_1)                                
    (sigma, 0 → X_2)                                                                                     
    (sigma, 0 → X_3)                                
    (sigma, 0 → X_4)                                                                                     
    (D, X_2 → X_1)                                  
    (D, X_3 → X_2)                                  
    (D, X_4 → X_3)                                  
    (D, X_1 → X_4)                                  
    (D, X_1 → X_2)                                  
    (D, X_2 → X_3)                                                                                       
    (D, X_3 → X_4)                                                                                       
    (D, X_4 → X_1)                                  
    (delta, 2X_1 → 0)                                                                                    
    (delta, 2X_2 → 0)                               
    (delta, 2X_3 → 0)                               
    (delta, 2X_4 → 0)                               
    (a, 0 → Z)                                      
    (b, Z + X_1 → 2X_1)                             
    (b, Z + X_2 → 2X_2)                             
    (b, Z + X_3 → 2X_3)                             
    (b, Z + X_4 → 2X_4)                             
end
```

I haven't spent much time with either Julia or SciML, so I would greatly appreciate any feedback!

**Remarks:**
* If `n` indices belonging to a graph appear in a reaction, the reaction is expanded for every n-edge of the graph. If `n==1` this corresponds to every node of the graph, if `n==2` we get every edge and for `n>=3` you can define your own higher-order edges to model more complex interactions. 
* If two different graphs appear in a reaction we expand jointly over all valid permutations of indices of both graphs

**Todos:**
* UGLY: the macro needs the values of the graphs to generate its output, and for this I used `Base.MainInclude.eval()`. What's the proper way to do this?
* The generated variables have names of the form var"X_$i", where i ranges over the vertices of the graph. There is probably a better way to encode this information...
* Prevent one species from being indexed by multiple graphs to avoid name-conflicts?
* Do some testing
* Work on graph interface
* How best to combine this with arbitrary parameters?