### PR TITLE
Use explicit time dependence

### DIFF
--- a/test/api.jl
+++ b/test/api.jl
@@ -3,7 +3,7 @@ using Catalyst, DiffEqBase, ModelingToolkit, Test
 using ModelingToolkit: value
 
 @parameters t k1 k2
-@variables S I R
+@variables S(t) I(t) R(t)
 rxs = [Reaction(k1, [S,I], [I], [1,1], [2]),
        Reaction(k2, [I], [R]) ]
 rs = ReactionSystem(rxs, t, [S,I,R], [k1,k2])
@@ -21,7 +21,7 @@ rs2 = ReactionSystem(rxs2, t, [R,I,S], [k2,k1])
 
 rs3 = make_empty_network()
 @parameters k3 k4
-@variables D
+@variables D(t)
 addspecies!(rs3, S)
 addspecies!(rs3, D)
 addparam!(rs3, k3)

--- a/test/api.jl
+++ b/test/api.jl
@@ -58,9 +58,9 @@ rs = ReactionSystem(rxs, t, [S,I,R], [k1,k2])
 deps = dependents(rxs[2], rs)
 @test isequal(deps, [R,I])
 @test isequal(dependents(rxs[1], rs), dependants(rxs[1], rs))
-addspecies!(rs, Variable(:S))
+addspecies!(rs, S)
 @test numspecies(rs) == 3
-addspecies!(rs, Variable(:S), disablechecks=true)
+addspecies!(rs, S, disablechecks=true)
 @test numspecies(rs) == 4
 addparam!(rs, k1)
 @test numparams(rs) == 2


### PR DESCRIPTION
ModelingToolkit now requires explicit time dependence for variables in time-dependent systems. See https://github.com/SciML/ModelingToolkit.jl/pull/1064