### PR TITLE
submodule for regsitered functions in registered_functions.jl

### DIFF
--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -52,8 +52,11 @@ include("reaction_network.jl")
 export @reaction_network, @add_reactions
 
 # registers CRN specific functions using Symbolics.jl
-include("registered_functions.jl")
-export mm, mmr, hill, hillr, hillar
+module Functions
+    using Symbolics
+    include("registered_functions.jl")
+    export mm, mmr, hill, hillr, hillar
+end
 
 # functions to query network properties
 include("networkapi.jl")

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -1,3 +1,4 @@
+using Catalyst.Functions
 # Implements handling of registered functions.
 mm_names = ([:mm])
 mmr_names = ([:mmr])

--- a/src/registered_functions.jl
+++ b/src/registered_functions.jl
@@ -4,7 +4,7 @@
 A Michaelis-Menten rate function.
 """
 mm(X,v,K) = v*X / (X + K)
-@register mm(X,v,K);
+@register_symbolic mm(X,v,K);
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{1}) = (args[2]*args[3]) / (args[1]+args[3])^2
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{2}) = args[1]/(args[1]+args[3])
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{3}) = - args[2]*args[1]/(args[1]+args[3])^2
@@ -16,7 +16,7 @@ Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{3}) = - args[2]*ar
 A repressive Michaelis-Menten rate function.
 """
 mmr(X,v,K) = v*K / (X + K)
-@register mmr(X,v,K); 
+@register_symbolic mmr(X,v,K); 
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{1}) = - (args[2]*args[3]) / (args[1]+args[3])^2
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{2}) = args[3]/(args[1]+args[3])
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{3}) = args[2]*args[1]/(args[1]+args[3])^2
@@ -28,7 +28,7 @@ Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{3}) = args[2]*arg
 A Hill rate function.
 """
 hill(X,v,K,n) = v*(X^n) / (X^n + K^n)
-@register hill(X,v,K,n);
+@register_symbolic hill(X,v,K,n);
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{1}) = args[2] * args[4] * (args[3]^args[4]) * (args[1]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{2}) = (args[1]^args[4])  /  (args[1]^args[4] + args[3]^args[4])
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{3}) = - args[2] * args[4] * (args[1]^args[4]) * (args[3]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
@@ -40,7 +40,7 @@ Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{4}) = args[2] * 
 A repressive Hill rate function.
 """
 hillr(X,v,K,n) = v*(K^n) / (X^n + K^n)
-@register hillr(X,v,K,n);
+@register_symbolic hillr(X,v,K,n);
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{1}) = - args[2] * args[4] * (args[3]^args[4]) * (args[1]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{2}) = (args[3]^args[4])  /  (args[1]^args[4] + args[3]^args[4])
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{3}) = args[2] * args[4] * (args[1]^args[4]) * (args[3]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
@@ -52,7 +52,7 @@ Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{4}) = args[2] *
 An activation/repressing Hill rate function.
 """
 hillar(X,Y,v,K,n) = v*(X^n) / (X^n + Y^n + K^n)
-@register hillar(X,Y,v,K,n);
+@register_symbolic hillar(X,Y,v,K,n);
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{1}) = args[3] * args[5] * (args[1]^(args[5]-1)) * (args[2]^args[5]+args[4]^args[5])  /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])^2
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{2}) = - args[3] * args[5] * (args[2]^(args[5]-1)) * (args[1]^args[5])  /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])^2
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{3}) = (args[1]^args[5])   /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,4 +1,4 @@
-using Catalyst, DiffEqBase, ModelingToolkit, Test
+using Catalyst,Catalyst.Functions ,DiffEqBase, ModelingToolkit, Test
 using SparseArrays
 using ModelingToolkit: value
 

--- a/test/custom_functions.jl
+++ b/test/custom_functions.jl
@@ -1,4 +1,4 @@
-using DiffEqBase, Catalyst, Random, Test
+using DiffEqBase, Catalyst, Catalyst.Functions, Random, Test
 using ModelingToolkit: get_states, get_ps
 
 using StableRNGs

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -1,4 +1,5 @@
 using Catalyst, ModelingToolkit
+using Catalyst.Functions
 
 # naming tests
 @parameters k

--- a/test/higher_order_reactions.jl
+++ b/test/higher_order_reactions.jl
@@ -1,5 +1,6 @@
 ### Fetch required packages ###
 using DiffEqBase, Catalyst, DiffEqJump, Random, Statistics, Test
+using Catalyst.Functions
 using ModelingToolkit: get_states, get_ps
 using StableRNGs
 rng = StableRNG(12345)

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -1,6 +1,6 @@
 ### Fetch required packages and reaction networks ###
 using Catalyst, Latexify
-
+using Catalyst.Functions
 ############################
 ### CURRENTLY NOT ACITVE ###
 ### REQUIRES REWRITING   ###

--- a/test/make_jacobian.jl
+++ b/test/make_jacobian.jl
@@ -1,6 +1,6 @@
 ### Fetch required packages and reaction networks ###
 using Catalyst, DiffEqBase, Random, Test
-
+using Catalyst.Functions
 using StableRNGs
 rng = StableRNG(12345)
 

--- a/test/test_networks.jl
+++ b/test/test_networks.jl
@@ -1,4 +1,5 @@
 ### File declaring various reaction networks for the tests to be run on ###
+using Catalyst.Functions
 
 #Declares the vectors which contains the various test sets.
 reaction_networks_standard = Vector{ReactionSystem}(undef,10)


### PR DESCRIPTION
This is about https://github.com/SciML/Catalyst.jl/issues/355

Functions 
`mm` , `mmr` , `hill` , `hillr` , `hillar`
 can imported with this PR as
```
using Catalyst.Functions
```