### PR TITLE
Make undefined variables in DSL become species

### DIFF
--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -171,13 +171,18 @@ complexgraph
 savegraph
 ```
 
-## Rate Law Expressions
+## Rate Laws
 As the underlying [`ReactionSystem`](@ref) is comprised of `ModelingToolkit`
 expressions, one can directly access the generated rate laws, and using
 `ModelingToolkit` tooling generate functions or Julia `Expr`s from them.
 ```@docs
 oderatelaw
 jumpratelaw
+mm
+mmr
+hill
+hillr
+hillar
 ```
 
 ## Transformations

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -54,6 +54,7 @@ export @reaction_network, @add_reactions
 
 # registers CRN specific functions using Symbolics.jl
 include("registered_functions.jl")
+export mm, mmr, hill, hillr, hillar
 
 # functions to query network properties
 include("networkapi.jl")

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -189,12 +189,14 @@ end
 function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSystem)))
     reactions = get_reactions(ex)
     reactants = get_reactants(reactions)
-    !isempty(intersect(forbidden_symbols,union(reactants,parameters))) && error("The following symbol(s) are used as reactants or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,union(reactants,parameters)))...))*"this is not permited.")    
+    allspecies = union(reactants, get_rate_species(reactions,parameters))
+    !isempty(intersect(forbidden_symbols,union(allspecies,parameters))) && 
+        error("The following symbol(s) are used as species or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,union(species,parameters)))...))*"this is not permited.")    
     network_code = Expr(:block,:(@parameters t),:(@variables), :(ReactionSystem([],t,[],[]; name=$(name))))
     foreach(parameter-> push!(network_code.args[1].args, parameter), parameters)
-    foreach(reactant -> push!(network_code.args[2].args, Expr(:call,reactant,:t)), reactants)
+    foreach(species -> push!(network_code.args[2].args, Expr(:call,species,:t)), allspecies)
     foreach(parameter-> push!(network_code.args[3].args[6].args, parameter), parameters)
-    foreach(reactant -> push!(network_code.args[3].args[5].args, reactant), reactants)
+    foreach(species -> push!(network_code.args[3].args[5].args, species), allspecies)
     for reaction in reactions
         subs_init = isempty(reaction.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
         prod_init = isempty(reaction.products) ? nothing : :([]); prod_stoich_init = deepcopy(prod_init)
@@ -210,6 +212,28 @@ function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSyste
         push!(network_code.args[3].args[3].args,reaction_func)
     end
     return network_code
+end
+
+function get_rate_species(rxs, ps)
+    pset = Set(ps)
+    species_set = Set{Symbol}()
+    for rx in rxs
+        find_species_in_rate!(species_set, rx.rate, pset)
+    end
+    collect(species_set)
+end
+
+function find_species_in_rate!(sset, rateex::ExprValues, ps)
+    if rateex isa Symbol
+        if !(rateex in forbidden_symbols) && !(rateex in ps) 
+            push!(sset, rateex)
+        end
+    elseif rateex isa Expr
+        for i = 2:length(rateex.args)
+            find_species_in_rate!(sset, rateex.args[i], ps)
+        end
+    end
+    nothing
 end
 
 #Generates a vector containing a number of reaction structures, each containing the information about one reaction.

--- a/src/registered_functions.jl
+++ b/src/registered_functions.jl
@@ -1,47 +1,58 @@
-using Symbolics
+"""
+    mm(X,v,K) = v*X / (X + K)
 
-# Registers the Michaelis-Menten function.
+A Michaelis-Menten rate function.
+"""
 mm(X,v,K) = v*X / (X + K)
-
 @register mm(X,v,K);
-
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{1}) = (args[2]*args[3]) / (args[1]+args[3])^2
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{2}) = args[1]/(args[1]+args[3])
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{3}) = - args[2]*args[1]/(args[1]+args[3])^2
 
 # Registers the repressing Michaelis-Menten function.
+"""
+    mmr(X,v,K) = v*K / (X + K)
+
+A repressive Michaelis-Menten rate function.
+"""
 mmr(X,v,K) = v*K / (X + K)
-
 @register mmr(X,v,K); 
-
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{1}) = - (args[2]*args[3]) / (args[1]+args[3])^2
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{2}) = args[3]/(args[1]+args[3])
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{3}) = args[2]*args[1]/(args[1]+args[3])^2
 
 
-# Registers the Hill function.
-hill(X,v,K,n) = v*(X^n) / (X^n + K^n)
+"""
+    hill(X,v,K,n) = v*(X^n) / (X^n + K^n)
 
+A Hill rate function.
+"""
+hill(X,v,K,n) = v*(X^n) / (X^n + K^n)
 @register hill(X,v,K,n);
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{1}) = args[2] * args[4] * (args[3]^args[4]) * (args[1]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{2}) = (args[1]^args[4])  /  (args[1]^args[4] + args[3]^args[4])
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{3}) = - args[2] * args[4] * (args[1]^args[4]) * (args[3]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{4}) = args[2] * (args[1]^args[4]) * (args[3]^args[4]) * (log(args[1])-log(args[3]))  /  (args[1]^args[4] + args[3]^args[4])^2
 
-# Registers the repressing hill function (alterantive to negative n).
+"""
+    hillr(X,v,K,n) = v*(K^n) / (X^n + K^n)
+
+A repressive Hill rate function.
+"""
 hillr(X,v,K,n) = v*(K^n) / (X^n + K^n)
-
 @register hillr(X,v,K,n);
-
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{1}) = - args[2] * args[4] * (args[3]^args[4]) * (args[1]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{2}) = (args[3]^args[4])  /  (args[1]^args[4] + args[3]^args[4])
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{3}) = args[2] * args[4] * (args[1]^args[4]) * (args[3]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{4}) = args[2] * (args[1]^args[4]) * (args[3]^args[4]) * (log(args[3])-log(args[1]))  /  (args[1]^args[4] + args[3]^args[4])^2
 
-# Registers the activation/repressing hill function.
+"""
+    hillar(X,Y,v,K,n) = v*(X^n) / (X^n + Y^n + K^n)
+
+An activation/repressing Hill rate function.
+"""
 hillar(X,Y,v,K,n) = v*(X^n) / (X^n + Y^n + K^n)
 @register hillar(X,Y,v,K,n);
-
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{1}) = args[3] * args[5] * (args[1]^(args[5]-1)) * (args[2]^args[5]+args[4]^args[5])  /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])^2
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{2}) = - args[3] * args[5] * (args[2]^(args[5]-1)) * (args[1]^args[5])  /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])^2
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{3}) = (args[1]^args[5])   /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -48,3 +48,12 @@ emptyrntest(rn, :name)
 rn = @reaction_network $name
 emptyrntest(rn, :blah)
 
+# test variables that appear only in rates and aren't ps 
+# are categorized as species
+rn = @reaction_network begin
+    π*k*D*hill(B,k2,B*D*H,n), 3*A  --> 2*C
+end k k2 n
+@parameters k,k2,n
+@variables t,A(t),B(t),C(t),D(t),H(t)
+@test issetequal([A,B,C,D,H], species(rn))
+@test issetequal([k,k2,n], parameters(rn))


### PR DESCRIPTION
Currently
```julia
rn = @reaction_network
    k*B, A --> B
end k
```
will error that `B` is unknown. This causes problems in using the DSL in component-based systems, where there may be variables that one wants to use that correspond to species in other components. 

While this PR is breaking, our next release will need to be breaking anyways due to other recent changes. The PR changes the DSL so that anything not declared a parameter is now treated as a chemical species. This isn't a particularly disruptive change since previously this would have errored anyways.

@TorkelE could you double check the macro usage here? I wasn't sure the best way to determine if a Symbol is a valid variable name in general, so just tested against the `forbidden_symbols` and the current list of parameters. 