### PR TITLE
Change ReactionNetworkImportes link

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,7 @@ etc).
 - Catalyst [`ReactionSystem`](@ref)s can be imported from SBML files via 
   [SBMLToolkit.jl](https://github.com/SciML/SBMLToolkit.jl), and from BioNetGen .net 
   files and various matrix network representations using 
-  [ReactionNetworkImporters.jl](https://github.com/isaacsas/ReactionNetworkImporters.jl).
+  [ReactionNetworkImporters.jl](https://github.com/SciML/ReactionNetworkImporters.jl).
 
 ## Installation
 Catalyst can be installed through the Julia package manager:


### PR DESCRIPTION
The doc had a reaction network importer link. Previously it was to https://github.com/isaacsas/ReactionNetworkImporters.jl but I presume the target should be https://github.com/isaacsas/ReactionNetworkImporters.jl ?