### PR TITLE
typo in `reactionrates` function description for docs

### DIFF
--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -214,7 +214,7 @@ function dependants(rx, network)
 end
 
 """
-    reaction_rates(network)
+    reactionrates(network)
 
 Given a [`ReactionSystem`](@ref), returns a vector of the symbolic reaction
 rates for each reaction.


### PR DESCRIPTION
was `reaction_rates` in description in docstring. It should be `reactionrates`