### PR TITLE
fix DSL annoyances

### DIFF
--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -172,7 +172,7 @@ netstoichmat
 reactionrates
 ```
 
-## Functions to Extend a Network
+## Functions to Extend or Modify a Network
 `ReactionSystem`s can be programmatically extended using [`addspecies!`](@ref),
 [`addparam!`](@ref), [`addreaction!`](@ref), [`@add_reactions`](@ref), or
 composed using [`ModelingToolkit.extend`](@ref) and
@@ -184,6 +184,7 @@ addspecies!
 reorder_states!
 addparam!
 addreaction!
+setdefaults!
 ModelingToolkit.extend
 ModelingToolkit.compose
 Catalyst.flatten

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -185,6 +185,7 @@ reorder_states!
 addparam!
 addreaction!
 setdefaults!
+symmap_to_varmap
 ModelingToolkit.extend
 ModelingToolkit.compose
 Catalyst.flatten

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -57,7 +57,7 @@ export mm, mmr, hill, hillr, hillar
 
 # functions to query network properties
 include("networkapi.jl")
-export species, reactionparams, reactions, speciesmap, paramsmap, reactionparamsmap, numspecies, numreactions, numreactionparams
+export species, reactionparams, reactions, speciesmap, paramsmap, reactionparamsmap, numspecies, numreactions, numreactionparams, setdefaults!
 export make_empty_network, addspecies!, addparam!, addreaction!
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -12,9 +12,10 @@ using ModelingToolkit; const MT = ModelingToolkit
 @reexport using ModelingToolkit
 using Symbolics
 using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems, 
-                       get_eqs, get_defaults, toparam, get_defaults, get_observed
+                       get_eqs, get_defaults, toparam, get_defaults, get_observed, get_var_to_name
 import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_variables!, 
-                        modified_states!, validate, namespace_variables, namespace_parameters
+                        modified_states!, validate, namespace_variables, namespace_parameters,
+                        flatten
 
 # internal but needed ModelingToolkit functions
 import ModelingToolkit: check_variables, check_parameters, _iszero, _merge, check_units, get_unit

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -57,7 +57,8 @@ export mm, mmr, hill, hillr, hillar
 
 # functions to query network properties
 include("networkapi.jl")
-export species, reactionparams, reactions, speciesmap, paramsmap, reactionparamsmap, numspecies, numreactions, numreactionparams, setdefaults!
+export species, reactionparams, reactions, speciesmap, paramsmap, reactionparamsmap
+export numspecies, numreactions, numreactionparams, setdefaults!, unpacksys
 export make_empty_network, addspecies!, addparam!, addreaction!
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities
@@ -66,7 +67,7 @@ export conservationlaws, conservedquantities
 export params, numparams
 
 # network analysis functions
-export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat, unpacksys
+export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat
 export incidencematgraph, linkageclasses, deficiency, subnetworks, linkagedeficiencies, isreversible, isweaklyreversible
   
 # for Latex printing of ReactionSystems

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -59,7 +59,7 @@ export mm, mmr, hill, hillr, hillar
 # functions to query network properties
 include("networkapi.jl")
 export species, reactionparams, reactions, speciesmap, paramsmap, reactionparamsmap
-export numspecies, numreactions, numreactionparams, setdefaults!, unpacksys
+export numspecies, numreactions, numreactionparams, setdefaults!, symmap_to_varmap
 export make_empty_network, addspecies!, addparam!, addreaction!
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -66,7 +66,7 @@ export conservationlaws, conservedquantities
 export params, numparams
 
 # network analysis functions
-export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat
+export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat, unpacksys
 export incidencematgraph, linkageclasses, deficiency, subnetworks, linkagedeficiencies, isreversible, isweaklyreversible
   
 # for Latex printing of ReactionSystems

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -348,8 +348,9 @@ gives initial/default values to each of `S`, `I` and `β`
 
 Notes:
 - Can not be used to set default values for species, variables or parameters of
-subsystems. Either set defaults for those systems directly, or [`flatten`](@ref)
-to collate them into one system before setting defaults.
+subsystems or constraint systems. Either set defaults for those systems
+directly, or [`flatten`](@ref) to collate them into one system before setting
+defaults.
 """
 function setdefaults!(rn::MT.AbstractSystem, newdefs::AbstractVector{Pair{Symbol,T}}) where {T}
     rndefs = MT.get_defaults(rn)

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -342,13 +342,11 @@ sir = @reaction_network SIR begin
     β, S + I --> 2I
     ν, I --> R
 end β ν
-
 setdefaults!(sir, [:S => 1.0, :I => 2.0, :β => 3.0])
 ```
 gives initial/default values to each of `S`, `I` and `β`
 
 Notes:
-
 - Can not be used to set default values for species, variables or parameters of
 subsystems. Either set defaults for those systems directly, or [`flatten`](@ref)
 to collate them into one system before setting defaults.

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -331,6 +331,37 @@ function netstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
 	sparse ? netstoichmat(SparseMatrixCSC{Int,Int}, rn; smap=smap) : netstoichmat(Matrix{Int}, rn; smap=smap)
 end
 
+"""
+    setdefaults!(rn::MT.AbstractSystem, newdefs)
+
+Sets the default (initial) values of parameters and species in `rn`.
+
+For example,
+```julia
+sir = @reaction_network SIR begin
+    β, S + I --> 2I
+    ν, I --> R
+end β ν
+
+setdefaults!(sir, [:S => 1.0, :I => 2.0, :β => 3.0])
+```
+gives initial/default values to each of `S`, `I` and `β`
+
+Notes:
+
+- Can not be used to set default values for species, variables or parameters of
+subsystems. Either set defaults for those systems directly, or [`flatten`](@ref)
+to collate them into one system before setting defaults.
+"""
+function setdefaults!(rn::MT.AbstractSystem, newdefs)
+    rndefs = MT.get_defaults(rn)
+    for (sym,val) in newdefs
+        var = MT.getproperty(rn, sym, namespace=false)
+        rndefs[var] = val
+    end
+    nothing
+end
+
 ######################## reaction complexes and reaction rates ###############################
 """
 $(TYPEDEF)

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -423,9 +423,9 @@ end
 """
     symmap_to_varmap(sys, symmap)
 
-Given a system and map of `Symbol`s to values, generates a map 
-from corresponding symbolic variables/parameters to the values
-that can be used to pass initial conditions and parameter mappings.
+Given a system and map of `Symbol`s to values, generates a map from
+corresponding symbolic variables/parameters to the values that can be used to
+pass initial conditions and parameter mappings.
 
 For example,
 ```julia
@@ -459,6 +459,10 @@ u0map  = symmap_to_varmap(sys, symmap)
 pmap   = symmap_to_varmap(sys, [:β => 1.0, :ν => 1.0, :subsys₊k => 1.0])
 ```
 `u0map` and `pmap` can then be used as input to various problem types.
+
+Notes:
+- Any `Symbol`, `sym`, within `symmap` must be a valid field of `sys`. i.e.
+  `sys.sym` must be defined.
 """
 function symmap_to_varmap(sys, symmap::Tuple)
     all(p -> p isa Pair{Symbol}, symmap) || error("All entries in the map must be of the form Symbol => value.")
@@ -471,7 +475,7 @@ symmap_to_varmap(sys, symmap::AbstractArray{Pair{Symbol,T}}) where {T} =
 symmap_to_varmap(sys, symmap::Dict{Symbol,T}) where {T} = 
     Dict(_symbol_to_var(sys,sym) => val for (sym,val) in symmap)
 
-# don't permute any other types, and let varmap_to_vars handle erroring
+# don't permute any other types and let varmap_to_vars handle erroring
 symmap_to_varmap(sys, symmap) = symmap
 #error("symmap_to_varmap requires a Dict, AbstractArray or Tuple to map Symbols to values.")
     

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -386,7 +386,7 @@ collate them into one system before calling.
 function unpacksys(rn::MT.AbstractSystem) 
     ex = :(begin end)
     for key in keys(rn.var_to_name)
-        var = ModelingToolkit.getproperty(rn, key, namespace=false)
+        var = MT.getproperty(rn, key, namespace=false)
         push!(ex.args, :($key = $var))
     end    
     ex

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -377,13 +377,18 @@ eval(ex)
 @show S
 ```
 will load the symbolic variables, `S`, `I`, `R`, `ν` and `β`
+
+Notes:
+- Can not be used to load species, variables, or parameters of subsystems.
+Either call `unpacksys` on those systems directly, or [`flatten`](@ref) to
+collate them into one system before setting defaults.
 """
-function unpacksys(rn::MT.AbstractSystem)
+function unpacksys(rn::MT.AbstractSystem) 
     ex = :(begin end)
-    for (key,val) in rn.var_to_name
+    for key in keys(rn.var_to_name)
         var = ModelingToolkit.getproperty(rn, key, namespace=false)
         push!(ex.args, :($key = $var))
-    end
+    end    
     ex
 end
 

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -385,7 +385,7 @@ collate them into one system before calling.
 """
 function unpacksys(rn::MT.AbstractSystem) 
     ex = :(begin end)
-    for key in keys(rn.var_to_name)
+    for key in keys(get_var_to_name(rn))
         var = MT.getproperty(rn, key, namespace=false)
         push!(ex.args, :($key = $var))
     end    
@@ -959,11 +959,7 @@ function addspecies!(network::ReactionSystem, s::Symbolic; disablechecks=false)
     curidx = disablechecks ? nothing : findfirst(S -> isequal(S, s), get_states(network))
     if curidx === nothing
         push!(get_states(network), s)
-        MT.process_variables!(
-            MT.get_var_to_name(network),
-            get_defaults(network),
-            get_states(network)
-        )
+        MT.process_variables!(get_var_to_name(network), get_defaults(network), [s])
         return length(get_states(network))
     else
         return curidx
@@ -1021,11 +1017,7 @@ function addparam!(network::ReactionSystem, p::Symbolic; disablechecks=false)
     curidx = disablechecks ? nothing : findfirst(S -> isequal(S, p), get_ps(network))
     if curidx === nothing
         push!(get_ps(network), p)
-        MT.process_variables!(
-            MT.get_var_to_name(network),
-            get_defaults(network),
-            get_ps(network)
-        )
+        MT.process_variables!(get_var_to_name(network), get_defaults(network), [p])
         return length(get_ps(network))
     else
         return curidx

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -332,7 +332,7 @@ function netstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
 end
 
 """
-    setdefaults!(rn::MT.AbstractSystem, newdefs::AbstractVector{Pair{Symbol,T}})
+    setdefaults!(rn::ModelingToolkit.AbstractSystem, newdefs::AbstractVector{Pair{Symbol,T}})
 
 Sets the default (initial) values of parameters and species in `rn`.
 
@@ -358,6 +358,33 @@ function setdefaults!(rn::MT.AbstractSystem, newdefs::AbstractVector{Pair{Symbol
         rndefs[var] = val
     end
     nothing
+end
+
+"""
+    unpacksys(rn::ModelingToolkit.AbstractSystem)
+
+Generates an expression which if `eval`'ed will load all species, variables,
+parameters and observables defined in `rn` within the current context.
+
+For example,
+```julia
+sir = @reaction_network SIR begin
+    β, S + I --> 2I
+    ν, I --> R
+end β ν
+ex = unpacksys(sir)
+eval(ex)
+@show S
+```
+will load the symbolic variables, `S`, `I`, `R`, `ν` and `β`
+"""
+function unpacksys(rn::MT.AbstractSystem)
+    ex = :(begin end)
+    for (key,val) in rn.var_to_name
+        var = ModelingToolkit.getproperty(rn, key, namespace=false)
+        push!(ex.args, :($key = $var))
+    end
+    ex
 end
 
 ######################## reaction complexes and reaction rates ###############################

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -332,7 +332,7 @@ function netstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
 end
 
 """
-    setdefaults!(rn::MT.AbstractSystem, newdefs)
+    setdefaults!(rn::MT.AbstractSystem, newdefs::AbstractVector{Pair{Symbol,T}})
 
 Sets the default (initial) values of parameters and species in `rn`.
 
@@ -353,7 +353,7 @@ Notes:
 subsystems. Either set defaults for those systems directly, or [`flatten`](@ref)
 to collate them into one system before setting defaults.
 """
-function setdefaults!(rn::MT.AbstractSystem, newdefs)
+function setdefaults!(rn::MT.AbstractSystem, newdefs::AbstractVector{Pair{Symbol,T}}) where {T}
     rndefs = MT.get_defaults(rn)
     for (sym,val) in newdefs
         var = MT.getproperty(rn, sym, namespace=false)

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -388,9 +388,9 @@ end β ν
 will load the symbolic variables, `S`, `I`, `R`, `ν` and `β`.
 
 Notes:
-- Can not be used to load species, variables, or parameters of subsystems.
-Either call `@unpacksys` on those systems directly, or [`flatten`](@ref) to
-collate them into one system before calling.
+- Can not be used to load species, variables, or parameters of subsystems or
+constraints. Either call `@unpacksys` on those systems directly, or
+[`flatten`](@ref) to collate them into one system before calling.
 - Note that this places symbolic variables within the calling module's scope, so
 calling from a function defined in a script or the REPL will still result in the
 symbolic variables being defined in the `Main` module.

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -354,8 +354,8 @@ to collate them into one system before setting defaults.
 function setdefaults!(rn::MT.AbstractSystem, newdefs::AbstractVector{Pair{Symbol,T}}) where {T}
     rndefs = MT.get_defaults(rn)
     for (sym,val) in newdefs
-        var = MT.getproperty(rn, sym, namespace=false)
-        rndefs[var] = val
+        var = value(MT.getproperty(rn, sym, namespace=false))
+        rndefs[var] = value(val)
     end
     nothing
 end

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -381,7 +381,7 @@ will load the symbolic variables, `S`, `I`, `R`, `ν` and `β`
 Notes:
 - Can not be used to load species, variables, or parameters of subsystems.
 Either call `unpacksys` on those systems directly, or [`flatten`](@ref) to
-collate them into one system before setting defaults.
+collate them into one system before calling.
 """
 function unpacksys(rn::MT.AbstractSystem) 
     ex = :(begin end)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -833,7 +833,7 @@ Notes:
 - Currently only `ReactionSystem`s, `NonlinearSystem`s and `ODESystem`s are
   supported as sub-systems when flattening.
 """
-function flatten(rs::ReactionSystem; name=nameof(rs))
+function MT.flatten(rs::ReactionSystem; name=nameof(rs))
 
     isempty(get_systems(rs)) && return rs
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -586,16 +586,15 @@ sol2 = solve(op, Tsit5())
 @test norm(sol.u - sol2.u) ≈ 0
 
 function unpacktest(rn)
-    ex = unpacksys(rn)
-    eval(ex)
-    u₀ = [S => 999.0, I => 1.0, R => 0.0]
-    p = [α => 1e-4, β => .01]
+    Catalyst.@unpacksys rn
+    u₀ = [S1 => 999.0, I1 => 1.0, R1 => 0.0]
+    p = [α1 => 1e-4, β1 => .01]
     op = ODEProblem(rn, u₀, (0.0, 250.0), p)
     solve(op, Tsit5())    
 end
 rn = @reaction_network begin
-    α, S + I --> 2I
-    β, I --> R
-end α β
+    α1, S1 + I1 --> 2I1
+    β1, I1 --> R1
+end α1 β1
 sol3 = unpacktest(rn)
 @test norm(sol.u - sol3.u) ≈ 0

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -1,5 +1,4 @@
-using Catalyst, ModelingToolkit, OrdinaryDiffEq
-using LinearAlgebra: norm
+using Catalyst, ModelingToolkit
 
 # naming tests
 @parameters k

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -117,3 +117,18 @@ setdefaults!(rn, [:S => 999.0, :I => 1.0, :R => 0.0, :α => 1e-4, :β => .01])
 op = ODEProblem(rn, [], tspan, [])
 sol2 = solve(op, Tsit5())
 @test norm(sol.u - sol2.u) ≈ 0
+
+function unpacktest(rn)
+    ex = unpacksys(rn)
+    eval(ex)
+    u₀ = [S => 999.0, I => 1.0, R => 0.0]
+    p = [α => 1e-4, β => .01]
+    op = ODEProblem(rn, u₀, (0.0, 250.0), p)
+    solve(op, Tsit5())    
+end
+rn = @reaction_network begin
+    α, S + I --> 2I
+    β, I --> R
+end α β
+sol3 = unpacktest(rn)
+@test norm(sol.u - sol3.u) ≈ 0

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -1,4 +1,5 @@
-using Catalyst, ModelingToolkit, OrdinaryDiffEq, LinearAlgebra
+using Catalyst, ModelingToolkit, OrdinaryDiffEq
+using LinearAlgebra: norm
 
 # naming tests
 @parameters k
@@ -102,33 +103,3 @@ rn2 = ReactionSystem([Reaction(α+kk1*kk2*AA, [A, B], [A], [2, 1], [1])], t; nam
     Base.remove_linenums!(ex)
     @test eval(Catalyst.make_reaction_system(ex, (:Ka, :Cl, :Vc))) isa ReactionSystem
 end
-
-# test defaults
-rn = @reaction_network begin
-    α, S + I --> 2I
-    β, I --> R
-end α β
-p     = [.1/1000, .01]
-tspan = (0.0,250.0)
-u0    = [999.0,1.0,0.0]
-op    = ODEProblem(rn, species(rn) .=> u0, tspan, parameters(rn) .=> p)
-sol   = solve(op, Tsit5())  # old style 
-setdefaults!(rn, [:S => 999.0, :I => 1.0, :R => 0.0, :α => 1e-4, :β => .01])
-op = ODEProblem(rn, [], tspan, [])
-sol2 = solve(op, Tsit5())
-@test norm(sol.u - sol2.u) ≈ 0
-
-function unpacktest(rn)
-    ex = unpacksys(rn)
-    eval(ex)
-    u₀ = [S => 999.0, I => 1.0, R => 0.0]
-    p = [α => 1e-4, β => .01]
-    op = ODEProblem(rn, u₀, (0.0, 250.0), p)
-    solve(op, Tsit5())    
-end
-rn = @reaction_network begin
-    α, S + I --> 2I
-    β, I --> R
-end α β
-sol3 = unpacktest(rn)
-@test norm(sol.u - sol3.u) ≈ 0


### PR DESCRIPTION
Closes https://github.com/SciML/Catalyst.jl/issues/464.

When using the DSL, not having variables and parameters defined in the current context makes it annoying to construct parameter / initial condition mappings. This PR adds helpers to make this easier. 
```julia
rn = @reaction_network begin
    α, S + I --> 2I
    β, I --> R
end α β
defs = [:S => 999.0, :I => 1.0, :R => 0.0, :α => 1e-4, :β => .01]
setdefaults!(rn, defs)
op = ODEProblem(rn, [], tspan, [])
sol = solve(op, Tsit5())
```

The docs make clear that `setdefaults!` only acts on states and parameters at the level of a given system, so needs to be manually called on sub-systems in hierarchical models, or used after flattening.

Also added the ability to unpack all variables and parameters into the current context, e.g.
```julia
rn = @reaction_network begin
    α, S + I --> 2I
    β, I --> R
end α β
Catalyst.@unpacksys rn

# now this works
u₀ = [S => 999.0, I => 1.0, R => 0.0]
p = [α => 1e-4, β => .01]
op = ODEProblem(rn, u₀, (0.0, 250.0), p)
solve(op, Tsit5())    
```
This again does not recurse into subsystems, and is not currently exported or in the docs since it is implicitly `eval`ing into the user's calling module... (But this is useful in working with Catalyst for developing I've found.)

Finally, I added a way to specify initial condition and parameter maps using symbols:
```julia
sir = @reaction_network sir begin
    β, S + I --> 2I
    ν, I --> R
end β ν
subsys = @reaction_network subsys begin
    k, A --> B
end k
@named sys = compose(sir, [subsys])
symmap = [:S => 1.0, :I => 1.0, :R => 1.0, :subsys₊A => 1.0, :subsys₊B => 1.0]
u0map  = symmap_to_varmap(sys, symmap)
pmap   = symmap_to_varmap(sys, [:β => 1.0, :ν => 1.0, :subsys₊k => 1.0])
tspan = (0.0, 250.0)
oprob = ODEProblem(sys, u0map, tspan, pmap)  # this should now work
```
