### PR TITLE
Chemical Master Equation lowering

### DIFF
--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -6,6 +6,7 @@ module Catalyst
 using DocStringExtensions
 using SparseArrays, DiffEqBase, Reexport, DiffEqJump
 using Latexify, Requires
+using DataStructures
 
 # ModelingToolkit imports and convenience functions we use
 using ModelingToolkit; const MT = ModelingToolkit
@@ -44,6 +45,9 @@ function __init__()
 include("reactionsystem.jl")
 export Reaction, ReactionSystem, ismassaction, oderatelaw, jumpratelaw
 export ODEProblem, SDEProblem, JumpProblem, NonlinearProblem, DiscreteProblem, SteadyStateProblem
+
+include("cme.jl")
+export ODESystem_cme
 
 # reaction_network macro
 const ExprValues = Union{Expr,Symbol,Float64,Int}

--- a/src/cme.jl
+++ b/src/cme.jl
@@ -57,10 +57,9 @@ function ODESystem_cme(rs, u0; truncation=nothing, kwargs...)
 	rxns = reactions(rs)
 	M = numreactions(rs)
 	jump_rates = jumpratelaw.(rxns)
-    nsm = netstoichmat(rs)
-    species = states(rs)
+	nsm = netstoichmat(rs)
+	species = states(rs)
 	
-	# eqs = Equation[]
 	eqs = Vector{Equation}(undef, N)
 	for (i, x) in enumerate(state_space)
 		eq = Num(0)
@@ -71,7 +70,6 @@ function ODESystem_cme(rs, u0; truncation=nothing, kwargs...)
 			t2 = substitute(jump_rates[j], Dict(species .=> x)) * u[d[x]]
 			eq += t1 - t2
 		end 
-		# push!(eqs, D(u[d[x]]) ~ eq)
 		eqs[i] = D(u[d[x]]) ~ eq
 	end
 	ODESystem(eqs, t, u, parameters(rs); name=nameof(rs), kwargs...)

--- a/src/cme.jl
+++ b/src/cme.jl
@@ -1,0 +1,78 @@
+
+"""
+Performs a breadth-first graph traversal of a  to enumerate all possible states.
+
+The truncation kwarg should be given as a vector of Int, denoting the maximum species' counts.
+If, upon taking traversing a reaction the amount of any species is greater than the value in the truncation vector, 
+the graph traversal will not add the state to the list of possible states.
+"""
+function traverse_reactionsystem(rs, u0; truncation=nothing)
+    num_molecules = sum(u0)
+    num_species = length(u0)
+    state_space = []
+    Q = Queue{typeof(u0)}()
+    enqueue!(Q, u0)
+    push!(state_space, u0)
+    nsm = netstoichmat(rs)
+    edges = eachcol(nsm)
+    while !isempty(Q)
+        w = dequeue!(Q)
+        for e in edges
+            x = w .+ e
+            if x ∉ state_space && all(y >= 0 for y in x)
+                if truncation === nothing 
+                    if sum(x) > num_molecules 
+                        error("need to provide truncation for infinite reaction system")
+                    else 
+                        push!(state_space, x)
+                        enqueue!(Q, x)
+                    end
+                else 
+                    if all(x[i] <= truncation[i] for i in 1:num_species)
+                        push!(state_space, x)
+                        enqueue!(Q, x)
+                    end
+                end
+            end
+        end
+    end
+    return state_space
+end
+
+function ODESystem_cme(rs, u0; truncation=nothing, kwargs...)
+	state_space = traverse_reactionsystem(rs, u0; truncation=truncation)
+
+	N = length(state_space)
+	d = Dict(state_space .=> 1:N)
+
+    # initializes the state corresponding to u0 to have probability 1
+	defs = zeros(N)
+	start_state = d[u0]
+	defs[start_state] = 1.
+
+
+	@variables t u[1:N](t) = defs
+	D = Differential(t)
+
+	rxns = reactions(rs)
+	M = numreactions(rs)
+	jump_rates = jumpratelaw.(rxns)
+    nsm = netstoichmat(rs)
+    species = states(rs)
+	
+	# eqs = Equation[]
+	eqs = Vector{Equation}(undef, N)
+	for (i, x) in enumerate(state_space)
+		eq = Num(0)
+		for j in 1:M
+			x′ = x .- @view(nsm[:, j]) # traverse a reaction and get the new counts
+			p_x′ = haskey(d, x′) ? u[d[x′]] : 0 # if the new state is not in `state_space`, set probability to 0
+			t1 = substitute(jump_rates[j], Dict(species .=> x′)) * p_x′
+			t2 = substitute(jump_rates[j], Dict(species .=> x)) * u[d[x]]
+			eq += t1 - t2
+		end 
+		# push!(eqs, D(u[d[x]]) ~ eq)
+		eqs[i] = D(u[d[x]]) ~ eq
+	end
+	ODESystem(eqs, t, u, parameters(rs); name=nameof(rs), kwargs...)
+end

--- a/test/cme.jl
+++ b/test/cme.jl
@@ -9,8 +9,6 @@ u0 = [10, 15, 3, 1]
 specmap = Num.(states(rs)) .=> u0
 state_space = Catalyst.traverse_reactionsystem(rs, u0)
 cmesys = Catalyst.ODESystem_cme(rs, u0)
-@benchmark Catalyst.ODESystem_cme(rs, u0)
-@benchmark Catalyst.ODESystem_cme2(rs, u0)
 prob = ODEProblem(cmesys, [], (0, 10.), [1., 2.])
 
 sol = solve(prob, Tsit5())

--- a/test/cme.jl
+++ b/test/cme.jl
@@ -1,0 +1,27 @@
+using Catalyst, LinearAlgebra, DiffEqJump, OrdinaryDiffEq, Test
+
+rs = @reaction_network begin
+  (c1,c2), A + B <--> C + D
+end c1 c2 
+
+u0 = [5, 5, 0, 0]
+u0 = [10, 15, 3, 1]
+specmap = Num.(states(rs)) .=> u0
+state_space = Catalyst.traverse_reactionsystem(rs, u0)
+cmesys = Catalyst.ODESystem_cme(rs, u0)
+@benchmark Catalyst.ODESystem_cme(rs, u0)
+@benchmark Catalyst.ODESystem_cme2(rs, u0)
+prob = ODEProblem(cmesys, [], (0, 10.), [1., 2.])
+
+sol = solve(prob, Tsit5())
+arr = Array(sol)
+@test all(sum(arr; dims=1) .≈ 1.) # sanity check that states sum to probability 1
+
+# birth death (infinte)
+rs = @reaction_network begin
+  (c1, c2), X <--> 2X
+end c1 c2
+u0 = [2]
+
+@test_throws ErrorException traverse_reactionsystem(rs, u0)
+@test length(traverse_reactionsystem(rs, u0; truncation=[10])) == 11

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ end
 
 # Tests related to solving Ordinary Differential Equations.
 @time @safetestset "ODE System Solving" begin include("solve_ODEs.jl") end
+@time @safetestset "Chemical Master Equation Lowering" begin include("cme.jl") end
 @time @safetestset "Make Jacobian" begin include("make_jacobian.jl") end
 #@time @safetestset "DiffEq Steady State Solving" begin include("steady_state_problems.jl") end
 


### PR DESCRIPTION
ported from my MTK PR

I'd like to know the best way to integrate this into the lowering code that exists.
Should I add a kwarg in the `convert(<:ODESystem, rn)` code that defaults to the current ode rate law? 
