### PR TITLE
update ReactionSystem constructors for defaults

### DIFF
--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -283,7 +283,7 @@ Construct an empty [`ReactionSystem`](@ref). `iv` is the independent variable,
 usually time, and `name` is the name to give the `ReactionSystem`.
 """
 function make_empty_network(; iv=DEFAULT_IV, name=gensym(:ReactionSystem))
-    ReactionSystem(Reaction[], iv, [], [], Equation[], name, ReactionSystem[])
+    ReactionSystem(Reaction[], iv, [], [], Equation[], name, ReactionSystem[], Dict())
 end
 
 """

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -125,7 +125,8 @@ macro reaction_network(name::Symbol=gensym(:ReactionSystem))
                                  [], 
                                  Equation[],
                                  $(QuoteNode(name)),
-                                 ReactionSystem[])))
+                                 ReactionSystem[],
+                                 Dict())))
 end
 
 ### Macros used for manipulating, and successively builing up, reaction systems. ###


### PR DESCRIPTION
used with https://github.com/SciML/ModelingToolkit.jl/pull/1129 
should fix the downstream test issues there. 

not sure how to make CI use PRs instead of main though, so this will fail 