### PR TITLE
fix for new reaction sys constructor

### DIFF
--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -283,7 +283,7 @@ Construct an empty [`ReactionSystem`](@ref). `iv` is the independent variable,
 usually time, and `name` is the name to give the `ReactionSystem`.
 """
 function make_empty_network(; iv=DEFAULT_IV, name=gensym(:ReactionSystem))
-    ReactionSystem(Reaction[], iv, [], [], Equation[], name, ReactionSystem[], Dict())
+    ReactionSystem(Reaction[], iv, [], [], Equation[], name, ReactionSystem[], Dict(), nothing)
 end
 
 """

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -126,7 +126,8 @@ macro reaction_network(name::Symbol=gensym(:ReactionSystem))
                                  Equation[],
                                  $(QuoteNode(name)),
                                  ReactionSystem[],
-                                 Dict())))
+                                 Dict(), 
+                                 nothing)))
 end
 
 ### Macros used for manipulating, and successively builing up, reaction systems. ###


### PR DESCRIPTION
Needs a new ModelingToolkit release and then tests to pass before merging.