### PR TITLE
Add var_to_name field

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Breaking updates and feature summaries across releases
 
 ## Catalyst unreleased (master branch) 
+- **BREAKING:** Added support for `@unpack observable_variable = rn` and `rn.observable_variable`. This requires a new inner constructor definition.
 
 ## Catalyst 10.0
 - `ReactionSystem(rxs::Vector{Reaction}, t)` should now work and will infer the

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -1083,8 +1083,12 @@ function validate(rs::ReactionSystem, info::String="")
         end
     end
     timeunits = get_unit(get_iv(rs))
-    rateunits = specunits / timeunits
 
+    # no units for species, time or parameters then assume validated
+    (specunits in (MT.unitless,nothing)) && (timeunits in (MT.unitless,nothing)) && 
+        MT.all_dimensionless(get_ps(rs)) && return true
+
+    rateunits = specunits / timeunits
     for rx in get_eqs(rs)
         rxunits = get_unit(rx.rate)
         for (i,sub) in enumerate(rx.substrates)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -218,7 +218,7 @@ struct ReactionSystem{U <: Union{Nothing,MT.AbstractSystem}} <: MT.AbstractTimeD
     end
 end
 
-function ReactionSystem(eqs, iv, species, ps;
+function ReactionSystem(eqs, iv, states, ps;
                         observed = [],
                         systems = [],
                         name = nothing,
@@ -251,7 +251,7 @@ function ReactionSystem(eqs, iv, species, ps;
     MT.process_variables!(var_to_name, defaults, ps′)
     MT.collect_var_to_name!(var_to_name, (eq.lhs for eq in observed))
     
-    ReactionSystem(eqs′, iv′, species′, ps′, var_to_name, observed, name, systems, 
+    ReactionSystem(eqs′, iv′, states′, ps′, var_to_name, observed, name, systems, 
                    defaults, connection_type, constraints; 
                    checks = checks, skipvalue = skipvalue)
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -188,7 +188,7 @@ struct ReactionSystem{U <: Union{Nothing,MT.AbstractSystem}} <: MT.AbstractTimeD
     states::Vector
     """Parameter variables. Must not contain the independent variable."""
     ps::Vector
-    """Array variables."""
+    """Maps Symbol to corresponding variable."""
     var_to_name::Dict{Symbol,Any}
     """Equations for observed variables."""
     observed::Vector{Equation}

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -244,7 +244,7 @@ function ReactionSystem(eqs, iv, species, ps;
         throw(ArgumentError("System names must be unique."))
 
     if !(isempty(default_u0) && isempty(default_p))
-        Base.depwarn("`default_u0` and `default_p` are deprecated. Use `defaults` instead.", :ODESystem, force=true)
+        Base.depwarn("`default_u0` and `default_p` are deprecated. Use `defaults` instead.", :ReactionSystem, force=true)
     end
 
     defaults = MT.todict(defaults)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -283,3 +283,10 @@ rxs = [Reaction(x*t*A*B+y, [A], nothing)]
 @named rs1 = ReactionSystem(rxs, t, [A,B], [x,y])
 @named rs2 = ReactionSystem(rxs, t)
 @test Catalyst.isequal_ignore_names(rs1,rs2)
+
+@variables t, L(t), H(t)
+obs = [Equation(L, 2*x + y)]
+@named rs3 = ReactionSystem(rxs, t; observed=obs)
+L2 = L
+@unpack L = rs3
+@test isequal(L,L2)


### PR DESCRIPTION
Handles https://github.com/SciML/ModelingToolkit.jl/issues/1335 for ReactionSystems and adds `var_to_name` to enable `sys.observable_name` and `@unpack observable_name = sys`. I also made the unit checking slightly more efficient in the case of no units.