### PR TITLE
Interpolate make_ReactionSystem_internal

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -225,7 +225,7 @@ function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSyste
     foreach(species -> (species isa Symbol) && push!(sexprs.args, Expr(:call,species,:t)), allspecies)
 
     # ReactionSystem
-    rxexprs = :(make_ReactionSystem_internal([],t,nothing,[]; name=$(name)))    
+    rxexprs = :($(make_ReactionSystem_internal)([],t,nothing,[]; name=$(name)))    
     foreach(parameter -> push!(rxexprs.args[6].args,parameter), parameters)
     for reaction in reactions
         subs_init = isempty(reaction.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -8,12 +8,12 @@ while --> is a correct arrow, neither <-- nor <--> works. Using non-filled
 arrows (⇐, ⟽, ⇒, ⟾, ⇔, ⟺) will disable mass kinetics and let you cutomize
 reaction rates yourself. Use 0 or ∅ for degradation/creation to/from nothing.
 
-Example systems: 
+Example systems:
 
-    ### Basic Usage ### 
-    rn = @reaction_network begin           # Creates a ReactionSystem. 
-        2.0, X + Y --> XY                  # This will have reaction rate corresponding to 2.0*[X][Y] 
-        2.0, XY ← X + Y                    # Identical to 2.0, X + Y --> XY 
+    ### Basic Usage ###
+    rn = @reaction_network begin           # Creates a ReactionSystem.
+        2.0, X + Y --> XY                  # This will have reaction rate corresponding to 2.0*[X][Y]
+        2.0, XY ← X + Y                    # Identical to 2.0, X + Y --> XY
     end
 
     ### Manipulating Reaction Rates ###
@@ -42,9 +42,9 @@ Example systems:
     end kB, kD
 
     ### Defining New Functions ###
-    my_hill_repression(x, v, k, n) = v*k^n/(k^n+x^n)  
+    my_hill_repression(x, v, k, n) = v*k^n/(k^n+x^n)
 
-    # may be necessary to 
+    # may be necessary to
     # @register my_hill_repression(x, v, k, n)
     # see https://mtk.sciml.ai/stable/tutorials/symbolic_functions/#Registering-Functions-1
 
@@ -67,7 +67,7 @@ bwd_arrows = Set{Symbol}([:<, :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :�
 double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇌, :⇋, :⇔, :⟺])
 pure_rate_arrows = Set{Symbol}([:⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
 
-# unfortunately the following doesn't seem to work on 1.5, so supporting these 
+# unfortunately the following doesn't seem to work on 1.5, so supporting these
 # operators seems to require us to only support 1.6 and up...
 @static if VERSION >= v"1.6.0"
     push!(bwd_arrows, Symbol("<--"))
@@ -107,7 +107,7 @@ end c1 c2
 emptyrn = @reaction_network empty
 
 # an empty network with random generated name
-emptyrn = @reaction_network 
+emptyrn = @reaction_network
 ```
 """
 macro reaction_network(name::Symbol, ex::Expr, parameters...)
@@ -119,31 +119,31 @@ macro reaction_network(name::Expr, ex::Expr, parameters...)
     make_reaction_system(MacroTools.striplines(ex), parameters; name=:($(esc(name.args[1]))))
 end
 
-macro reaction_network(ex::Expr, parameters...) 
+macro reaction_network(ex::Expr, parameters...)
     ex = MacroTools.striplines(ex)
 
     # no name but equations: @reaction_network begin ... end ...
     if ex.head == :block
         make_reaction_system(ex, parameters)
-    else  # empty but has interpolated name: @reaction_network $name        
+    else  # empty but has interpolated name: @reaction_network $name
         networkname = :($(esc(ex.args[1])))
         return Expr(:block,:(@parameters t),
                     :(ReactionSystem(Reaction[],
                                     t,
                                     [],
-                                    [];                                 
+                                    [];
                                     name=$networkname)))
     end
 end
 
 #Returns a empty network (with, or without, a declared name)
-# @reaction_network name 
+# @reaction_network name
 macro reaction_network(name::Symbol=gensym(:ReactionSystem))
     return Expr(:block,:(@parameters t),
                 :(ReactionSystem(Reaction[],
                                  t,
                                  [],
-                                 [];                                 
+                                 [];
                                  name=$(QuoteNode(name)))))
 end
 
@@ -195,7 +195,7 @@ function esc_dollars!(ex)
         else
             for i = 1:length(ex.args)
                 ex.args[i] = esc_dollars!(ex.args[i])
-            end            
+            end
         end
     end
     ex
@@ -211,9 +211,9 @@ function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSyste
     reactions = get_reactions(ex)
     reactants = get_reactants(reactions)
     allspecies = union(reactants, get_rate_species(reactions,parameters))
-    !isempty(intersect(forbidden_symbols,union(allspecies,parameters))) && 
-        error("The following symbol(s) are used as species or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,union(species,parameters)))...))*"this is not permited.")    
-    
+    !isempty(intersect(forbidden_symbols,union(allspecies,parameters))) &&
+        error("The following symbol(s) are used as species or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,union(species,parameters)))...))*"this is not permited.")
+
     # parameters
     pexprs = isempty(parameters) ? :() : :(@parameters)
     if !isempty(parameters)
@@ -225,7 +225,7 @@ function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSyste
     foreach(species -> (species isa Symbol) && push!(sexprs.args, Expr(:call,species,:t)), allspecies)
 
     # ReactionSystem
-    rxexprs = :($(make_ReactionSystem_internal)([],t,nothing,[]; name=$(name)))    
+    rxexprs = :($(make_ReactionSystem_internal)([],t,nothing,[]; name=$(name)))
     foreach(parameter -> push!(rxexprs.args[6].args,parameter), parameters)
     for reaction in reactions
         subs_init = isempty(reaction.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
@@ -261,10 +261,10 @@ end
 
 function find_species_in_rate!(sset, rateex::ExprValues, ps)
     if rateex isa Symbol
-        if !(rateex in forbidden_symbols) && !(rateex in ps) 
+        if !(rateex in forbidden_symbols) && !(rateex in ps)
             push!(sset, rateex)
         end
-    elseif rateex isa Expr   
+    elseif rateex isa Expr
         # note, this (correctly) skips $(...) expressions
         for i = 2:length(rateex.args)
             find_species_in_rate!(sset, rateex.args[i], ps)
@@ -307,7 +307,7 @@ end
 
 #Recursive function that loops through the reaction line and finds the reactants and their stoichiometry. Recursion makes it able to handle weird cases like 2(X+Y+3(Z+XY)).
 function recursive_find_reactants!(ex::ExprValues, mult::Int, reactants::Vector{ReactantStruct})
-    if typeof(ex)!=Expr || (ex.head == :escape)        
+    if typeof(ex)!=Expr || (ex.head == :escape)
         (ex == 0 || in(ex,empty_set)) && (return reactants)
         if in(ex, getfield.(reactants,:reactant))
             idx = findall(x -> x==ex, getfield.(reactants,:reactant))[1]

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -265,7 +265,6 @@ end
 
 # Only used internally by the @reaction_network macro. Permits giving an initial order to the parameters, 
 # and then adds additional ones found in the reaction. Name could be changed.
-# Any changes to the API of this function should be considered breaking as it's being used downstream.
 function make_ReactionSystem_internal(rxs::Vector{<:Reaction}, iv, no_sps::Nothing, ps_in; kwargs...)  
     t    = value(iv)   
     sts  = OrderedSet(spec for rx in rxs for spec in Iterators.flatten((rx.substrates,rx.products)))

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -122,8 +122,8 @@ end
 function ModelingToolkit.namespace_equation(rx::Reaction, name)
     subs  = isempty(rx.substrates) ? rx.substrates : [namespace_expr(sub, name) for sub in rx.substrates]
     prods = isempty(rx.products) ? rx.products : [namespace_expr(prod, name) for prod in rx.products]
-    Reaction(namespace_expr(rx.rate, name), 
-             subs, prods, rx.substoich, rx.prodstoich,            
+    Reaction(namespace_expr(rx.rate, name),
+             subs, prods, rx.substoich, rx.prodstoich,
              [namespace_expr(n[1],name) => n[2] for n in rx.netstoich], rx.only_use_rate)
 end
 
@@ -155,10 +155,10 @@ $(FIELDS)
 Continuing from the example in the [`Reaction`](@ref) definition:
 ```julia
 # simple constructor that infers species and parameters
-@named rs = ReactionSystem(rxs, t)   
+@named rs = ReactionSystem(rxs, t)
 
 # allows specification of species and parameters
-@named rs = ReactionSystem(rxs, t, [A,B,C,D], k) 
+@named rs = ReactionSystem(rxs, t, [A,B,C,D], k)
 ```
 
 Keyword Arguments:
@@ -166,7 +166,7 @@ Keyword Arguments:
 - `systems::Vector{AbstractSystems}`, vector of sub-systems. Can be
   `ReactionSystem`s, `ODESystem`s, or `NonlinearSystem`s.
 - `name::Symbol`, the name of the system (must be provided, or `@named` must be
-  used). 
+  used).
 - `defaults::Dict`, a dictionary mapping parameters to their default values and
   species to their default initial values.
 - `checks = true`, boolean for whether to check units.
@@ -207,7 +207,7 @@ struct ReactionSystem{U <: Union{Nothing,MT.AbstractSystem}} <: MT.AbstractTimeD
     constraints::U
 
     # inner constructor is considered private and may change between non-breaking releases.
-    function ReactionSystem(eqs, iv, states, ps, var_to_name, observed, name, systems, defaults, connection_type, csys; 
+    function ReactionSystem(eqs, iv, states, ps, var_to_name, observed, name, systems, defaults, connection_type, csys;
                             checks::Bool=true, skipvalue=false)
         if checks
             check_variables(states, iv)
@@ -227,10 +227,10 @@ function ReactionSystem(eqs, iv, states, ps;
                         default_p=Dict(),
                         defaults=_merge(Dict(default_u0), Dict(default_p)),
                         connection_type=nothing,
-                        checks = true, 
+                        checks = true,
                         constraints = nothing,
                         skipvalue = false)
-    
+
     name === nothing && throw(ArgumentError("The `name` keyword must be provided. Please consider using the `@named` macro"))
     sysnames = nameof.(systems)
     (length(unique(sysnames)) == length(sysnames)) ||
@@ -242,7 +242,7 @@ function ReactionSystem(eqs, iv, states, ps;
     defaults = MT.todict(defaults)
     defaults = Dict{Any,Any}(value(k) => value(v) for (k, v) in pairs(defaults))
 
-    iv′     = value(iv)        
+    iv′     = value(iv)
     states′ = skipvalue ? states : value.(MT.scalarize(states))
     ps′     = skipvalue ? ps : value.(MT.scalarize(ps))
     eqs′    = (eqs isa Vector) ? eqs : collect(eqs)
@@ -251,22 +251,22 @@ function ReactionSystem(eqs, iv, states, ps;
     MT.process_variables!(var_to_name, defaults, states′)
     MT.process_variables!(var_to_name, defaults, ps′)
     MT.collect_var_to_name!(var_to_name, (eq.lhs for eq in observed))
-    
-    ReactionSystem(eqs′, iv′, states′, ps′, var_to_name, observed, name, systems, 
-                   defaults, connection_type, constraints; 
+
+    ReactionSystem(eqs′, iv′, states′, ps′, var_to_name, observed, name, systems,
+                   defaults, connection_type, constraints;
                    checks = checks, skipvalue = skipvalue)
 end
 
 
 # Previous function called by the macro, but still avaiable for general use.
-function ReactionSystem(rxs::Vector{<:Reaction}, iv; kwargs...)  
-    make_ReactionSystem_internal(rxs, iv, nothing, Vector{Num}(); kwargs...) 
+function ReactionSystem(rxs::Vector{<:Reaction}, iv; kwargs...)
+    make_ReactionSystem_internal(rxs, iv, nothing, Vector{Num}(); kwargs...)
 end
 
-# Only used internally by the @reaction_network macro. Permits giving an initial order to the parameters, 
+# Only used internally by the @reaction_network macro. Permits giving an initial order to the parameters,
 # and then adds additional ones found in the reaction. Name could be changed.
-function make_ReactionSystem_internal(rxs::Vector{<:Reaction}, iv, no_sps::Nothing, ps_in; kwargs...)  
-    t    = value(iv)   
+function make_ReactionSystem_internal(rxs::Vector{<:Reaction}, iv, no_sps::Nothing, ps_in; kwargs...)
+    t    = value(iv)
     sts  = OrderedSet(spec for rx in rxs for spec in Iterators.flatten((rx.substrates,rx.products)))
     ps   = OrderedSet{Any}(ps_in)
     vars = OrderedSet()
@@ -274,7 +274,7 @@ function make_ReactionSystem_internal(rxs::Vector{<:Reaction}, iv, no_sps::Nothi
         MT.get_variables!(vars, rx.rate)
         for var in vars
             isequal(t,var) && continue
-            if MT.isparameter(var) 
+            if MT.isparameter(var)
                 push!(ps, var)
             else
                 push!(sts, var)
@@ -294,7 +294,7 @@ end
 
 ####################### ModelingToolkit inherited accessors #############################
 
-""" 
+"""
     get_constraints(sys::ReactionSystem)
 
 Return the current constraint subsystem, if none is defined will return `nothing`.
@@ -303,7 +303,7 @@ get_constraints(sys::ReactionSystem) = getfield(sys, :constraints)
 has_constraints(sys::ReactionSystem) = isdefined(sys, :constraints)
 
 function MT.states(sys::ReactionSystem)
-    sts = (get_constraints(sys) === nothing) ? get_states(sys) : vcat(get_states(sys), get_states(get_constraints(sys)))       
+    sts = (get_constraints(sys) === nothing) ? get_states(sys) : vcat(get_states(sys), get_states(get_constraints(sys)))
     systems = get_systems(sys)
     unique(isempty(systems) ? sts : [sts; reduce(vcat,namespace_variables.(systems))])
 end
@@ -317,7 +317,7 @@ end
 function MT.equations(sys::ReactionSystem)
     eqs = (get_constraints(sys) === nothing) ? get_eqs(sys) : Any[get_eqs(sys); get_eqs(get_constraints(sys))]
     systems = get_systems(sys)
-    if !isempty(systems)        
+    if !isempty(systems)
         return Any[eqs; reduce(vcat, MT.namespace_equations.(systems); init=Any[])]
     end
     return eqs
@@ -550,7 +550,7 @@ end
 #         elseif sys isa T
 #             systems[i] = sys
 #         else
-#             try 
+#             try
 #                 if (T <: MT.AbstractTimeDependentSystem) && (sys isa MT.AbstractTimeIndependentSystem)
 #                     systems[i] = MT.convert_system(T, sys, get_iv(rs))
 #                 else
@@ -560,18 +560,18 @@ end
 #                 error("ModelingToolkit does not currently support convert_system($T, $(typeof(sys)))")
 #             end
 #         end
-#     end    
+#     end
 #     systems
 # end
 
 # merge constraint eqs, states and ps into the top-level eqs, states and ps
-function addconstraints!(eqs, rs::ReactionSystem)   
-    csys = get_constraints(rs)     
+function addconstraints!(eqs, rs::ReactionSystem)
+    csys = get_constraints(rs)
     sts  = get_states(rs); ps = get_ps(rs)
 
     if csys !== nothing
         csts = get_states(csys); cps = get_ps(csys); ceqs = get_eqs(csys)
-        sts  = isempty(csts) ? sts : [sts; csts]        
+        sts  = isempty(csts) ? sts : [sts; csts]
         ps   = isempty(cps) ? ps : [ps; cps]
         (!isempty(ceqs)) && append!(eqs,ceqs)
     end
@@ -581,12 +581,12 @@ end
 
 # used by systems that don't support constraint equations currently
 function error_if_constraints(::Type{T}, sys::ReactionSystem) where {T <: MT.AbstractSystem}
-    (get_constraints(sys) === nothing) || 
+    (get_constraints(sys) === nothing) ||
             error("Can not convert to a system of type ", T, " when there are constraints.")
 end
 
 function error_if_constraint_odes(::Type{T}, rs::ReactionSystem) where {T <: MT.AbstractSystem}
-    csys = get_constraints(rs)    
+    csys = get_constraints(rs)
     if csys !== nothing
         structsys = MT.SystemStructures.initialize_system_structure(csys)
         structure = MT.get_structure(structsys)
@@ -608,15 +608,15 @@ law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
 `combinatoric_ratelaws=false` then the ratelaw is `k*S^2`, i.e. the scaling factor is
 ignored.
 """
-function Base.convert(::Type{<:ODESystem}, rs::ReactionSystem; 
-                      name=nameof(rs), combinatoric_ratelaws=true, include_zero_odes=true, 
+function Base.convert(::Type{<:ODESystem}, rs::ReactionSystem;
+                      name=nameof(rs), combinatoric_ratelaws=true, include_zero_odes=true,
                       checks=false, kwargs...)
     fullrs = Catalyst.flatten(rs)
-    eqs = assemble_drift(fullrs; combinatoric_ratelaws=combinatoric_ratelaws, 
-                             include_zero_odes=include_zero_odes)                                 
+    eqs = assemble_drift(fullrs; combinatoric_ratelaws=combinatoric_ratelaws,
+                             include_zero_odes=include_zero_odes)
     eqs,sts,ps = addconstraints!(eqs, fullrs)
-    ODESystem(eqs, get_iv(fullrs), sts, ps; name=name, defaults=get_defaults(fullrs), 
-                                            observed=get_observed(fullrs), checks=checks, 
+    ODESystem(eqs, get_iv(fullrs), sts, ps; name=name, defaults=get_defaults(fullrs),
+                                            observed=get_observed(fullrs), checks=checks,
                                             kwargs...)
 end
 
@@ -634,15 +634,15 @@ law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
 ignored.
 """
 function Base.convert(::Type{<:NonlinearSystem}, rs::ReactionSystem;
-                      name=nameof(rs), combinatoric_ratelaws=true, include_zero_odes=true, 
+                      name=nameof(rs), combinatoric_ratelaws=true, include_zero_odes=true,
                       checks = false, kwargs...)
     fullrs = Catalyst.flatten(rs)
-    eqs = assemble_drift(fullrs; combinatoric_ratelaws=combinatoric_ratelaws, as_odes=false, 
+    eqs = assemble_drift(fullrs; combinatoric_ratelaws=combinatoric_ratelaws, as_odes=false,
                                  include_zero_odes=include_zero_odes)
     error_if_constraint_odes(NonlinearSystem, fullrs)
     eqs,sts,ps = addconstraints!(eqs, fullrs)
-    NonlinearSystem(eqs, sts, ps; name=name, defaults=get_defaults(fullrs), 
-                                  observed=get_observed(fullrs), checks = checks, 
+    NonlinearSystem(eqs, sts, ps; name=name, defaults=get_defaults(fullrs),
+                                  observed=get_observed(fullrs), checks = checks,
                                   kwargs...)
 end
 
@@ -668,10 +668,10 @@ Here the noise for each reaction is scaled by the corresponding parameter in the
 This input may contain repeat parameters.
 """
 function Base.convert(::Type{<:SDESystem}, rs::ReactionSystem;
-                      noise_scaling=nothing, name=nameof(rs), combinatoric_ratelaws=true, 
+                      noise_scaling=nothing, name=nameof(rs), combinatoric_ratelaws=true,
                       include_zero_odes=true, checks = false, kwargs...)
 
-    flatrs = Catalyst.flatten(rs)                      
+    flatrs = Catalyst.flatten(rs)
     error_if_constraints(SDESystem, flatrs)
 
     if noise_scaling isa AbstractArray
@@ -685,15 +685,15 @@ function Base.convert(::Type{<:SDESystem}, rs::ReactionSystem;
         noise_scaling = fill(value(noise_scaling),numreactions(flatrs))
     end
 
-    eqs = assemble_drift(flatrs; combinatoric_ratelaws=combinatoric_ratelaws, 
+    eqs = assemble_drift(flatrs; combinatoric_ratelaws=combinatoric_ratelaws,
                                  include_zero_odes=include_zero_odes)
     noiseeqs = assemble_diffusion(flatrs, noise_scaling;
                                   combinatoric_ratelaws=combinatoric_ratelaws)
     SDESystem(eqs, noiseeqs, get_iv(flatrs), get_states(flatrs),
               (noise_scaling===nothing) ? get_ps(flatrs) : union(get_ps(flatrs), toparam(noise_scaling));
-              name=name, 
+              name=name,
               defaults=get_defaults(flatrs),
-              observed=get_observed(flatrs), 
+              observed=get_observed(flatrs),
               checks = checks,
               kwargs...)
 end
@@ -711,15 +711,15 @@ Notes:
   the ratelaw is `k*S*(S-1)`, i.e. the rate law is not normalized by the scaling
   factor.
 """
-function Base.convert(::Type{<:JumpSystem},rs::ReactionSystem; 
+function Base.convert(::Type{<:JumpSystem},rs::ReactionSystem;
                       name=nameof(rs), combinatoric_ratelaws=true, checks = false, kwargs...)
-    
+
     flatrs = Catalyst.flatten(rs)
     error_if_constraints(JumpSystem, flatrs)
 
     eqs = assemble_jumps(flatrs; combinatoric_ratelaws=combinatoric_ratelaws)
-    JumpSystem(eqs, get_iv(flatrs), get_states(flatrs), get_ps(flatrs); name=name, 
-               defaults=get_defaults(flatrs), observed=get_observed(flatrs), 
+    JumpSystem(eqs, get_iv(flatrs), get_states(flatrs), get_ps(flatrs); name=name,
+               defaults=get_defaults(flatrs), observed=get_observed(flatrs),
                checks = checks, kwargs...)
 end
 
@@ -728,20 +728,20 @@ end
 
 
 # ODEProblem from AbstractReactionNetwork
-function DiffEqBase.ODEProblem(rs::ReactionSystem, u0, tspan, p=DiffEqBase.NullParameters(), args...; 
+function DiffEqBase.ODEProblem(rs::ReactionSystem, u0, tspan, p=DiffEqBase.NullParameters(), args...;
                                check_length=false, kwargs...)
     return ODEProblem(convert(ODESystem,rs; kwargs...),u0,tspan,p, args...; check_length, kwargs...)
 end
 
 # NonlinearProblem from AbstractReactionNetwork
-function DiffEqBase.NonlinearProblem(rs::ReactionSystem, u0, p=DiffEqBase.NullParameters(), args...; 
+function DiffEqBase.NonlinearProblem(rs::ReactionSystem, u0, p=DiffEqBase.NullParameters(), args...;
                                      check_length=false, kwargs...)
     return NonlinearProblem(convert(NonlinearSystem,rs; kwargs...), u0, p, args...; check_length, kwargs...)
 end
 
 
 # SDEProblem from AbstractReactionNetwork
-function DiffEqBase.SDEProblem(rs::ReactionSystem, u0, tspan, p=DiffEqBase.NullParameters(), args...; 
+function DiffEqBase.SDEProblem(rs::ReactionSystem, u0, tspan, p=DiffEqBase.NullParameters(), args...;
                                noise_scaling=nothing, kwargs...)
     sde_sys  = convert(SDESystem,rs;noise_scaling=noise_scaling, kwargs...)
     p_matrix = zeros(length(get_states(rs)), length(get_eqs(rs)))
@@ -749,7 +749,7 @@ function DiffEqBase.SDEProblem(rs::ReactionSystem, u0, tspan, p=DiffEqBase.NullP
 end
 
 # DiscreteProblem from AbstractReactionNetwork
-function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0, tspan::Tuple, p=DiffEqBase.NullParameters(), 
+function DiffEqBase.DiscreteProblem(rs::ReactionSystem, u0, tspan::Tuple, p=DiffEqBase.NullParameters(),
                                     args...; kwargs...)
     return DiscreteProblem(convert(JumpSystem,rs; kwargs...), u0,tspan,p, args...; kwargs...)
 end
@@ -760,7 +760,7 @@ function DiffEqJump.JumpProblem(rs::ReactionSystem, prob, aggregator, args...; k
 end
 
 # SteadyStateProblem from AbstractReactionNetwork
-function DiffEqBase.SteadyStateProblem(rs::ReactionSystem, u0, p=DiffEqBase.NullParameters(), args...; 
+function DiffEqBase.SteadyStateProblem(rs::ReactionSystem, u0, p=DiffEqBase.NullParameters(), args...;
                                        kwargs...)
     return SteadyStateProblem(ODEFunction(convert(ODESystem,rs; kwargs...)),u0,p, args...; kwargs...)
 end
@@ -784,7 +784,7 @@ end
 
 
 ########################## Compositional Tooling ###########################
-function getsubsyseqs!(eqs::Vector{Equation}, sys) 
+function getsubsyseqs!(eqs::Vector{Equation}, sys)
     if sys isa ReactionSystem
         push!(eqs, get_eqs(get_constraints(sys)))
     else
@@ -796,7 +796,7 @@ function getsubsyseqs!(eqs::Vector{Equation}, sys)
     end
     eqs
 end
-function getsubsyseqs(sys)    
+function getsubsyseqs(sys)
     getsubsyseqs!(Vector{Equation}(), sys)
 end
 
@@ -807,7 +807,7 @@ function getsubsystypes!(typeset::Set{Type}, sys::T) where {T <: MT.AbstractSyst
     for subsys in get_systems(sys)
         getsubsystypes!(typeset, subsys)
     end
-    typeset 
+    typeset
 end
 function getsubsystypes(sys)
     typeset = Set{Type}()
@@ -818,7 +818,7 @@ end
 """
     Catalyst.flatten(rs::ReactionSystem)
 
-Merges all subsystems of the given [`ReactionSystem`](@ref) up into `rs`. 
+Merges all subsystems of the given [`ReactionSystem`](@ref) up into `rs`.
 
 Notes:
 - Returns a new `ReactionSystem` that represents the flattened system.
@@ -833,19 +833,19 @@ Notes:
 - Currently only `ReactionSystem`s, `NonlinearSystem`s and `ODESystem`s are
   supported as sub-systems when flattening.
 """
-function flatten(rs::ReactionSystem; name=nameof(rs)) 
-    
+function flatten(rs::ReactionSystem; name=nameof(rs))
+
     isempty(get_systems(rs)) && return rs
-    
+
     # right now only NonlinearSystems and ODESystems can be handled as subsystems
     subsys_types  = getsubsystypes(rs)
-    allowed_types = (ReactionSystem, NonlinearSystem, ODESystem)    
-    all(T -> any(T .<: allowed_types), subsys_types) || 
+    allowed_types = (ReactionSystem, NonlinearSystem, ODESystem)
+    all(T -> any(T .<: allowed_types), subsys_types) ||
         error("flattening is currently only supported for subsystems mixing ReactionSystems, NonlinearSystems and ODESystems.")
 
     specs      = species(rs)
-    sts        = states(rs)    
-    reactionps = reactionparams(rs)   
+    sts        = states(rs)
+    reactionps = reactionparams(rs)
     ps         = parameters(rs)
     alleqs     = equations(rs)
     rxs        = Reaction[rx for rx in alleqs if rx isa Reaction]
@@ -860,13 +860,13 @@ function flatten(rs::ReactionSystem; name=nameof(rs))
         if ODESystem in subsys_types
             newcsys = ODESystem(ceqs, get_iv(rs), csts, cps; name=name)
         else # must be a NonlinearSystem
-            any(T -> T <: NonlinearSystem, subsys_types) || 
+            any(T -> T <: NonlinearSystem, subsys_types) ||
                 error("Error, found constraint Equations but no ODESystem or NonlinearSystem associated with them.")
-            newcsys = NonlinearSystem(ceqs, csts, cps; name=name)        
+            newcsys = NonlinearSystem(ceqs, csts, cps; name=name)
         end
     end
 
-    ReactionSystem(rxs, get_iv(rs), specs, reactionps; observed = MT.observed(rs),                    
+    ReactionSystem(rxs, get_iv(rs), specs, reactionps; observed = MT.observed(rs),
                                                        name = name,
                                                        defaults = MT.defaults(rs),
                                                        checks = false,
@@ -885,10 +885,10 @@ Notes:
 - By default, the new `ReactionSystem` will have the same name as `sys`.
 """
 function ModelingToolkit.extend(sys::Union{NonlinearSystem,ODESystem}, rs::ReactionSystem; name::Symbol=nameof(sys))
-    csys = (get_constraints(rs) === nothing) ? sys : extend(sys, get_constraints(rs))       
-    ReactionSystem(get_eqs(rs), get_iv(rs), get_states(rs), get_ps(rs); 
-                    observed = get_observed(rs), name = name, 
-                    systems = get_systems(rs), defaults = get_defaults(rs), 
+    csys = (get_constraints(rs) === nothing) ? sys : extend(sys, get_constraints(rs))
+    ReactionSystem(get_eqs(rs), get_iv(rs), get_states(rs), get_ps(rs);
+                    observed = get_observed(rs), name = name,
+                    systems = get_systems(rs), defaults = get_defaults(rs),
                     checks=false, constraints=csys)
 end
 
@@ -913,12 +913,12 @@ function ModelingToolkit.extend(sys::ReactionSystem, rs::ReactionSystem; name::S
 
     csys = get_constraints(rs)
     csys2 = get_constraints(sys)
-    if csys === nothing        
+    if csys === nothing
         newcsys = csys2
     else
         newcsys = (csys2 === nothing) ? csys : extend(csys2, csys, name)
     end
-    
-    ReactionSystem(eqs, get_iv(rs), sts, ps; observed = obs, name = name, 
+
+    ReactionSystem(eqs, get_iv(rs), sts, ps; observed = obs, name = name,
                     systems = syss, defaults = defs, checks=false, constraints=newcsys)
 end

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -92,3 +92,13 @@ end α
 @parameters α
 rn2 = ReactionSystem([Reaction(α+kk1*kk2*AA, [A, B], [A], [2, 1], [1])], t; name=:rn)
 @test rn == rn2
+
+@testset "make_reaction_system can be called from another module" begin
+    ex = quote
+        (Ka, Depot --> Central)
+        (CL / Vc, Central --> 0)
+    end
+    # Line number nodes aren't ignored so have to be manually removed
+    Base.remove_linenums!(ex)
+    @test eval(Catalyst.make_reaction_system(ex, (:Ka, :Cl, :Vc))) isa ReactionSystem
+end

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -15,7 +15,7 @@ function emptyrntest(rn, name)
     @test nameof(rn) == name
     @test numreactions(rn) == 0
     @test numspecies(rn) == 0
-    @test numreactionparams(rn) == 0    
+    @test numreactionparams(rn) == 0
 end
 
 rn = @reaction_network name begin
@@ -48,7 +48,7 @@ emptyrntest(rn, :name)
 rn = @reaction_network $name
 emptyrntest(rn, :blah)
 
-# test variables that appear only in rates and aren't ps 
+# test variables that appear only in rates and aren't ps
 # are categorized as species
 rn = @reaction_network begin
     π*k*D*hill(B,k2,B*D*H,n), 3*A  --> 2*C
@@ -64,7 +64,7 @@ end k k2 n
 AA = A
 AAA = A^2 + B
 rn = @reaction_network rn begin
-    k*$AAA, C --> D    
+    k*$AAA, C --> D
 end k
 rn2 = ReactionSystem([Reaction(k*AAA, [C], [D])], t; name=:rn)
 @test rn == rn2
@@ -77,10 +77,10 @@ rn2 = ReactionSystem([Reaction(k, [AA,C], [D])], t; name=:rn)
 
 BB = B; A2 = A
 rn = @reaction_network rn begin
-    (k1,k2), C + $A2 + $BB + $A2 <--> $BB + $BB    
+    (k1,k2), C + $A2 + $BB + $A2 <--> $BB + $BB
 end k1 k2
 rn2 = ReactionSystem([Reaction(k1, [C, A, B], [B], [1,2,1],[2]),
-                      Reaction(k2, [B], [C, A, B], [2], [1,2,1])], 
+                      Reaction(k2, [B], [C, A, B], [2], [1,2,1])],
                      t; name=:rn)
 @test rn == rn2
 


### PR DESCRIPTION
...into `Expr` in `make_reaction_system` to ensure that it is properly qualified when `make_reaction_system` is used
from other modules.

This makes

```julia
julia> ex = quote
           (Ka, Depot --> Central)
           (CL / Vc, Central --> 0)
       end;

julia> Base.remove_linenums!(ex);

julia> eval(Catalyst.make_reaction_system(ex, (:CL, :Vc, :Ka)))
Model ##ReactionSystem#274 with 2 equations
States (2):
  Depot(t)
  Central(t)
Parameters (3):
  CL
  Vc
  Ka
```
work.

(I've also removed some white space while here, so please click the first commit when reviewing the diff).