### PR TITLE
Fix reaction equality in sets and add upconversion to ODESystems in convert

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,9 @@
   all parameters of a system and all subsystems, or use `reactionparams` to get
   all parameters of a system and all `ReactionSystem` subsystems. The latter
   correspond to those parameters used within `Reaction`s.)
+- Added a custom `hash` for `Reaction`s to ensure they work in `Dict`s and
+  `Set`s properly, and set-type comparisons between collections of `Reaction`s
+  work.
 
 ## Catalyst 9.0
 *1.* **BREAKING:** `netstoichmat`, `prodstoichmat` and `substoichmat` are now

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -147,7 +147,7 @@ isweaklyreversible
 ## Network Comparison 
 ```@docs
 ==(rn1::Reaction, rn2::Reaction)
-isequal_without_names
+isequal_ignore_names
 ==(rn1::ReactionSystem, rn2::ReactionSystem)
 ```
 

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -56,10 +56,13 @@ include("registered_functions.jl")
 
 # functions to query network properties
 include("networkapi.jl")
-export species, reactionparams, reactions, speciesmap, paramsmap, numspecies, numreactions, numparams
+export species, reactionparams, reactions, speciesmap, paramsmap, numspecies, numreactions, numreactionparams
 export make_empty_network, addspecies!, addparam!, addreaction!
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities
+
+# depreciated functions to remove in future releases
+export params, numparams
 
 # network analysis functions
 export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -800,8 +800,18 @@ function (==)(rx1::Reaction, rx2::Reaction)
     rx1.only_use_rate == rx2.only_use_rate
 end
 
+function hash(rx::Reaction, h::UInt) 
+    h = Base.hash(rx.rate, h)
+    h = Base.hash(rx.substrates, h)
+    h = Base.hash(rx.products, h)
+    h = Base.hash(rx.prodstoich, h)
+    h = Base.hash(rx.substoich, h)
+    h = Base.hash(rx.netstoich, h)
+    Base.hash(rx.only_use_rate, h)
+end
+
 """
-    isequal_without_names(rn1::ReactionSystem, rn2::ReactionSystem)
+    isequal_ignore_names(rn1::ReactionSystem, rn2::ReactionSystem)
 
 Tests whether the underlying species, parameters and reactions are the same in
 the two [`ReactionSystem`](@ref)s. Ignores the names of the systems in testing
@@ -812,16 +822,12 @@ Notes:
     considered different than `(A+1)^2`.
 - Does not include `defaults` in determining equality.
 """
-function isequal_without_names(rn1::ReactionSystem, rn2::ReactionSystem)
+function isequal_ignore_names(rn1::ReactionSystem, rn2::ReactionSystem)
     isequal(get_iv(rn1), get_iv(rn2)) || return false
     issetequal(get_states(rn1), get_states(rn2)) || return false
     issetequal(get_ps(rn1), get_ps(rn2)) || return false
     issetequal(MT.get_observed(rn1), MT.get_observed(rn2))
-  
-    # reactions
-    # issetequal fails for some reason, so need to use issubset
-    (length(get_eqs(rn1)) == length(get_eqs(rn2))) || return false
-    issubset(get_eqs(rn1),get_eqs(rn2)) && issubset(get_eqs(rn2),get_eqs(rn1)) || return false
+    issetequal(get_eqs(rn1), get_eqs(rn2))
 
     # subsystems
     (length(get_systems(rn1)) == length(get_systems(rn2))) || return false
@@ -844,7 +850,7 @@ Notes:
 """
 function (==)(rn1::ReactionSystem, rn2::ReactionSystem)
     (nameof(rn1) == nameof(rn2)) || return false
-    isequal_without_names(rn1,rn2)
+    isequal_ignore_names(rn1,rn2)
 end
 
 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -460,6 +460,23 @@ function make_systems_with_type!(systems::Vector{T}, rs::ReactionSystem, include
     end    
     systems
 end
+
+# specialize conversion to ODESystems as MT provides convert_system here
+function make_systems_with_type!(systems::Vector{T}, rs::ReactionSystem, include_zero_odes=true) where {T <: ODESystem}
+    resize!(systems, length(get_systems(rs)))
+    for (i,sys) in enumerate(get_systems(rs))
+        if sys isa ReactionSystem
+            systems[i] = convert(T, sys, include_zero_odes=include_zero_odes)
+        elseif sys isa T
+            systems[i] = sys
+        else
+            systems[i] = MT.convert_system(T, sys, get_iv(rs))
+        end
+    end    
+    systems
+end
+
+
 """
 ```julia
 Base.convert(::Type{<:ODESystem},rs::ReactionSystem)

--- a/test/api.jl
+++ b/test/api.jl
@@ -63,9 +63,9 @@ addspecies!(rs, S)
 addspecies!(rs, S, disablechecks=true)
 @test numspecies(rs) == 4
 addparam!(rs, k1)
-@test numparams(rs) == 2
+@test numreactionparams(rs) == 2
 addparam!(rs, k1, disablechecks=true)
-@test numparams(rs) == 3
+@test numreactionparams(rs) == 3
 
 
 rnmat = @reaction_network begin


### PR DESCRIPTION
1. Adds `hash` on reactions so they work properly in dictionaries and sets, fixing `issetequal` for collections of them.
2. Uses `convert_system` for upconverting non-ReactionSystem subsystems when possible, throwing an error when an appropriate `convert_system` does not exist.
3. Added back exports of depreciated functions (we can keep them exported with warnings for one major release cycle).