### PR TITLE
Adding support for conservation law

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+
+# Vim files
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
 version = "6.12.1"
 
 [deps]
+AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -12,6 +12,7 @@ import MacroTools
 import Base: (==), merge!, merge
 using Symbolics
 using Latexify, Requires
+using AbstractAlgebra
 
 # as used in Catlab
 const USE_GV_JLL = Ref(false)
@@ -42,6 +43,7 @@ include("networkapi.jl")
 export species, params, reactions, speciesmap, paramsmap, numspecies, numreactions, numparams
 export make_empty_network, addspecies!, addparam!, addreaction!
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
+export conservationlaws, conservedquantities
 
 # for Latex printing of ReactionSystems
 include("latexify_recipes.jl")

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -183,6 +183,47 @@ function netstoichmat(rn; smap=speciesmap(rn))
 end
 
 
+######################## conservation laws ###############################
+
+""" 
+    conservationlaws(netstoichmat::AbstractMatrix)::Matrix
+
+Given the net stoichiometry matrix of a reaction system, computes a matrix
+of conservation laws, each represented as a row in the output. 
+"""
+function conservationlaws(nsm::AbstractMatrix)::Matrix
+    n_reac, n_spec = size(nsm)
+    
+    # We basically have to compute the left null space of the matrix
+    # over the integers; this is best done using its Smith Normal Form.
+    nsm_conv = AbstractAlgebra.matrix(AbstractAlgebra.ZZ, nsm)
+    S, T, U = AbstractAlgebra.snf_with_transform(nsm_conv)
+    
+    # Zero columns of S (which occur after nonzero columns in SNF)
+    # correspond to conserved quantities
+    n = findfirst(i -> all(S[:,i] .== 0), 1:n_spec)
+    if n === nothing
+        return zeros(Int, 0, n_spec)
+    end
+    
+    ret = Matrix(U[:,n:end]')
+    
+    # If all coefficients for a conservation law are negative
+    # we might as well flip them to become positive
+    for i in 1:size(ret,1)
+        all(ret[i,:] .<= 0) && (ret[i,:] .*= -1)
+    end
+    
+    ret
+end
+
+"""
+    conservedquantities(state, cons_laws)
+
+Compute conserved quantities for a system with the given conservation laws.
+"""
+conservedquantities(state, cons_laws) = cons_laws * state
+
 ######################## reaction network operators #######################
 
 """

--- a/test/conslaws.jl
+++ b/test/conslaws.jl
@@ -1,0 +1,27 @@
+using Catalyst, Test
+
+rn = @reaction_network begin
+    (1, 2), A + B <--> C 
+    (3, 2), D <--> E 
+    (0.1, 0.2), E <--> F
+    6, F --> G
+    7, H --> G
+    5, 0 --> K
+    3, A + B --> Z + C
+end
+
+S = netstoichmat(rn)
+C = conservationlaws(S)
+
+@test size(C,1) == 3
+
+b = [ 0, 0, 0, 1, 1, 1, 1, 1, 0, 0 ]
+@test any(b == C[i,:] for i in 1:size(C,1))
+
+# For the A + B <--> C subsystem one of these must occur
+# as a conservation law
+D = [ 1 -1 0 0 0 0 0 0 0 0;
+      -1 1 0 0 0 0 0 0 0 0
+      0  1 1 0 0 0 0 0 0 0 ]
+
+@test any(D[j,:] == C[i,:] for i in 1:size(C,1), j in size(D,1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,4 +35,6 @@ end
 @time @safetestset "Latexify" begin include("latexify.jl") end
 @time @safetestset "Graphs" begin include("graphs.jl") end
 
+@time @safetestset "Conservation Laws" begin include("conslaws.jl") end
+
 end # @time


### PR DESCRIPTION
Following onwards from [here](https://github.com/SciML/ModelingToolkit.jl/issues/965) I've added some code taken from [here](https://github.com/kaandocal/FiniteStateProjection.jl/) to detect conservation laws for a reaction system together with a rudimentary unit test for Catalyst. 

### Notes:
- There are multiple equivalent matrices of conservation laws for most systems, afaik there's no way to guarantee which one you're going to get
- It introduces a dependency on AbstractAlgebra.jl
- This will not be very efficient for large (>100 species) systems

Going forward it would be great if we could add functionality to simplify a system based on a conservation law. Basically I was thinking of something like a function `structsimplify(rn, species, cons)` that takes a reaction network and a list of species to be elided and returns an equivalent reaction network without these species. It should check whether these species can be removed simultaneously and replace their occurrences by the other species (using the conserved quantities `cons`). 

Example:
```julia
rn = @reaction_network begin
    ρ_u, G_u --> G_u + P
    ρ_b, G_b --> G_b + P
    d, P --> 0
    σ_u, G_b --> G_u + P
    σ_b, G_u + P --> G_b
end ρ_u ρ_b d σ_u σ_b
```

There is one conservation law `[G_u] + [G_b] == N`, and we can replace the above by the equivalent system
```julia
rn = @reaction_network begin
    ρ_u, G_u --> G_u + P
    ρ_b * (N - G_u), 0 --> P
    d, P --> 0
    σ_u * (N - G_u), 0 --> G_u + P
    σ_b, G_u + P --> 0
end ρ_u ρ_b d σ_u σ_b N
```

(thanks to @palmtree2013 for the example). I've implemented equivalent functionality in my FSP package but it might be nicer if we could just move this straight to Catalyst.jl.