### PR TITLE
Unit validation and tests 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "8.2"
+version = "8.2.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -42,6 +42,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Graphviz_jll", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test"]
+test = ["Graphviz_jll", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "Unitful"]

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -5,17 +5,20 @@ module Catalyst
 
 using DocStringExtensions
 using DiffEqBase, Reexport, ModelingToolkit, DiffEqJump
-using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems, get_eqs, get_defaults, toparam
-import ModelingToolkit: get_variables, namespace_expr
-import ModelingToolkit: namespace_equation, get_variables!, modified_states!
+
+# ModelingToolkit imports and convenience functions we use
+using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems, 
+                       get_eqs, get_defaults, toparam
+import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_variables!, 
+                        modified_states!, validate
 
 # internal but needed ModelingToolkit functions
-import ModelingToolkit: check_variables, check_parameters, _iszero, _merge
+import ModelingToolkit: check_variables, check_parameters, _iszero, _merge, check_units, get_unit
 
 const DEFAULT_IV = (@parameters t)[1]
 @reexport using ModelingToolkit
 import MacroTools
-import Base: (==), merge!, merge, hash, size, getindex, setindex, isless, Sort.defalg, length
+import Base: (==), merge!, merge, hash, size, getindex, setindex, isless, Sort.defalg, length, show
 using Symbolics
 using Latexify, Requires
 import AbstractAlgebra
@@ -38,12 +41,10 @@ include("reactionsystem.jl")
 export Reaction, ReactionSystem, ismassaction, oderatelaw, jumpratelaw
 export ODEProblem, SDEProblem, JumpProblem, NonlinearProblem, DiscreteProblem, SteadyStateProblem
 
+# reaction_network macro
 const ExprValues = Union{Expr,Symbol,Float64,Int}
-
 include("expression_utils.jl")
 include("reaction_network.jl")
-
-# reaction network macro
 export @reaction_network, @add_reactions
 
 # registers CRN specific functions using Symbolics.jl

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -611,7 +611,7 @@ function validate(rs::ReactionSystem, info::String="")
     for spec in specs
         if get_unit(spec) != specunits
             validated = false 
-            @warn("Species are expected to have the same units of $specunits, however, species $spec has units $(get_unit(spec)).")
+            @warn("Species are expected to have units of $specunits, however, species $spec has units $(get_unit(spec)).")
         end
     end
     timeunits = get_unit(get_iv(rs))

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -592,11 +592,9 @@ function validate(rx::Reaction; info::String = "")
         end
     end
 
-    if (subunits !== nothing) && (produnits !== nothing)
-        if subunits != produnits
-            validated = false
-            @warn("in $rxstr, the substrate units are not consistent with the product units.")
-        end
+    if (subunits !== nothing) && (produnits !== nothing) && (subunits != produnits)
+        validated = false
+        @warn("in $rxstr, the substrate units are not consistent with the product units.")
     end
 
     validated

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -573,14 +573,13 @@ end
 
 # right now we just check the rate is valid and species have the same units
 function validate(rx::Reaction; info::String = "")     
-    rxstr = string(rx)
-    validated = ModelingToolkit._validate([rx.rate], ["$rxstr: rate",], info = info)
+    validated = ModelingToolkit._validate([rx.rate], [string(rx, ": rate")], info = info)
     
     subunits = isempty(rx.substrates) ? nothing : get_unit(rx.substrates[1])
     for i in 2:length(rx.substrates)
         if get_unit(rx.substrates[i]) != subunits
             validated = false
-            @warn("In $rxstr, the substrates have differing units.")
+            @warn(string("In ", rx, " the substrates have differing units."))
         end
     end
 
@@ -588,13 +587,13 @@ function validate(rx::Reaction; info::String = "")
     for i in 2:length(rx.products)
         if get_unit(rx.products[i]) != produnits
             validated = false
-            @warn("In $rxstr, the products have differing units.")
+            @warn(string("In ", rx, " the products have differing units."))
         end
     end
 
     if (subunits !== nothing) && (produnits !== nothing) && (subunits != produnits)
         validated = false
-        @warn("in $rxstr, the substrate units are not consistent with the product units.")
+        @warn(string("in ", rx, " the substrate units are not consistent with the product units."))
     end
 
     validated
@@ -611,7 +610,7 @@ function validate(rs::ReactionSystem, info::String="")
     for spec in specs
         if get_unit(spec) != specunits
             validated = false 
-            @warn("Species are expected to have units of $specunits, however, species $spec has units $(get_unit(spec)).")
+            @warn(string("Species are expected to have units of ", specunits, " however, species ", spec, " has units ", get_unit(spec), "."))
         end
     end
     timeunits = get_unit(get_iv(rs))
@@ -625,7 +624,7 @@ function validate(rs::ReactionSystem, info::String="")
 
         if rxunits != rateunits
             validated = false
-            @warn("Reaction rate laws are expected to have units of $(rateunits), however, $(rx) has units of $rxunits.")
+            @warn(string("Reaction rate laws are expected to have units of ", rateunits, " however, ", rx, " has units of ", rxunits, "."))
         end
     end
 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -100,9 +100,9 @@ function print_rxside(io::IO, specs, stoich)
     else
         for (i,spec) in enumerate(specs)
             if stoich[1] == 1
-                print(io, "$(ModelingToolkit.operation(spec))")
+                print(io, ModelingToolkit.operation(spec))
             else
-                print(io, "$(stoich[i])$(ModelingToolkit.operation(spec))")
+                print(io, stoich[i], ModelingToolkit.operation(spec))
             end
 
             (i < length(specs)) && print(io, " + ")

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -157,11 +157,11 @@ Continuing from the example in the [`Reaction`](@ref) definition:
 @named rs = ReactionSystem(rxs, t, [A,B,C,D], k)
 
 Notes:
-- ReactionSystems currently do rudimentary unit checking by generating for all 
-  reactions the corresponding ODE rate expressions, and making sure they are 
-  independently self-consistent. Note, this does not check that all the ODE 
-  rate laws actually have the same units, just that they do not involve sums
-  with differing units.
+- ReactionSystems currently do rudimentary unit checking, requiring that
+  all species have the same units, and all reactions have rate laws with 
+  units of (species units) / (time units). Unit checking can be disabled
+  by passing the keyword argument `checks=false`.
+
 ```
 """
 struct ReactionSystem <: ModelingToolkit.AbstractTimeDependentSystem

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,5 +40,5 @@ end
 @time @safetestset "Graphs" begin include("graphs.jl") end
 
 @time @safetestset "Conservation Laws" begin include("conslaws.jl") end
-
+@time @safetestset "Units" begin include("units.jl") end
 end # @time

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,0 +1,46 @@
+using Catalyst, Unitful, Test
+const MT = ModelingToolkit
+
+@parameters α [unit=u"μM/s"] β [unit=u"s"^(-1)] γ [unit=u"μM*s"^(-1)]
+@variables t [unit=u"s"] A(t) [unit=u"μM"] B(t) [unit=u"μM"] C(t) [unit=u"μM"]
+rxs = [Reaction(α, nothing, [A]),
+       Reaction(β, [A], [B]),
+       Reaction(γ, [A,B], [B], [1,1], [2])]
+rs = ReactionSystem(rxs, t, [A,B,C], [α,β,γ], name=Symbol("unittester"))
+@test_nowarn ReactionSystem(rxs, t, [A,B,C], [α,β,γ], name=Symbol("unittester"))
+
+odeunit = u"μM/s"
+#jumpunit = u"s^(-1)"
+for rx in reactions(rs)
+    @test MT.get_unit(oderatelaw(rx)) == odeunit
+
+    # we don't currently convert units, so they will be the same as for ODEs
+    @test MT.get_unit(jumpratelaw(rx)) == odeunit  
+end
+
+@test_nowarn convert(ODESystem,rs)
+@test_nowarn convert(SDESystem,rs)
+@test_nowarn convert(JumpSystem,rs)
+
+@parameters β [unit=u"M"]
+rxs = [Reaction(α, nothing, [A]),
+       Reaction(β, [A], [B]),
+       Reaction(γ, [A,B], [B], [1,1], [2])]
+@test (@test_logs (:warn, ) match_mode=:any ModelingToolkit.validate(ReactionSystem(rxs, t, [A,B,C], [α,β,γ], name=Symbol("unittester")))) == false
+
+@parameters β [unit=u"s"^(-1)]
+@variables B(t) [unit=u"M"]
+rxs = [Reaction(α, nothing, [A]),
+       Reaction(β, [A], [B]),
+       Reaction(γ, [A,B], [B], [1,1], [2])]
+@test (@test_logs (:warn, ) match_mode=:any ModelingToolkit.validate(ReactionSystem(rxs, t, [A,B,C], [α,β,γ], name=Symbol("unittester")))) == false
+
+@variables B(t) [unit=u"μM"] D(t) [unit=u"M"]
+badrx1 = Reaction(α, [A], [D])
+@test (@test_logs (:warn, ) match_mode=:any ModelingToolkit.validate(badrx1)) == false
+badrx2 = Reaction(α, [A], [B,D])
+@test (@test_logs (:warn, ) match_mode=:any ModelingToolkit.validate(badrx2)) == false
+badrx3 = Reaction(α, [A,D], [B])
+@test (@test_logs (:warn, ) match_mode=:any ModelingToolkit.validate(badrx3)) == false
+badrx4 = Reaction(α + β, [A], [B])
+@test (@test_logs (:warn, ) match_mode=:any ModelingToolkit.validate(badrx4)) == false


### PR DESCRIPTION
I also added a `show` definition for `Reaction`s that prints out stuff like
```
Reaction{Any, Int64}: γ, A + B --> 2B
```
so a user could easily round-trip to/from the DSL. (I kept the summary with type info, but could drop that from `show` if anyone thinks that makes sense.)