### PR TITLE
Always flatten before converting

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -813,11 +813,11 @@ function flatten(rs::ReactionSystem; name=nameof(rs))
         newcsys = nothing
     else
         if ODESystem in subsys_types
-            newcsys = ODESystem(ceqs, get_iv(rs), csts, cps; name=nameof(rs))
+            newcsys = ODESystem(ceqs, get_iv(rs), csts, cps; name=name)
         else # must be a NonlinearSystem
             any(T -> T <: NonlinearSystem, subsys_types) || 
                 error("Error, found constraint Equations but no ODESystem or NonlinearSystem associated with them.")
-            newcsys = NonlinearSystem(ceqs, csts, cps; name=nameof(rs))        
+            newcsys = NonlinearSystem(ceqs, csts, cps; name=name)        
         end
     end
 


### PR DESCRIPTION
To avoid https://github.com/SciML/ModelingToolkit.jl/issues/1274 we should always `flatten` before converting. Otherwise we'd need extra steps in conversion to merge ODEs with the same rhs (or nonlinear eqs. that should be one eq). Such extra processing would then require both merging generated equations into one system, and removing one of them from the other, which seems messy...