### PR TITLE
Fix access to variables added with addparam! or addspecies!

### DIFF
--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -898,6 +898,11 @@ function addspecies!(network::ReactionSystem, s::Symbolic; disablechecks=false)
     curidx = disablechecks ? nothing : findfirst(S -> isequal(S, s), get_states(network))
     if curidx === nothing
         push!(get_states(network), s)
+        MT.process_variables!(
+            MT.get_var_to_name(network),
+            get_defaults(network),
+            get_states(network)
+        )
         return length(get_states(network))
     else
         return curidx
@@ -955,6 +960,11 @@ function addparam!(network::ReactionSystem, p::Symbolic; disablechecks=false)
     curidx = disablechecks ? nothing : findfirst(S -> isequal(S, p), get_ps(network))
     if curidx === nothing
         push!(get_ps(network), p)
+        MT.process_variables!(
+            MT.get_var_to_name(network),
+            get_defaults(network),
+            get_ps(network)
+        )
         return length(get_ps(network))
     else
         return curidx

--- a/test/model_modification.jl
+++ b/test/model_modification.jl
@@ -33,6 +33,15 @@ eqs,iv,ps,name,systems = unpacksys(empty_network_2)
 @test all(getproperty.(ps,:name) .== [:p1,:p2,:p3,:p4,:p5])
 
 
+### Tests accessing parameters and species added with network API ###
+empty_network_3 = @reaction_network
+@variables x p
+addspecies!(empty_network_3, x)
+addparam!(empty_network_3, p)
+@test isequal(empty_network_3.x, states(empty_network_3, x))
+@test isequal(empty_network_3.p, parameters(empty_network_3, p))
+
+
 ### Tests creating a network and adding reactions ###
 unfinished_network = @reaction_network begin
     (k1,k2), X1 ↔ X2


### PR DESCRIPTION
Variables added with addparam! or addspecies! can now be accessed
using Base.getproperty.

The addparams! and addspecies! methods now use
ModelingToolkit.process_variables! to update the var_to_name
dictionary when variables are added.