### PR TITLE
Sparse representation of `stoichiometric matrices` functions and matrices in complex-based functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
@@ -43,6 +44,7 @@ SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [targets]
-test = ["Graphviz_jll", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "Unitful"]
+test = ["Graphviz_jll", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "Unitful","SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,6 @@ SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [targets]
-test = ["Graphviz_jll", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "Unitful","SparseArrays"]
+test = ["Graphviz_jll", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StableRNGs", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test", "Unitful"]

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -121,6 +121,7 @@ conservationlaws
 conservedquantities
 ReactionComplexElement
 ReactionComplex
+reactioncomplexmap
 reactioncomplexes
 complexstoichmat
 complexoutgoingmat

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -5,7 +5,7 @@ module Catalyst
 
 using DocStringExtensions
 using DiffEqBase, Reexport, ModelingToolkit, DiffEqJump
-
+using SparseArrays
 # ModelingToolkit imports and convenience functions we use
 using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems, 
                        get_eqs, get_defaults, toparam

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -56,7 +56,7 @@ export species, params, reactions, speciesmap, paramsmap, numspecies, numreactio
 export make_empty_network, addspecies!, addparam!, addreaction!
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities
-export reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat
+export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat
     
 # for Latex printing of ReactionSystems
 include("latexify_recipes.jl")

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -4,8 +4,8 @@ $(DocStringExtensions.README)
 module Catalyst
 
 using DocStringExtensions
-using DiffEqBase, Reexport, ModelingToolkit, DiffEqJump
-using SparseArrays
+using SparseArrays, DiffEqBase, Reexport, ModelingToolkit, DiffEqJump
+
 # ModelingToolkit imports and convenience functions we use
 using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems, 
                        get_eqs, get_defaults, toparam

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -465,11 +465,12 @@ Given the net stoichiometry matrix of a reaction system, computes a matrix
 of conservation laws, each represented as a row in the output. 
 """
 function conservationlaws(nsm::AbstractMatrix)::Matrix
-    n_reac, n_spec = size(nsm)
+    n_spec,n_reac = size(nsm)
     
     # We basically have to compute the left null space of the matrix
     # over the integers; this is best done using its Smith Normal Form.
-    nsm_conv = AbstractAlgebra.matrix(AbstractAlgebra.ZZ, nsm)
+    # note, we transpose as this was written when netstoichmat was reac by spec
+    nsm_conv = AbstractAlgebra.matrix(AbstractAlgebra.ZZ, nsm')
     S, T, U = AbstractAlgebra.snf_with_transform(nsm_conv)
     
     # Zero columns of S (which occur after nonzero columns in SNF)

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -135,105 +135,108 @@ end
 
 
 """
-    substoichmat(rn,sparsity=false; smap=speciesmap(rn))
+    substoichmat(rn; sparse=false, smap=speciesmap(rn))
 
-Returns the substrate stoichiometry matrix
+Returns the substrate stoichiometry matrix, S, with Sᵢⱼ the stoichiometric
+coefficient of the ith substrate within the jth reaction.
 
 Note:
-- Set sparsity=true for sparse representation
+- Set sparse=true for a sparse matrix representation
 """
-function substoichmat(::Type{SparseMatrixCSC}, rn::ReactionSystem; smap=speciesmap(rn))
-    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+function substoichmat(::Type{SparseMatrixCSC{Int,Int}}, rn::ReactionSystem; smap=speciesmap(rn))
+    Is=Int[];  Js=Int[];  Vs=Int[];
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.substoich
         for (i,sub) in enumerate(rx.substrates)
-            push!(Is,k)
-            push!(Js, smap[sub])
+            push!(Js, k)
+            push!(Is, smap[sub])
             push!(Vs, stoich[i])
         end
     end
-    smat = sparse(Is,Js,Vs,numreactions(rn),numspecies(rn))
+    sparse(Is,Js,Vs,numspecies(rn),numreactions(rn))
 end
-function substoichmat(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
-    smat = zeros(Int,numreactions(rn),numspecies(rn))
+function substoichmat(::Type{Matrix{Int}},rn::ReactionSystem; smap=speciesmap(rn))
+    smat = zeros(Int, numspecies(rn), numreactions(rn))
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.substoich
         for (i,sub) in enumerate(rx.substrates)
-            smat[k,smap[sub]] = stoich[i]
+            smat[smap[sub],k] = stoich[i]
         end
     end
     smat
 end
-function substoichmat(rn::ReactionSystem, sparsity::Bool=false; smap=speciesmap(rn))
-	sparsity ? substoichmat(SparseMatrixCSC, rn; smap=smap) : substoichmat(Matrix, rn; smap=smap)
+function substoichmat(rn::ReactionSystem; sparse::Bool=false; smap=speciesmap(rn))
+	sparse ? substoichmat(SparseMatrixCSC{Int,Int}, rn; smap=smap) : substoichmat(Matrix{Int}, rn; smap=smap)
 end
 
 
 """
-    prodstoichmat(rn,sparsity=false; smap=speciesmap(rn))
+    prodstoichmat(rn; sparse=false, smap=speciesmap(rn))
 
-Returns the product stoichiometry matrix
+Returns the product stoichiometry matrix, P, with Pᵢⱼ the stoichiometric
+coefficient of the ith product within the jth reaction.
 
 Note:
-- Set sparsity=true for sparse representation
+- Set sparse=true for a sparse matrix representation
 """
-function prodstoichmat(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=speciesmap(rn))
-    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+function prodstoichmat(::Type{SparseMatrixCSC{Int}}, rn::ReactionSystem; smap=speciesmap(rn))
+    Is=Int[];  Js=Int[];  Vs=Int[];
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.prodstoich
         for (i,prod) in enumerate(rx.products)
-			push!(Is,k)
-			push!(Js, smap[prod])
+			push!(Js, k)
+			push!(Is, smap[prod])
 			push!(Vs, stoich[i])
         end
     end
-    smat = sparse(Is,Js,Vs,numreactions(rn),numspecies(rn))
+    sparse(Is,Js,Vs,numspecies(rn),numreactions(rn))
 end
-function prodstoichmat(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
-    pmat = zeros(Int,(numreactions(rn),numspecies(rn)))
+function prodstoichmat(::Type{Matrix{Int}},rn::ReactionSystem; smap=speciesmap(rn))
+    pmat = zeros(Int, numspecies(rn), numreactions(rn))
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.prodstoich
         for (i,prod) in enumerate(rx.products)
-            pmat[k,smap[prod]] = stoich[i]
+            pmat[smap[prod],k] = stoich[i]
         end
     end
     pmat
 end
-function prodstoichmat(rn::ReactionSystem, sparsity::Bool=false; smap=speciesmap(rn))
-	sparsity ? prodstoichmat(SparseMatrixCSC, rn; smap=smap) : prodstoichmat(Matrix, rn; smap=smap)
+function prodstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
+	sparse ? prodstoichmat(SparseMatrixCSC{Int,Int}, rn; smap=smap) : prodstoichmat(Matrix{Int}, rn; smap=smap)
 end
 
 
 """
     netstoichmat(rn,sparsity=false; smap=speciesmap(rn))
 
-Returns the net stoichiometry matrix
+Returns the net stoichiometry matrix, N, with Nᵢⱼ the net stoichiometric
+coefficient of the ith species within the jth reaction.
 
 Note:
-- Set sparsity=true for sparse representation
+- Set sparse=true for a sparse matrix representation
 """
-function netstoichmat(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=speciesmap(rn))
-    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+function netstoichmat(::Type{SparseMatrixCSC{Int,Int}}, rn::ReactionSystem; smap=speciesmap(rn))
+    Is=Int[];  Js=Int[];  Vs=Int[];
     for (k,rx) in pairs(reactions(rn))
         for (spec,coef) in rx.netstoich
-			push!(Is,k)
-			push!(Js, smap[spec])
+			push!(Js, k)
+			push!(Is, smap[spec])
 			push!(Vs, coef)
         end
     end
-    nmat = sparse(Is,Js,Vs,numreactions(rn),numspecies(rn))
+    sparse(Is,Js,Vs,numspecies(rn),numreactions(rn))
 end
-function netstoichmat(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
-    nmat = zeros(Int,(numreactions(rn),numspecies(rn)))
+function netstoichmat(::Type{Matrix{Int}},rn::ReactionSystem; smap=speciesmap(rn))
+    nmat = zeros(Int,numspecies(rn),numreactions(rn))
     for (k,rx) in pairs(reactions(rn))
         for (spec,coef) in rx.netstoich
-            nmat[k,smap[spec]] = coef
+            nmat[smap[spec],k] = coef
         end
     end
     nmat
 end
-function netstoichmat(rn::ReactionSystem, sparsity::Bool=false; smap=speciesmap(rn))
-	sparsity ? netstoichmat(SparseMatrixCSC, rn; smap=smap) : netstoichmat(Matrix, rn; smap=smap)
+function netstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
+	sparse ? netstoichmat(SparseMatrixCSC{Int,Int}, rn; smap=smap) : netstoichmat(Matrix{Int}, rn; smap=smap)
 end
 
 
@@ -295,7 +298,7 @@ Notes:
            0, otherwise
 - Set sparsity=true for sparse representation of incidence matrix
 """
-function reactioncomplexes(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=speciesmap(rn))
+function reactioncomplexes(::Type{SparseMatrixCSC{Int,Int}},rn::ReactionSystem; smap=speciesmap(rn))
     rxs = reactions(rn)
     numreactions(rn) > 0 || error("There must be at least one reaction to find reaction complexes.")
     complextorxsmap = OrderedDict{ReactionComplex{eltype(rxs[1].substoich)},Vector{Pair{Int,Int}}}()
@@ -327,10 +330,10 @@ function reactioncomplexes(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=spec
 			push!(Vs, σ)
         end
     end
-	B = sparse(Is,Js,Vs,length(complexes), numreactions(rn))
+	B = sparse(Is,Js,Vs,length(complexes),numreactions(rn))
     complexes,B
 end
-function reactioncomplexes(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
+function reactioncomplexes(::Type{Matrix{Int}},rn::ReactionSystem; smap=speciesmap(rn))
     rxs = reactions(rn)
     numreactions(rn) > 0 || error("There must be at least one reaction to find reaction complexes.")
     complextorxsmap = OrderedDict{ReactionComplex{eltype(rxs[1].substoich)},Vector{Pair{Int,Int}}}()
@@ -361,8 +364,8 @@ function reactioncomplexes(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn
     end
     complexes,B
 end
-function reactioncomplexes(rn::ReactionSystem,sparsity::Bool=false; smap=speciesmap(rn))
-	sparsity ? reactioncomplexes(SparseMatrixCSC,rn;smap=smap) : reactioncomplexes(Matrix,rn;smap=smap)
+function reactioncomplexes(rn::ReactionSystem; sparse=false; smap=speciesmap(rn))
+	sparse ? reactioncomplexes(SparseMatrixCSC{Int,Int},rn;smap=smap) : reactioncomplexes(Matrix{Int},rn;smap=smap)
 end
 
 

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -135,12 +135,27 @@ end
 
 
 """
-    substoichmat(rn; smap=speciesmap(rn))
+    substoichmat(rn,sparsity=false; smap=speciesmap(rn))
 
 Returns the substrate stoichiometry matrix
+
+Note:
+- Set sparsity=true for sparse representation
 """
-function substoichmat(rn; smap=speciesmap(rn))
-    smat = zeros(Int,(numreactions(rn),numspecies(rn)))
+function substoichmat(::Type{SparseMatrixCSC}, rn::ReactionSystem; smap=speciesmap(rn))
+    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+    for (k,rx) in enumerate(reactions(rn))
+        stoich = rx.substoich
+        for (i,sub) in enumerate(rx.substrates)
+            push!(Is,k)
+            push!(Js, smap[sub])
+            push!(Vs, stoich[i])
+        end
+    end
+    smat = sparse(Is,Js,Vs,numreactions(rn),numspecies(rn))
+end
+function substoichmat(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
+    smat = zeros(Int,numreactions(rn),numspecies(rn))
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.substoich
         for (i,sub) in enumerate(rx.substrates)
@@ -149,13 +164,32 @@ function substoichmat(rn; smap=speciesmap(rn))
     end
     smat
 end
+function substoichmat(rn::ReactionSystem, sparsity::Bool=false; smap=speciesmap(rn))
+	sparsity ? substoichmat(SparseMatrixCSC, rn; smap=smap) : substoichmat(Matrix, rn; smap=smap)
+end
+
 
 """
-    prodstoichmat(rn; smap=speciesmap(rn))
+    prodstoichmat(rn,sparsity=false; smap=speciesmap(rn))
 
 Returns the product stoichiometry matrix
+
+Note:
+- Set sparsity=true for sparse representation
 """
-function prodstoichmat(rn; smap=speciesmap(rn))
+function prodstoichmat(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=speciesmap(rn))
+    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+    for (k,rx) in enumerate(reactions(rn))
+        stoich = rx.prodstoich
+        for (i,prod) in enumerate(rx.products)
+			push!(Is,k)
+			push!(Js, smap[prod])
+			push!(Vs, stoich[i])
+        end
+    end
+    smat = sparse(Is,Js,Vs,numreactions(rn),numspecies(rn))
+end
+function prodstoichmat(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
     pmat = zeros(Int,(numreactions(rn),numspecies(rn)))
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.prodstoich
@@ -165,14 +199,31 @@ function prodstoichmat(rn; smap=speciesmap(rn))
     end
     pmat
 end
+function prodstoichmat(rn::ReactionSystem, sparsity::Bool=false; smap=speciesmap(rn))
+	sparsity ? prodstoichmat(SparseMatrixCSC, rn; smap=smap) : prodstoichmat(Matrix, rn; smap=smap)
+end
 
 
 """
-    netstoichmat(rn; smap=speciesmap(rn))
+    netstoichmat(rn,sparsity=false; smap=speciesmap(rn))
 
 Returns the net stoichiometry matrix
+
+Note:
+- Set sparsity=true for sparse representation
 """
-function netstoichmat(rn; smap=speciesmap(rn))
+function netstoichmat(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=speciesmap(rn))
+    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+    for (k,rx) in pairs(reactions(rn))
+        for (spec,coef) in rx.netstoich
+			push!(Is,k)
+			push!(Js, smap[spec])
+			push!(Vs, coef)
+        end
+    end
+    nmat = sparse(Is,Js,Vs,numreactions(rn),numspecies(rn))
+end
+function netstoichmat(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
     nmat = zeros(Int,(numreactions(rn),numspecies(rn)))
     for (k,rx) in pairs(reactions(rn))
         for (spec,coef) in rx.netstoich
@@ -180,6 +231,9 @@ function netstoichmat(rn; smap=speciesmap(rn))
         end
     end
     nmat
+end
+function netstoichmat(rn::ReactionSystem, sparsity::Bool=false; smap=speciesmap(rn))
+	sparsity ? netstoichmat(SparseMatrixCSC, rn; smap=smap) : netstoichmat(Matrix, rn; smap=smap)
 end
 
 
@@ -226,8 +280,9 @@ Base.setindex!(rc::ReactionComplex, t::ReactionComplexElement, i...) =
 Base.isless(a::ReactionComplexElement, b::ReactionComplexElement) = isless(a.speciesid, b.speciesid)
 Base.Sort.defalg(::ReactionComplex{T}) where {T <: Integer} = Base.DEFAULT_UNSTABLE
 
+
 """
-    reactioncomplexes(network, smap=speciesmap(rn))
+    reactioncomplexes(network,sparsity=false; smap=speciesmap(rn))
 
 Calculate the reaction complexes and complex incidence matrix for the given [`ReactionSystem`](@ref). 
 
@@ -238,8 +293,9 @@ Notes:
     Bᵢⱼ = -1, if the i'th complex is the substrate of the j'th reaction,
            1, if the i'th complex is the product of the j'th reaction,
            0, otherwise
+- Set sparsity=true for sparse representation of incidence matrix
 """
-function reactioncomplexes(rn; smap=speciesmap(rn))
+function reactioncomplexes(::Type{SparseMatrixCSC},rn::ReactionSystem; smap=speciesmap(rn))
     rxs = reactions(rn)
     numreactions(rn) > 0 || error("There must be at least one reaction to find reaction complexes.")
     complextorxsmap = OrderedDict{ReactionComplex{eltype(rxs[1].substoich)},Vector{Pair{Int,Int}}}()
@@ -260,7 +316,42 @@ function reactioncomplexes(rn; smap=speciesmap(rn))
             complextorxsmap[prodrc] = [i => 1]
         end
     end
-    
+
+    complexes = collect(keys(complextorxsmap))
+
+    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+	for (i,c) in enumerate(complexes)
+        for (j,σ) in complextorxsmap[c]
+			push!(Is, i)
+			push!(Js, j)
+			push!(Vs, σ)
+        end
+    end
+	B = sparse(Is,Js,Vs,length(complexes), numreactions(rn))
+    complexes,B
+end
+function reactioncomplexes(::Type{Matrix},rn::ReactionSystem; smap=speciesmap(rn))
+    rxs = reactions(rn)
+    numreactions(rn) > 0 || error("There must be at least one reaction to find reaction complexes.")
+    complextorxsmap = OrderedDict{ReactionComplex{eltype(rxs[1].substoich)},Vector{Pair{Int,Int}}}()
+    for (i,rx) in enumerate(rxs)
+        reactantids = isempty(rx.substrates) ? Vector{Int}() : [smap[sub] for sub in rx.substrates]
+        subrc = sort!(ReactionComplex(reactantids, copy(rx.substoich)))
+        if haskey(complextorxsmap, subrc)
+            push!(complextorxsmap[subrc], i => -1)
+        else
+            complextorxsmap[subrc] = [i => -1]
+        end
+
+        productids = isempty(rx.products) ? Vector{Int}() : [smap[prod] for prod in rx.products]
+        prodrc = sort!(ReactionComplex(productids, copy(rx.prodstoich)))
+        if haskey(complextorxsmap, prodrc)
+            push!(complextorxsmap[prodrc], i => 1)
+        else
+            complextorxsmap[prodrc] = [i => 1]
+        end
+    end
+
     complexes = collect(keys(complextorxsmap))
     B = zeros(Int64, length(complexes), numreactions(rn));
     for (i,c) in enumerate(complexes)
@@ -270,6 +361,10 @@ function reactioncomplexes(rn; smap=speciesmap(rn))
     end
     complexes,B
 end
+function reactioncomplexes(rn::ReactionSystem,sparsity::Bool=false; smap=speciesmap(rn))
+	sparsity ? reactioncomplexes(SparseMatrixCSC,rn;smap=smap) : reactioncomplexes(Matrix,rn;smap=smap)
+end
+
 
 """
     reaction_rates(network)
@@ -282,15 +377,29 @@ end
 
 
 """
-    complexstoichmat(network; rcs=reactioncomplexes(rn)[1]))
+    complexstoichmat(network,sparsity=false; rcs=reactioncomplexes(rn)[1]))
 
 Given a [`ReactionSystem`](@ref) and vector of reaction complexes, return a
 matrix with positive entries of size num_of_species x num_of_complexes, where
 the non-zero positive entries in the kth column denote stoichiometric
 coefficients of the species participating in the kth reaction complex.
+
+Note:
+- Set sparsity=true for sparse representation
 """
-function complexstoichmat(rn; rcs=reactioncomplexes(rn)[1])
-    Z = zeros(Int64, numspecies(rn), length(rcs));
+function complexstoichmat(::Type{SparseMatrixCSC},rn::ReactionSystem; rcs=reactioncomplexes(rn)[1])
+    Is=Int64[];  Js=Int64[];  Vs=Int64[];
+    for (i,rc) in enumerate(rcs)
+        for rcel in rc
+			push!(Is,rcel.speciesid)
+			push!(Js, i)
+			push!(Vs, rcel.speciesstoich)
+        end
+    end
+    Z = sparse(Is,Js,Vs, numspecies(rn), length(rcs))
+end
+function complexstoichmat(::Type{Matrix},rn::ReactionSystem; rcs=reactioncomplexes(rn)[1])
+    Z=zeros(Int64, numspecies(rn), length(rcs))
     for (i,rc) in enumerate(rcs)
         for rcel in rc
             Z[rcel.speciesid,i] = rcel.speciesstoich
@@ -298,9 +407,12 @@ function complexstoichmat(rn; rcs=reactioncomplexes(rn)[1])
     end
     Z
 end
+function complexstoichmat(rn::ReactionSystem, sparsity::Bool=false; rcs=reactioncomplexes(rn,sparsity)[1])
+	sparsity ? complexstoichmat(SparseMatrixCSC,rn;rcs = rcs) : complexstoichmat(Matrix,rn;rcs=rcs)
+end
 
 """
-    complexoutgoingmat(network; B=reactioncomplexes(rn)[2])
+    complexoutgoingmat(network,sparsity=false; B=reactioncomplexes(rn)[2])
 
 Given a [`ReactionSystem`](@ref) and complex incidence matrix, B, return a matrix
 of size num_of_complexes x num_of_reactions.
@@ -309,13 +421,31 @@ Notes
 - The complex outgoing matrix, Δ, is defined by 
     Δᵢⱼ = 0,    if Bᵢⱼ = 1 
     Δᵢⱼ = Bᵢⱼ,  otherwise
+- Set sparsity=true for sparse representation
 """
-function complexoutgoingmat(rn; B=reactioncomplexes(rn)[2])
+function complexoutgoingmat(::Type{SparseMatrixCSC}; B=reactioncomplexes(rn)[2])
+    Δ = copy(B)
+	n = size(Δ,2)
+	rows = rowvals(Δ)
+	vals = nonzeros(Δ)
+	for j = 1:n
+	   for i in nzrange(Δ, j)
+	      if vals[i] == 1
+			  Δ[rows[i],j] = 0
+		  end
+	   end
+	end
+    dropzeros(Δ)
+end
+function complexoutgoingmat(::Type{Matrix}; B=reactioncomplexes(rn)[2])
     Δ = copy(B)
     for (I,b) in pairs(Δ)
         (b == 1) && (Δ[I] = 0)
     end
     Δ
+end
+function complexoutgoingmat(rn::ReactionSystem, sparsity::Bool=false; B=reactioncomplexes(rn,sparsity)[2])
+	sparsity ? complexoutgoingmat(SparseMatrixCSC;B = B) : complexoutgoingmat(Matrix;B=B)
 end
 
 

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -165,7 +165,7 @@ function substoichmat(::Type{Matrix{Int}},rn::ReactionSystem; smap=speciesmap(rn
     end
     smat
 end
-function substoichmat(rn::ReactionSystem; sparse::Bool=false; smap=speciesmap(rn))
+function substoichmat(rn::ReactionSystem; sparse::Bool=false, smap=speciesmap(rn))
 	sparse ? substoichmat(SparseMatrixCSC{Int,Int}, rn; smap=smap) : substoichmat(Matrix{Int}, rn; smap=smap)
 end
 
@@ -179,7 +179,7 @@ coefficient of the ith product within the jth reaction.
 Note:
 - Set sparse=true for a sparse matrix representation
 """
-function prodstoichmat(::Type{SparseMatrixCSC{Int}}, rn::ReactionSystem; smap=speciesmap(rn))
+function prodstoichmat(::Type{SparseMatrixCSC{Int,Int}}, rn::ReactionSystem; smap=speciesmap(rn))
     Is=Int[];  Js=Int[];  Vs=Int[];
     for (k,rx) in enumerate(reactions(rn))
         stoich = rx.prodstoich
@@ -360,7 +360,7 @@ function reactioncomplexes(::Type{Matrix{Int}},rn::ReactionSystem;
     end
     complexes,B
 end
-function reactioncomplexes(rn::ReactionSystem; sparse=false; smap=speciesmap(rn))
+function reactioncomplexes(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
 	sparse ? reactioncomplexes(SparseMatrixCSC{Int,Int}, rn; smap=smap) : reactioncomplexes(Matrix{Int}, rn; smap=smap)
 end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,5 +1,5 @@
 using Catalyst, DiffEqBase, ModelingToolkit, Test
-
+using SparseArrays
 using ModelingToolkit: value
 
 @parameters t k1 k2

--- a/test/api.jl
+++ b/test/api.jl
@@ -77,8 +77,8 @@ smat = [1 2 0;
         0 3 0]
 pmat = [0 2 0;
         1 0 2]
-@test all(smat .== substoichmat(rnmat))
-@test all(pmat .== prodstoichmat(rnmat))
+@test all(smat .== substoichmat(rnmat) .== Array(substoichmat(rnmat,true)))
+@test all(pmat .== prodstoichmat(rnmat) .== Array(prodstoichmat(rnmat,true)))
               
 ############## testing newly added intermediate complexes reaction networks##############
 rns  = Vector{ReactionSystem}(undef,6)
@@ -103,9 +103,9 @@ B = [-1 0 0 0;
       0 0 0 1]
 Δ = [-1 0 0 0; 0 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 0; 0 0 0 -1; 0 0 0 0]
 rcs,B2 = reactioncomplexes(rns[1])
-@test B == B2
-@test Z == complexstoichmat(rns[1])
-@test Δ == complexoutgoingmat(rns[1])
+@test B == B2 == Array(reactioncomplexes(rns[1],true)[2])
+@test Z == complexstoichmat(rns[1]) == Array(complexstoichmat(rns[1],true))
+@test Δ == complexoutgoingmat(rns[1]) == Array(complexoutgoingmat(rns[1],true))
 
 # mass-action rober
 rns[2] = @reaction_network begin
@@ -123,9 +123,9 @@ B = [-1 0 0;
       0 0 1]
 Δ = [-1 0 0; 0 0 0; 0 -1 0; 0 0 -1; 0 0 0]
 rcs,B2 = reactioncomplexes(rns[2])
-@test B == B2
-@test Z == complexstoichmat(rns[2])
-@test Δ == complexoutgoingmat(rns[2])
+@test B == B2 == Array(reactioncomplexes(rns[2],true)[2])
+@test Z == complexstoichmat(rns[2]) == Array(complexstoichmat(rns[2],true))
+@test Δ == complexoutgoingmat(rns[2]) == Array(complexoutgoingmat(rns[2],true))
 
 
 #  some rational functions as rates
@@ -145,9 +145,9 @@ B = [-1 0 0 1;
       0 0 0 -1]
 Δ = [-1 0 0 0; 0 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 -1]
 rcs,B2 = reactioncomplexes(rns[3])
-@test B == B2
-@test Z == complexstoichmat(rns[3])
-@test Δ == complexoutgoingmat(rns[3])
+@test B == B2 == Array(reactioncomplexes(rns[3],true)[2])
+@test Z == complexstoichmat(rns[3]) == Array(complexstoichmat(rns[3],true))
+@test Δ == complexoutgoingmat(rns[3]) ==  Array(complexoutgoingmat(rns[3],true))
 
 # repressilator
 rns[4]  = @reaction_network begin
@@ -184,9 +184,9 @@ B = [-1 -1 -1 1 -1 1 -1 1 -1 0 0 0 1 1 1;
        0 0 0 0 0 0 0 -1 0 0 0 -1 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0;
        0 0 0 0 0 0 0 0 0 0 0 0 -1 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 -1 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1]
 rcs,B2 = reactioncomplexes(rns[4])
-@test B == B2
-@test Z == complexstoichmat(rns[4])
-@test Δ == complexoutgoingmat(rns[4])
+@test B == B2 == Array(reactioncomplexes(rns[4],true)[2])
+@test Z == complexstoichmat(rns[4]) == Array(complexstoichmat(rns[4],true))
+@test Δ == complexoutgoingmat(rns[4]) == Array(complexoutgoingmat(rns[4],true))
 
 #brusselator
 rns[5] = @reaction_network begin
@@ -204,9 +204,9 @@ B = [-1 0 0 1;
       0 0 1 0]
 Δ = [-1 0 0 0; 0 0 -1 -1; 0 -1 0 0; 0 0 0 0; 0 0 0 0]
 rcs,B2 = reactioncomplexes(rns[5])
-@test B == B2
-@test Z == complexstoichmat(rns[5])
-@test Δ == complexoutgoingmat(rns[5])
+@test B == B2 == Array(reactioncomplexes(rns[5],true)[2])
+@test Z == complexstoichmat(rns[5]) == Array(complexstoichmat(rns[5],true))
+@test Δ == complexoutgoingmat(rns[5]) == Array(complexoutgoingmat(rns[5],true))
 
 # some rational functions as rates
 rns[6] = @reaction_network begin
@@ -232,9 +232,9 @@ B = [-1 1 0 0 0 0;
       0 0 0 0 1 -1]
 Δ = [-1 0 0 0 0 0; 0 -1 0 0 0 0; 0 0 -1 0 0 0; 0 0 0 -1 0 0; 0 0 0 0 -1 0; 0 0 0 0 0 -1]
 rcs,B2 = reactioncomplexes(rns[6])
-@test all(B .== B2)
-@test Z == complexstoichmat(rns[6]; rcs=rcs)
-@test Δ == complexoutgoingmat(rns[6], B=B2)
+@test B == B2 == Array(reactioncomplexes(rns[6],true)[2])
+@test Z == complexstoichmat(rns[6]) == Array(complexstoichmat(rns[6],true))
+@test Δ == complexoutgoingmat(rns[6]) == Array(complexoutgoingmat(rns[6],true))
                      
 
 reaction_networks_standard = Vector{ReactionSystem}(undef,10)
@@ -420,8 +420,10 @@ end d v1 K1 n1 v2 K2 n2
 myrn = [reaction_networks_standard;reaction_networks_hill;reaction_networks_real]
 for i in 1:length(myrn)
     local rcs,B = reactioncomplexes(myrn[i])
+    @test B == Array(reactioncomplexes(myrn[i],true)[2])
     local Z = complexstoichmat(myrn[i])
-    @test Z*B == (netstoichmat(myrn[i])')
+    @test Z == Array(complexstoichmat(myrn[i],true))
+    @test Z*B == (netstoichmat(myrn[i])') == Array(netstoichmat(myrn[i],true)')
 end
 
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -73,10 +73,12 @@ rnmat = @reaction_network begin
        β, 3I --> 2R + S
    end α β
 
-smat = [1 2 0;
-        0 3 0]
-pmat = [0 2 0;
-        1 0 2]
+smat = [1 0;
+        2 3;
+        0 0]
+pmat = [0 1;
+        2 0;
+        0 2]
 @test smat == substoichmat(rnmat) == Matrix(substoichmat(rnmat, sparse=true))
 @test pmat == prodstoichmat(rnmat) == Matrix(prodstoichmat(rnmat, sparse=true))
               

--- a/test/api.jl
+++ b/test/api.jl
@@ -77,8 +77,8 @@ smat = [1 2 0;
         0 3 0]
 pmat = [0 2 0;
         1 0 2]
-@test all(smat .== substoichmat(rnmat) .== Array(substoichmat(rnmat,true)))
-@test all(pmat .== prodstoichmat(rnmat) .== Array(prodstoichmat(rnmat,true)))
+@test smat == substoichmat(rnmat) == Matrix(substoichmat(rnmat, sparse=true))
+@test pmat == prodstoichmat(rnmat) == Matrix(prodstoichmat(rnmat, sparse=true))
               
 ############## testing newly added intermediate complexes reaction networks##############
 rns  = Vector{ReactionSystem}(undef,6)
@@ -103,9 +103,9 @@ B = [-1 0 0 0;
       0 0 0 1]
 Δ = [-1 0 0 0; 0 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 0; 0 0 0 -1; 0 0 0 0]
 rcs,B2 = reactioncomplexes(rns[1])
-@test B == B2 == Array(reactioncomplexes(rns[1],true)[2])
-@test Z == complexstoichmat(rns[1]) == Array(complexstoichmat(rns[1],true))
-@test Δ == complexoutgoingmat(rns[1]) == Array(complexoutgoingmat(rns[1],true))
+@test B == B2 == Matrix(reactioncomplexes(rns[1], sparse=true)[2])
+@test Z == complexstoichmat(rns[1]) == Matrix(complexstoichmat(rns[1], sparse=true))
+@test Δ == complexoutgoingmat(rns[1]) == Matrix(complexoutgoingmat(rns[1], sparse=true))
 
 # mass-action rober
 rns[2] = @reaction_network begin
@@ -123,9 +123,9 @@ B = [-1 0 0;
       0 0 1]
 Δ = [-1 0 0; 0 0 0; 0 -1 0; 0 0 -1; 0 0 0]
 rcs,B2 = reactioncomplexes(rns[2])
-@test B == B2 == Array(reactioncomplexes(rns[2],true)[2])
-@test Z == complexstoichmat(rns[2]) == Array(complexstoichmat(rns[2],true))
-@test Δ == complexoutgoingmat(rns[2]) == Array(complexoutgoingmat(rns[2],true))
+@test B == B2 == Matrix(reactioncomplexes(rns[2], sparse=true)[2])
+@test Z == complexstoichmat(rns[2]) == Matrix(complexstoichmat(rns[2], sparse=true))
+@test Δ == complexoutgoingmat(rns[2]) == Matrix(complexoutgoingmat(rns[2], sparse=true))
 
 
 #  some rational functions as rates
@@ -145,9 +145,9 @@ B = [-1 0 0 1;
       0 0 0 -1]
 Δ = [-1 0 0 0; 0 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 -1]
 rcs,B2 = reactioncomplexes(rns[3])
-@test B == B2 == Array(reactioncomplexes(rns[3],true)[2])
-@test Z == complexstoichmat(rns[3]) == Array(complexstoichmat(rns[3],true))
-@test Δ == complexoutgoingmat(rns[3]) ==  Array(complexoutgoingmat(rns[3],true))
+@test B == B2 == Matrix(reactioncomplexes(rns[3], sparse=true)[2])
+@test Z == complexstoichmat(rns[3]) == Matrix(complexstoichmat(rns[3], sparse=true))
+@test Δ == complexoutgoingmat(rns[3]) ==  Matrix(complexoutgoingmat(rns[3], sparse=true))
 
 # repressilator
 rns[4]  = @reaction_network begin
@@ -184,9 +184,9 @@ B = [-1 -1 -1 1 -1 1 -1 1 -1 0 0 0 1 1 1;
        0 0 0 0 0 0 0 -1 0 0 0 -1 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0;
        0 0 0 0 0 0 0 0 0 0 0 0 -1 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 -1 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1]
 rcs,B2 = reactioncomplexes(rns[4])
-@test B == B2 == Array(reactioncomplexes(rns[4],true)[2])
-@test Z == complexstoichmat(rns[4]) == Array(complexstoichmat(rns[4],true))
-@test Δ == complexoutgoingmat(rns[4]) == Array(complexoutgoingmat(rns[4],true))
+@test B == B2 == Matrix(reactioncomplexes(rns[4], sparse=true)[2])
+@test Z == complexstoichmat(rns[4]) == Matrix(complexstoichmat(rns[4], sparse=true))
+@test Δ == complexoutgoingmat(rns[4]) == Matrix(complexoutgoingmat(rns[4], sparse=true))
 
 #brusselator
 rns[5] = @reaction_network begin
@@ -204,9 +204,9 @@ B = [-1 0 0 1;
       0 0 1 0]
 Δ = [-1 0 0 0; 0 0 -1 -1; 0 -1 0 0; 0 0 0 0; 0 0 0 0]
 rcs,B2 = reactioncomplexes(rns[5])
-@test B == B2 == Array(reactioncomplexes(rns[5],true)[2])
-@test Z == complexstoichmat(rns[5]) == Array(complexstoichmat(rns[5],true))
-@test Δ == complexoutgoingmat(rns[5]) == Array(complexoutgoingmat(rns[5],true))
+@test B == B2 == Matrix(reactioncomplexes(rns[5], sparse=true)[2])
+@test Z == complexstoichmat(rns[5]) == Matrix(complexstoichmat(rns[5], sparse=true))
+@test Δ == complexoutgoingmat(rns[5]) == Matrix(complexoutgoingmat(rns[5], sparse=true))
 
 # some rational functions as rates
 rns[6] = @reaction_network begin
@@ -232,15 +232,15 @@ B = [-1 1 0 0 0 0;
       0 0 0 0 1 -1]
 Δ = [-1 0 0 0 0 0; 0 -1 0 0 0 0; 0 0 -1 0 0 0; 0 0 0 -1 0 0; 0 0 0 0 -1 0; 0 0 0 0 0 -1]
 rcs,B2 = reactioncomplexes(rns[6])
-@test B == B2 == Array(reactioncomplexes(rns[6],true)[2])
-@test Z == complexstoichmat(rns[6]) == Array(complexstoichmat(rns[6],true))
-@test Δ == complexoutgoingmat(rns[6]) == Array(complexoutgoingmat(rns[6],true))
+@test B == B2 == Matrix(reactioncomplexes(rns[6], sparse=true)[2])
+@test Z == complexstoichmat(rns[6]) == Matrix(complexstoichmat(rns[6], sparse=true))
+@test Δ == complexoutgoingmat(rns[6]) == Matrix(complexoutgoingmat(rns[6], sparse=true))
                      
 
 reaction_networks_standard = Vector{ReactionSystem}(undef,10)
 reaction_networks_hill = Vector{ReactionSystem}(undef,10)
 reaction_networks_real = Vector{ReactionSystem}(undef,3)
-### some more networks to test whether Z*B == netstoichmat(rn)' or not. ###
+### some more networks to test whether Z*B == netstoichmat(rn) or not. ###
 reaction_networks_standard[1] = @reaction_network begin
     (p1,p2,p3), ∅ → (X1,X2,X3)
     (k1,k2), X2 ⟷ X1 + 2X3
@@ -420,10 +420,10 @@ end d v1 K1 n1 v2 K2 n2
 myrn = [reaction_networks_standard;reaction_networks_hill;reaction_networks_real]
 for i in 1:length(myrn)
     local rcs,B = reactioncomplexes(myrn[i])
-    @test B == Array(reactioncomplexes(myrn[i],true)[2])
+    @test B == Matrix(reactioncomplexes(myrn[i], sparse=true)[2])
     local Z = complexstoichmat(myrn[i])
-    @test Z == Array(complexstoichmat(myrn[i],true))
-    @test Z*B == (netstoichmat(myrn[i])') == Array(netstoichmat(myrn[i],true)')
+    @test Z == Matrix(complexstoichmat(myrn[i], sparse=true))
+    @test Z*B == netstoichmat(myrn[i]) == Matrix(netstoichmat(myrn[i], sparse=true))
 end
 
 


### PR DESCRIPTION
from https://github.com/SciML/Catalyst.jl/issues/386#issuecomment-904876595

example. We use a second  function argument of type `Bool` to switch `sparsity` on or off. Default is dense representation as earlier, i.e.`sparsity=false`
```julia
rn = @reaction_network begin
    k₁, 2A --> B
    k₂, A --> C
    k₃, C --> D
    k₄, B + D --> E
end k₁ k₂ k₃ k₄

julia> substoichmat(rn)   # usual function or substoichmat(rn,false)
4×5 Matrix{Int64}:
 2  0  0  0  0
 1  0  0  0  0
 0  0  1  0  0
 0  1  0  1  0

julia> substoichmat(rn,true)     # sparse representation
4×5 SparseMatrixCSC{Int64, Int64} with 5 stored entries:
 2  ⋅  ⋅  ⋅  ⋅
 1  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  1  ⋅  ⋅
 ⋅  1  ⋅  1  ⋅
```