### PR TITLE
Constraints, flattening, and extending for ReactionSystems

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,12 @@
 - Added a custom `hash` for `Reaction`s to ensure they work in `Dict`s and
   `Set`s properly, and set-type comparisons between collections of `Reaction`s
   work.
+- Added `extend(sys, reactionnetwork, name=nameof(sys))` to extend
+  `ReactionSystem`s with constraint equations (algebraic equations or ODEs).
+  Constraints are stored as a `NonlinearSystem` or `ODESystem` within the
+  `ReactionSystem`, and accessible via `get_constraints(reactionnetwork)`.
+- Added `Catalyst.flatten(rn)` to allow flattening of a `ReactionSystem` with
+  sub-systems into one `ReactionSystem`.
 
 ## Catalyst 9.0
 *1.* **BREAKING:** `netstoichmat`, `prodstoichmat` and `substoichmat` are now

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -89,7 +89,7 @@ numreactions
 numreactionparams
 ```
 
-## ModelingToolkit-Inherited Accessor Functions
+## ModelingToolkit and Catalyst Accessor Functions
 See [The generated `ReactionSystem` and `Reaction`s](@ref) for more details
 
 - `ModelingToolkit.get_eqs(sys)`: The reactions of the system (ignores subsystems).
@@ -102,6 +102,8 @@ See [The generated `ReactionSystem` and `Reaction`s](@ref) for more details
 - `ModelingToolkit.get_iv(sys)`: The independent variable of the system, usually time.
 - `ModelingToolkit.get_systems(sys)`: The sub-systems of `sys`.
 - `ModelingToolkit.get_defaults(sys)`: The default values for parameters and initial conditions for `sys`.
+- `Catalyst.get_constraints(sys)`: Return the current constraint subsystem, if
+  none is defined will return `nothing`.
 
 ## Basic Reaction Properties
 ```@docs
@@ -122,6 +124,7 @@ addparam!
 addreaction!
 ModelingToolkit.extend
 ModelingToolkit.compose
+Catalyst.flatten
 merge!(network1::ReactionSystem, network2::ReactionSystem)
 ```
 

--- a/docs/src/tutorials/generated_systems.md
+++ b/docs/src/tutorials/generated_systems.md
@@ -50,12 +50,12 @@ algebraic constraints with a `NonlinearSystem`, it can also be convenient to
 collect all state variables (e.g. species and algebraic variables) and such. The
 following ModelingToolkit functions provide this information
 
-* [`states(rn)`](@ref) returns all species *and variables* across the system and
-  *all sub-systems*.
-* [`parameters(rn)`](@ref) returns all parameters across the system and *all
-  sub-systems*.
-* [`equations(rn)`](@ref) returns all [`Reaction`](@ref)s and all
-  [`Equations`](@ref) defined across the system and *all sub-systems*.
+* `ModelingToolkit.states(rn)` returns all species *and variables*
+  across the system and *all sub-systems*.
+* `ModelingToolkit.parameters(rn)` returns all parameters across the
+  system and *all sub-systems*.
+* `ModelingToolkit.equations(rn)` returns all [`Reaction`](@ref)s and
+  all `Equations` defined across the system and *all sub-systems*.
 
 `states` and `parameters` should be assumed to always allocate, while
 `equations` will allocate unless there are no subsystems. In the latter case

--- a/docs/src/tutorials/models.md
+++ b/docs/src/tutorials/models.md
@@ -25,12 +25,11 @@ sol = solve(prob, Tsit5())
 ```
 Here, the order of unknowns in `u0` and `p` matches the order that species and
 parameters first appear within the DSL. They can also be determined by examining
-the ordering within the [`species(rn)`](@ref) and [`parameters(rn)`](@ref) vectors,
-or accessed more explicitly through the [`speciesmap(rn)`](@ref) and
-[`paramsmap(rn)`](@ref) dictionaries, which map the ModelingToolkit `Term`s
-and/or `Sym`s corresponding to each species or parameter to their integer id.
-Note, if no parameters are given in the [`@reaction_network`](@ref), then `p`
-does not need to be provided.
+the ordering within the `species(rn)` and `parameters` vectors, or accessed more
+explicitly through the [`speciesmap(rn)`](@ref) and [`paramsmap(rn)`](@ref)
+dictionaries, which map the ModelingToolkit `Term`s and/or `Sym`s corresponding
+to each species or parameter to their integer id. Note, if no parameters are
+given in the [`@reaction_network`](@ref), then `p` does not need to be provided.
 
 We can then plot the solution using the solution plotting recipe:
 ```julia

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -44,6 +44,7 @@ function __init__()
 include("reactionsystem.jl")
 export Reaction, ReactionSystem, ismassaction, oderatelaw, jumpratelaw
 export ODEProblem, SDEProblem, JumpProblem, NonlinearProblem, DiscreteProblem, SteadyStateProblem
+export get_constraints
 
 # reaction_network macro
 const ExprValues = Union{Expr,Symbol,Float64,Int}

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -72,7 +72,6 @@ export incidencematgraph, linkageclasses, deficiency, subnetworks, linkagedefici
 include("latexify_recipes.jl")
 
 # for making and saving graphs
-import Base.Iterators: flatten
 import DataStructures: OrderedDict
 import Parameters: @with_kw_noshow
 include("graphs.jl")

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -329,7 +329,7 @@ function complexgraph(rn::ReactionSystem; complexdata=reactioncomplexes(rn))
     end
     stmts2 = Vector{Statement}()
     append!(stmts2, compnodes)
-    append!(stmts2, collect(flatten(edges)))
+    append!(stmts2, collect(Iterators.flatten(edges)))
     g = Digraph("G", stmts2; graph_attrs=graph_attrs, node_attrs=node_attrs,edge_attrs=edge_attrs)
     return g
 end
@@ -368,7 +368,7 @@ function Graph(rn::ReactionSystem)
 
     stmts2 = Vector{Statement}()
     append!(stmts2, stmts)
-    append!(stmts2, collect(flatten(edges)))
+    append!(stmts2, collect(Iterators.flatten(edges)))
     g = Digraph("G", stmts2; graph_attrs=graph_attrs, node_attrs=node_attrs, edge_attrs=edge_attrs)
     return g
 end

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -197,8 +197,8 @@ end
 
 See documentation for [`dependents`](@ref).
 """
-function dependants(network, rxidx)
-    dependents(network, rxidx)
+function dependants(rx, network)
+    dependents(rx, network)
 end
 
 """
@@ -826,8 +826,9 @@ function isequal_ignore_names(rn1::ReactionSystem, rn2::ReactionSystem)
     isequal(get_iv(rn1), get_iv(rn2)) || return false
     issetequal(get_states(rn1), get_states(rn2)) || return false
     issetequal(get_ps(rn1), get_ps(rn2)) || return false
-    issetequal(MT.get_observed(rn1), MT.get_observed(rn2))
-    issetequal(get_eqs(rn1), get_eqs(rn2))
+    issetequal(MT.get_observed(rn1), MT.get_observed(rn2)) || return false
+    issetequal(get_eqs(rn1), get_eqs(rn2)) || return false
+    (get_constraints(rn1) == get_constraints(rn2)) || return false
 
     # subsystems
     (length(get_systems(rn1)) == length(get_systems(rn2))) || return false
@@ -979,6 +980,8 @@ Notes:
 - Returns `network1`.
 """
 function Base.merge!(network1::ReactionSystem, network2::ReactionSystem)
+    ((get_constraints(network1) === nothing) && (get_constraints(network2) === nothing)) ||
+        error("merge! does not currently support ReactionSystems with constraints, consider ModelingToolkit.extend instead.")
     isequal(get_iv(network1), get_iv(network2)) || 
         error("Reaction networks must have the same independent variable to be mergable.")
     append!(get_eqs(network1), get_eqs(network2))

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -734,7 +734,7 @@ end
 
 Given the subnetworks corresponding to the each linkage class of reaction network,
 determines if the reaction network is weakly reversible or not.
-For example, continuing the example from [`is_reversible`](@ref)
+For example, continuing the example from [`isreversible`](@ref)
 ```julia
 isweaklyreversible(subnets)
 ```

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -107,14 +107,33 @@ emptyrn = @reaction_network
 ```
 """
 macro reaction_network(name::Symbol, ex::Expr, parameters...)
-    make_reaction_system(MacroTools.striplines(ex), parameters; name=name)
+    make_reaction_system(MacroTools.striplines(ex), parameters; name=:($(QuoteNode(name))))
 end
 
-macro reaction_network(ex::Expr, parameters...)
-    make_reaction_system(MacroTools.striplines(ex), parameters)
+# allows @reaction_network $name begin ... to interpolate variables storing a name
+macro reaction_network(name::Expr, ex::Expr, parameters...)
+    make_reaction_system(MacroTools.striplines(ex), parameters; name=:($(esc(name.args[1]))))
+end
+
+macro reaction_network(ex::Expr, parameters...) 
+    ex = MacroTools.striplines(ex)
+
+    # no name but equations: @reaction_network begin ... end ...
+    if ex.head == :block
+        make_reaction_system(ex, parameters)
+    else  # empty but has interpolated name: @reaction_network $name        
+        networkname = :($(esc(ex.args[1])))
+        return Expr(:block,:(@parameters t),
+                    :(ReactionSystem(Reaction[],
+                                    t,
+                                    [],
+                                    [];                                 
+                                    name=$networkname)))
+    end
 end
 
 #Returns a empty network (with, or without, a declared name)
+# @reaction_network name 
 macro reaction_network(name::Symbol=gensym(:ReactionSystem))
     return Expr(:block,:(@parameters t),
                 :(ReactionSystem(Reaction[],
@@ -167,11 +186,11 @@ end
 ### Functions that process the input and rephrase it as a reaction system ###
 
 # Takes the reactions, and rephrases it as a "ReactionSystem" call, as designated by the ModelingToolkit IR.
-function make_reaction_system(ex::Expr, parameters; name=gensym(:ReactionSystem))
+function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSystem)))
     reactions = get_reactions(ex)
     reactants = get_reactants(reactions)
     !isempty(intersect(forbidden_symbols,union(reactants,parameters))) && error("The following symbol(s) are used as reactants or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,union(reactants,parameters)))...))*"this is not permited.")    
-    network_code = Expr(:block,:(@parameters t),:(@variables), :(ReactionSystem([],t,[],[]; name=$(QuoteNode(name)))))
+    network_code = Expr(:block,:(@parameters t),:(@variables), :(ReactionSystem([],t,[],[]; name=$(name))))
     foreach(parameter-> push!(network_code.args[1].args, parameter), parameters)
     foreach(reactant -> push!(network_code.args[2].args, Expr(:call,reactant,:t)), reactants)
     foreach(parameter-> push!(network_code.args[3].args[6].args, parameter), parameters)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -811,5 +811,5 @@ function ModelingToolkit.extend(sys::ReactionSystem, rs::ReactionSystem; name::S
     end
     
     ReactionSystem(eqs, get_iv(rs), sts, ps; observed = obs, name = name, 
-                    systems = syss, defaults = defs, checks=false, constraints=csys)
+                    systems = syss, defaults = defs, checks=false, constraints=newcsys)
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -716,7 +716,7 @@ function flatten(rs::ReactionSystem)
     systems = get_systems(rs)
     isempty(systems) && return rs
     
-    all(T -> T in (ReactionSystem,NonlinearSystem), getsubsystypes(rs)) || 
+    all(T -> any(T .<: (ReactionSystem,NonlinearSystem)), getsubsystypes(rs)) || 
         error("flattening is currently only supported for subsystems mixing ReactionSystems and NonlinearSystems.")
     
     specs      = species(rs)
@@ -735,5 +735,5 @@ function flatten(rs::ReactionSystem)
                    name = nameof(rs),
                    defaults = MT.defaults(rs),
                    checks = false,
-                   constraints = NonlinearSystem(ceqs,csts,cps))
+                   constraints = NonlinearSystem(ceqs,csts,cps,name=nameof(rs)))
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -521,10 +521,13 @@ end
 
 function error_if_constraint_odes(::Type{T}, rs::ReactionSystem) where {T <: MT.AbstractSystem}
     csys = get_constraints(rs)    
-    structsys = MT.SystemStructures.initialize_system_structure(csys)
-    structure = MT.get_structure(structsys)
-    any(i -> MT.SystemStructures.isdiffeq(structure,i), eachindex(get_eqs(structsys))) &&
-        error("Cannot convert to system type $T when then there are ODE constraint equations.")
+    if csys !== nothing
+        structsys = MT.SystemStructures.initialize_system_structure(csys)
+        structure = MT.get_structure(structsys)
+        any(i -> MT.SystemStructures.isdiffeq(structure,i), eachindex(get_eqs(structsys))) &&
+            error("Cannot convert to system type $T when then there are ODE constraint equations.")
+    end
+    nothing
 end
 
 """

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -740,11 +740,10 @@ end
 
 function MT.extend(sys::NonlinearSystem, rs::ReactionSystem; name::Symbol=nameof(sys))
     csys = (get_constraints(rs) === nothing) ? sys : extend(sys, get_constraints(rs))       
-    ReactionSystem(get_eqs(rs), get_states(rs), get_ps(rs); 
+    ReactionSystem(get_eqs(rs), get_iv(rs), get_states(rs), get_ps(rs); 
                     observed = get_observed(rs), name = name, 
                     systems = get_systems(rs), defaults = get_defaults(rs), 
-                    connection_type=get_connection_type(sys), checks=false, 
-                    constraints=csys)
+                    checks=false, constraints=csys)
 end
 
 function MT.extend(sys::ReactionSystem, rs::ReactionSystem; name::Symbol=nameof(sys))

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -1,0 +1,50 @@
+using Catalyst, ModelingToolkit
+
+# naming tests
+@parameters k
+@variables t, A(t)
+rx = Reaction(k, [A], nothing)
+function rntest(rn, name)
+    @test nameof(rn) == name
+    @test isequal(species(rn)[1], ModelingToolkit.unwrap(A))
+    @test isequal(parameters(rn)[1], ModelingToolkit.unwrap(k))
+    @test reactions(rn)[1] == rx
+end
+
+function emptyrntest(rn, name)
+    @test nameof(rn) == name
+    @test numreactions(rn) == 0
+    @test numspecies(rn) == 0
+    @test numreactionparams(rn) == 0    
+end
+
+rn = @reaction_network name begin
+    k, A --> 0
+end k
+rntest(rn, :name)
+
+name = :blah
+rn = @reaction_network $name begin
+    k, A --> 0
+end k
+rntest(rn, :blah)
+
+rn = @reaction_network begin
+    k, A --> 0
+end k
+rntest(rn, nameof(rn))
+
+function makern(; name)
+    @reaction_network $name begin
+        k, A --> 0
+    end k
+end
+@named testnet = makern()
+rntest(testnet, :testnet)
+
+rn = @reaction_network name
+emptyrntest(rn, :name)
+
+rn = @reaction_network $name
+emptyrntest(rn, :blah)
+

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -38,11 +38,11 @@ end v1 K1 n1 v2 K2 n2 v3 K3 n3 v4 K4 n4 v5 K5 n5 k1 k2 k3 k4 k5 k6 d1 d2 d3 d4 d
 @test latexify(r) == replace(
 raw"\begin{align}
 \require{mhchem}
-\ce{ \varnothing &->[\frac{v1 \left( \mathrm{X4}\left( t \right) \right)^{n1}}{K1^{n1} + \left( \mathrm{X4}\left( t \right) \right)^{n1}} \frac{v1 K1^{n1}}{K1^{n1} + \left( \mathrm{X2}\left( t \right) \right)^{n1}}] X1}\\
-\ce{ \varnothing &->[\frac{v2 \left( \mathrm{X5}\left( t \right) \right)^{n2}}{K2^{n2} + \left( \mathrm{X5}\left( t \right) \right)^{n2}}] X2}\\
-\ce{ \varnothing &->[\frac{v3 \left( \mathrm{X3}\left( t \right) \right)^{n3}}{K3^{n3} + \left( \mathrm{X3}\left( t \right) \right)^{n3}}] X3}\\
-\ce{ \varnothing &->[\frac{v4 K4^{n4}}{K4^{n4} + \left( \mathrm{X1}\left( t \right) \right)^{n4}}] X4}\\
-\ce{ \varnothing &->[\frac{v5 \left( \mathrm{X2}\left( t \right) \right)^{n5}}{K5^{n5} + \left( \mathrm{X2}\left( t \right) \right)^{n5}}] X5}\\
+\ce{ \varnothing &->[\frac{v1 X4^{n1}}{K1^{n1} + X4^{n1}} \frac{v1 K1^{n1}}{K1^{n1} + X2^{n1}}] X1}\\
+\ce{ \varnothing &->[\frac{v2 X5^{n2}}{K2^{n2} + X5^{n2}}] X2}\\
+\ce{ \varnothing &->[\frac{v3 X3^{n3}}{K3^{n3} + X3^{n3}}] X3}\\
+\ce{ \varnothing &->[\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}] X4}\\
+\ce{ \varnothing &->[\frac{v5 X2^{n5}}{K5^{n5} + X2^{n5}}] X5}\\
 \ce{ X2 &<=>[k1][k2] X1 + 2 X4}\\
 \ce{ X4 &<=>[k3][k4] X3}\\
 \ce{ 3 X5 + X1 &<=>[k5][k6] X2}\\
@@ -54,15 +54,14 @@ raw"\begin{align}
 \end{align}
 ", "\r\n"=>"\n")
 
-
 # Latexify.@generate_test latexify(r, mathjax=false)
 @test latexify(r, mathjax = false) == replace(
 raw"\begin{align}
-\ce{ \varnothing &->[$\frac{v1 \left( \mathrm{X4}\left( t \right) \right)^{n1}}{K1^{n1} + \left( \mathrm{X4}\left( t \right) \right)^{n1}} \frac{v1 K1^{n1}}{K1^{n1} + \left( \mathrm{X2}\left( t \right) \right)^{n1}}$] X1}\\
-\ce{ \varnothing &->[$\frac{v2 \left( \mathrm{X5}\left( t \right) \right)^{n2}}{K2^{n2} + \left( \mathrm{X5}\left( t \right) \right)^{n2}}$] X2}\\
-\ce{ \varnothing &->[$\frac{v3 \left( \mathrm{X3}\left( t \right) \right)^{n3}}{K3^{n3} + \left( \mathrm{X3}\left( t \right) \right)^{n3}}$] X3}\\
-\ce{ \varnothing &->[$\frac{v4 K4^{n4}}{K4^{n4} + \left( \mathrm{X1}\left( t \right) \right)^{n4}}$] X4}\\
-\ce{ \varnothing &->[$\frac{v5 \left( \mathrm{X2}\left( t \right) \right)^{n5}}{K5^{n5} + \left( \mathrm{X2}\left( t \right) \right)^{n5}}$] X5}\\
+\ce{ \varnothing &->[$\frac{v1 X4^{n1}}{K1^{n1} + X4^{n1}} \frac{v1 K1^{n1}}{K1^{n1} + X2^{n1}}$] X1}\\
+\ce{ \varnothing &->[$\frac{v2 X5^{n2}}{K2^{n2} + X5^{n2}}$] X2}\\
+\ce{ \varnothing &->[$\frac{v3 X3^{n3}}{K3^{n3} + X3^{n3}}$] X3}\\
+\ce{ \varnothing &->[$\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}$] X4}\\
+\ce{ \varnothing &->[$\frac{v5 X2^{n5}}{K5^{n5} + X2^{n5}}$] X5}\\
 \ce{ X2 &<=>[$k1$][$k2$] X1 + 2 X4}\\
 \ce{ X4 &<=>[$k3$][$k4$] X3}\\
 \ce{ 3 X5 + X1 &<=>[$k5$][$k6$] X2}\\
@@ -86,7 +85,7 @@ end p_a k n d_a p_b d_b r_a r_b
 @test latexify(r) == replace(
 raw"\begin{align}
 \require{mhchem}
-\ce{ \varnothing &<=>[\frac{p_{a} \left( B\left( t \right) \right)^{n}}{k^{n} + \left( B\left( t \right) \right)^{n}}][d_{a}] A}\\
+\ce{ \varnothing &<=>[\frac{p_{a} B^{n}}{k^{n} + B^{n}}][d_{a}] A}\\
 \ce{ \varnothing &<=>[p_{b}][d_{b}] B}\\
 \ce{ 3 B &<=>[r_{a}][r_{b}] A}
 \end{align}
@@ -95,7 +94,7 @@ raw"\begin{align}
 # Latexify.@generate_test latexify(r, mathjax=false)
 @test latexify(r, mathjax = false) == replace(
 raw"\begin{align}
-\ce{ \varnothing &<=>[$\frac{p_{a} \left( B\left( t \right) \right)^{n}}{k^{n} + \left( B\left( t \right) \right)^{n}}$][$d_{a}$] A}\\
+\ce{ \varnothing &<=>[$\frac{p_{a} B^{n}}{k^{n} + B^{n}}$][$d_{a}$] A}\\
 \ce{ \varnothing &<=>[$p_{b}$][$d_{b}$] B}\\
 \ce{ 3 B &<=>[$r_{a}$][$r_{b}$] A}
 \end{align}

--- a/test/reactionsystem_components.jl
+++ b/test/reactionsystem_components.jl
@@ -129,6 +129,19 @@ oprob = ODEProblem(sys2, u₀, tspan, pvals)
 sol = solve(oprob, Tsit5())
 @test all(isapprox.(sol(tvs,idxs=sys₁.P),sol2(tvs, idxs=4),atol=1e-4))
 
+# test extending with NonlinearSystem
+@named repressilator2 = ReactionSystem(t; systems=[sys₁,sys₂,sys₃])
+repressilator2 = Catalyst.flatten(repressilator2)
+repressilator2 = extend(csys, repressilator2)
+@named nlrepressilator = convert(NonlinearSystem, repressilator2, include_zero_odes=false)
+sys2 = structural_simplify(nlrepressilator)
+@test length(equations(sys2)) == 6
+nlprob = NonlinearProblem(sys2, u₀, pvals)
+sol = solve(nlprob, NewtonRaphson(), tol=1e-9)
+@test sol[sys₁.P] ≈ sol[sys₂.P] ≈ sol[sys₃.P]
+@test sol[sys₁.m] ≈ sol[sys₂.m] ≈ sol[sys₃.m]
+@test sol[sys₁.R] ≈ sol[sys₂.R] ≈ sol[sys₃.R]
+
 
 # TODO add conversion to SDE and JumpSystems once supported
 

--- a/test/reactionsystem_components.jl
+++ b/test/reactionsystem_components.jl
@@ -96,6 +96,8 @@ sol = solve(nlprob, NewtonRaphson(), tol=1e-9)
 @test sol[sys₁.m] ≈ sol[sys₂.m] ≈ sol[sys₃.m]
 @test sol[sys₁.R] ≈ sol[sys₂.R] ≈ sol[sys₃.R]
 
+# using ReactionSystem constraints
+
 # TODO add conversion to SDE and JumpSystems once supported
 
 # adding algebraic constraints

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using SafeTestsets
 if VERSION >= v"1.6.0"
     @time @safetestset "1.6 Arrows" begin include("newarrows.jl") end
 end
+@time @safetestset "Basic DSL" begin include("dsl.jl") end
 @time @safetestset "Model Construction" begin include("make_model.jl") end
 @time @safetestset "Custom Functions" begin include("custom_functions.jl") end
 @time @safetestset "Model Modification" begin include("model_modification.jl") end


### PR DESCRIPTION
Enables `extend`ing `ReactionSystem`s with algebraic and ODE constraints. While we currently can have sub-systems of algebraic (or even ODE) constraints, this is annoying for specifying algebraic equations to couple systems (since everything needs to get parent scoped). i.e. imagine wanting to hook three systems representing genes together, conceptually this is not necessarily a hierarchical system, but more a collection of parallel systems with coupling equations one level up. (This wouldn't necessarily be an issue if we could make the top-level system a `NonlinearSystem`, but currently MT requires sub-systems to have the same type, so top-level systems must be `ReactionSystem`s.)

This PR allows attaching to a `ReactionSystem` an internal constraint system, which is considered at the same scope as the `ReactionSystem`. In this way we can logically `extend` `ReactionSystem`s with equations and/or other `ReactionSystem`s (we already support `compose`). For a simple `alias_elimination` of basic `A ~ B` type equations we could then `flatten` the full hierarchy of systems into one `ReactionSystem` and one internal `sys.constraint` system, and then apply the elimination.

~~Still TODO:~~
- [x] `get_constraints(network)` and support a parallel constraint subsystem
- [x] `flatten`
- [x] `extend`
- [x] tests
- [x] Allow / use `ODESystem`s as constraints, and error if then try to convert to NonlinearSystem.
- [x] Allow interpolation of variables storing network names in the DSL. 