### PR TITLE
ModelingToolkit unit validation logic

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -154,13 +154,15 @@ struct ReactionSystem <: ModelingToolkit.AbstractTimeDependentSystem
     """
     connection_type::Any
 
-
-    function ReactionSystem(eqs, iv, states, ps, observed, name, systems, defaults, connection_type)
-        iv′ = value(iv)
-        states′ = value.(states)
-        ps′ = value.(ps)
-        check_variables(states′, iv′)
-        check_parameters(ps′, iv′)
+    function ReactionSystem(eqs, iv, states, ps, observed, name, systems, defaults, connection_type; checks::Bool = true)
+        if checks
+            iv′ = value(iv)
+            states′ = value.(states)
+            ps′ = value.(ps)
+            check_variables(states′, iv′)
+            check_parameters(ps′, iv′)
+            ModelingToolkit.check_units(eqs)
+        end
         new(collect(eqs), iv′, states′, ps′, observed, name, systems, defaults, connection_type)
     end
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -552,7 +552,7 @@ function ModelingToolkit.get_variables!(deps::Set, rx::Reaction, variables)
     deps
 end
 
-Modelingtoolkit.validate(eq::Reaction; info::String = "") = ModelingToolkit._validate([oderatelaw(eq)], ["reaction ",], info = info)
+ModelingToolkit.validate(eq::Reaction; info::String = "") = ModelingToolkit._validate([oderatelaw(eq)], ["reaction ",], info = info)
 
 # determine which species a reaction modifies
 function ModelingToolkit.modified_states!(mstates, rx::Reaction, sts::Set)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -552,6 +552,8 @@ function ModelingToolkit.get_variables!(deps::Set, rx::Reaction, variables)
     deps
 end
 
+Modelingtoolkit.validate(eq::Reaction; info::String = "") = ModelingToolkit._validate([oderatelaw(eq)], ["reaction ",], info = info)
+
 # determine which species a reaction modifies
 function ModelingToolkit.modified_states!(mstates, rx::Reaction, sts::Set)
     for (species,stoich) in rx.netstoich


### PR DESCRIPTION
This will be necessary (in order to take advantage of unit validation) when [ModelingToolkit.jl#1156](https://github.com/SciML/ModelingToolkit.jl/pull/1156#) lands.