### PR TITLE
@reaction macro

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,26 @@
 # Breaking updates and feature summaries across releases
 
 ## Catalyst unreleased (master branch) 
+- Added `@reaction` macro
+  ```julia
+  rx = @reaction k*v, A + B --> C + D
 
-## Catalyst 10.4.2
-- Fixed bugs in `extend` and in supporting namespacing for variables within constraint systems.
+  # is equivalent to
+  @parameters k v
+  @variables t A(t) B(t) C(t) D(t)
+  rx == Reaction(k*v, [A,B], [C,D])
+  ```
+  Here `k` and `v` will be parameters and `A`, `B`, `C` and `D` will be
+  variables. Interpolation of existing parameters/variables also works
+  ```julia
+  @parameters k b
+  @variables t A(t)
+  ex = k*A^2 + t
+  rx = @reaction b*$ex*$A, $A --> C
+  ```
+  Any symbols arising in the rate expression that aren't interpolated are
+  treated as parameters, while any in the reaction part (`A + B --> C + D`) are
+  treated as species.
 
 ## Catalyst 10.4
 - Added `symmap_to_varmap`, `setdefaults!`, and updated all `*Problem(rn,...)`

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -49,7 +49,7 @@ export get_constraints
 const ExprValues = Union{Expr,Symbol,Float64,Int}
 include("expression_utils.jl")
 include("reaction_network.jl")
-export @reaction_network, @add_reactions
+export @reaction_network, @add_reactions, @reaction
 
 # registers CRN specific functions using Symbolics.jl
 include("registered_functions.jl")

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -150,7 +150,7 @@ end
 ### Macros used for manipulating, and successively builing up, reaction systems. ###
 
 macro reaction(ex)
-    return make_reaction(ex)
+    make_reaction(ex)
 end
 
 """

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -205,15 +205,15 @@ function esc_dollars!(ex)
     ex
 end
 
-function symbolic_reaction(reaction)
-    subs_init = isempty(reaction.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
-    prod_init = isempty(reaction.products) ? nothing : :([]); prod_stoich_init = deepcopy(prod_init)
-    reaction_func = :(Reaction($(recursive_expand_functions!(reaction.rate)), $subs_init, $prod_init, $subs_stoich_init, $prod_stoich_init, only_use_rate=$(reaction.only_use_rate)))
-    for sub in reaction.substrates
+function symbolic_reaction(rxexpr)
+    subs_init = isempty(rxexpr.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
+    prod_init = isempty(rxexpr.products) ? nothing : :([]); prod_stoich_init = deepcopy(prod_init)
+    reaction_func = :(Reaction($(recursive_expand_functions!(rxexpr.rate)), $subs_init, $prod_init, $subs_stoich_init, $prod_stoich_init, only_use_rate=$(rxexpr.only_use_rate)))
+    for sub in rxexpr.substrates
         push!(reaction_func.args[3].args, sub.reactant)
         push!(reaction_func.args[5].args, sub.stoichiometry)
     end
-    for prod in reaction.products
+    for prod in rxexpr.products
         push!(reaction_func.args[4].args, prod.reactant)
         push!(reaction_func.args[6].args, prod.stoichiometry)
     end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -249,6 +249,54 @@ function make_reaction_system(ex::Expr, parameters; name=:(gensym(:ReactionSyste
     end
 end
 
+# function make_reaction(ex::Expr)
+
+#     # handle interpolation of variables
+#     ex = esc_dollars!(ex)
+
+#     # parse DSL lines
+#     reaction = get_reaction(ex)
+#     reactants = get_reactants(reactions)
+#     allspecies = union(reactants, get_rate_species(reactions,parameters))
+#     !isempty(intersect(forbidden_symbols,union(allspecies,parameters))) &&
+#         error("The following symbol(s) are used as species or parameters: "*((map(s -> "'"*string(s)*"', ",intersect(forbidden_symbols,union(species,parameters)))...))*"this is not permited.")
+
+#     # parameters
+#     pexprs = isempty(parameters) ? :() : :(@parameters)
+#     if !isempty(parameters)
+#         foreach(parameter-> push!(pexprs.args, parameter), parameters)
+#     end
+
+#     # species
+#     sexprs = :(@variables t)
+#     foreach(species -> (species isa Symbol) && push!(sexprs.args, Expr(:call,species,:t)), allspecies)
+
+#     # ReactionSystem
+#     rxexprs = :($(make_ReactionSystem_internal)([],t,nothing,[]; name=$(name)))
+#     foreach(parameter -> push!(rxexprs.args[6].args,parameter), parameters)
+#     for reaction in reactions
+#         subs_init = isempty(reaction.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
+#         prod_init = isempty(reaction.products) ? nothing : :([]); prod_stoich_init = deepcopy(prod_init)
+#         reaction_func = :(Reaction($(recursive_expand_functions!(reaction.rate)), $subs_init, $prod_init, $subs_stoich_init, $prod_stoich_init, only_use_rate=$(reaction.only_use_rate)))
+#         for sub in reaction.substrates
+#             push!(reaction_func.args[3].args, sub.reactant)
+#             push!(reaction_func.args[5].args, sub.stoichiometry)
+#         end
+#         for prod in reaction.products
+#             push!(reaction_func.args[4].args, prod.reactant)
+#             push!(reaction_func.args[6].args, prod.stoichiometry)
+#         end
+#         push!(rxexprs.args[3].args,reaction_func)
+#     end
+
+#     quote
+#         _ps = $pexprs
+#         $sexprs
+#         $rxexprs
+#     end
+# end
+
+
 
 function get_rate_species(rxs, ps)
     pset = Set(ps)
@@ -273,22 +321,43 @@ function find_species_in_rate!(sset, rateex::ExprValues, ps)
     nothing
 end
 
+function get_reaction(line)
+    (line.head != :tuple) && error("Malformed reaction line: $line") 
+    (rate,r_line) = line.args
+    (r_line.head  == :-->) && (r_line = Expr(:call,:→,r_line.args[1],r_line.args[2]))
+
+    arrow = r_line.args[1]
+    in(arrow,double_arrows) && error("Double arrows not allowed for single reactions.")
+
+    only_use_rate = in(arrow,pure_rate_arrows)
+    if in(arrow,fwd_arrows)
+        rs = create_ReactionStruct(r_line.args[2], r_line.args[3], rate, only_use_rate)
+    elseif in(arrow,bwd_arrows)
+        rs = create_ReactionStruct(r_line.args[3], r_line.args[2], rate, only_use_rate)
+    else
+        throw("malformed reaction")
+    end
+
+    rs
+end
+
 #Generates a vector containing a number of reaction structures, each containing the information about one reaction.
 function get_reactions(ex::Expr, reactions = Vector{ReactionStruct}(undef,0))
     for line in ex.args
-        (line.head != :tuple) && (continue)
+        (line.head != :tuple) && error("Malformed reaction line: $line") 
         (rate,r_line) = line.args
         (r_line.head  == :-->) && (r_line = Expr(:call,:→,r_line.args[1],r_line.args[2]))
 
         arrow = r_line.args[1]
+        only_use_rate = in(arrow,pure_rate_arrows)
         if in(arrow,double_arrows)
             (typeof(rate) == Expr && rate.head == :tuple) || error("Error: Must provide a tuple of reaction rates when declaring a bi-directional reaction.")
-            push_reactions!(reactions, r_line.args[2], r_line.args[3], rate.args[1], in(arrow,pure_rate_arrows))
-            push_reactions!(reactions, r_line.args[3], r_line.args[2], rate.args[2], in(arrow,pure_rate_arrows))
+            push_reactions!(reactions, r_line.args[2], r_line.args[3], rate.args[1], only_use_rate)
+            push_reactions!(reactions, r_line.args[3], r_line.args[2], rate.args[2], only_use_rate)
         elseif in(arrow,fwd_arrows)
-            push_reactions!(reactions, r_line.args[2], r_line.args[3], rate, in(arrow,pure_rate_arrows))
+            push_reactions!(reactions, r_line.args[2], r_line.args[3], rate, only_use_rate)
         elseif in(arrow,bwd_arrows)
-            push_reactions!(reactions, r_line.args[3], r_line.args[2], rate, in(arrow,pure_rate_arrows))
+            push_reactions!(reactions, r_line.args[3], r_line.args[2], rate, only_use_rate)
         else
             throw("malformed reaction")
         end
@@ -296,9 +365,15 @@ function get_reactions(ex::Expr, reactions = Vector{ReactionStruct}(undef,0))
     return reactions
 end
 
+function create_ReactionStruct(sub_line::ExprValues, prod_line::ExprValues, rate::ExprValues, only_use_rate::Bool)
+    all(==(1), (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate))) ||
+        error("Malformed line, appears to be defining multiple reactions.")
+    ReactionStruct(get_tup_arg(sub_line,1), get_tup_arg(prod_line,1), get_tup_arg(rate,1), only_use_rate)
+end
+
 #Takes a reaction line and creates reactions from it and pushes those to the reaction array. Used to create multiple reactions from, for instance, 1.0, (X,Y) --> 0.
 function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues, prod_line::ExprValues, rate::ExprValues, only_use_rate::Bool)
-    lengs = [tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate)]
+    lengs = (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate))
     for i = 1:maximum(lengs)
         (count(lengs.==1) + count(lengs.==maximum(lengs)) < 3) && (throw("malformed reaction"))
         push!(reactions, ReactionStruct(get_tup_arg(sub_line,i), get_tup_arg(prod_line,i), get_tup_arg(rate,i), only_use_rate))
@@ -327,15 +402,20 @@ function recursive_find_reactants!(ex::ExprValues, mult::Int, reactants::Vector{
     return reactants
 end
 
-# Extract the reactants from the set of reactions.
-function get_reactants(reactions::Vector{ReactionStruct})
-    reactants = Vector{Union{Symbol,Expr}}()
-    for reaction in reactions, reactant in union(reaction.substrates,reaction.products)
+function get_reactants(reaction::ReactionStruct, reactants=Vector{Union{Symbol,Expr}}())
+    for reactant in Iterators.flatten((reaction.substrates,reaction.products))
         !in(reactant.reactant,reactants) && push!(reactants,reactant.reactant)
     end
     return reactants
 end
 
+# Extract the reactants from the set of reactions.
+function get_reactants(reactions::Vector{ReactionStruct}, reactants=Vector{Union{Symbol,Expr}}())
+    for reaction in reactions
+        get_reactants(reaction, reactants)
+    end
+    return reactants
+end
 
 ### Functionality for expanding function call to custom and specific functions ###
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -205,15 +205,15 @@ function esc_dollars!(ex)
     ex
 end
 
-function symbolic_reaction(rxexpr)
-    subs_init = isempty(rxexpr.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
-    prod_init = isempty(rxexpr.products) ? nothing : :([]); prod_stoich_init = deepcopy(prod_init)
-    reaction_func = :(Reaction($(recursive_expand_functions!(rxexpr.rate)), $subs_init, $prod_init, $subs_stoich_init, $prod_stoich_init, only_use_rate=$(rxexpr.only_use_rate)))
-    for sub in rxexpr.substrates
+function symbolic_reaction(rxstruct)
+    subs_init = isempty(rxstruct.substrates) ? nothing : :([]); subs_stoich_init = deepcopy(subs_init)
+    prod_init = isempty(rxstruct.products) ? nothing : :([]); prod_stoich_init = deepcopy(prod_init)
+    reaction_func = :(Reaction($(recursive_expand_functions!(rxstruct.rate)), $subs_init, $prod_init, $subs_stoich_init, $prod_stoich_init, only_use_rate=$(rxstruct.only_use_rate)))
+    for sub in rxstruct.substrates
         push!(reaction_func.args[3].args, sub.reactant)
         push!(reaction_func.args[5].args, sub.stoichiometry)
     end
-    for prod in rxexpr.products
+    for prod in rxstruct.products
         push!(reaction_func.args[4].args, prod.reactant)
         push!(reaction_func.args[6].args, prod.stoichiometry)
     end

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -102,3 +102,15 @@ rn2 = ReactionSystem([Reaction(α+kk1*kk2*AA, [A, B], [A], [2, 1], [1])], t; nam
     Base.remove_linenums!(ex)
     @test eval(Catalyst.make_reaction_system(ex, (:Ka, :Cl, :Vc))) isa ReactionSystem
 end
+
+
+rx = @reaction k*h, A + 2*B --> 3*C + D
+@parameters k h
+@variables t A(t) B(t) C(t) D(t)
+@test rx == Reaction(k*h,[A,B],[C,D],[1,2],[3,1])
+
+ex = k*A^2 + B
+V  = A
+rx = @reaction b+$ex, 2*$V + C--> ∅
+@parameters b
+@test rx == Reaction(b+ex, [A,C], nothing, [2,1], nothing)


### PR DESCRIPTION
Allows
```julia
rx = @reaction k*v, A + B --> C + D
```
where `k` and `v` will be parameters and `A`, `B`, `C` and `D` will be variables.

Interpolation of existing parameters/variables also works
```julia
@parameters k b
@variables t A(t)
ex = k*A^2 + t
rx = @reaction b*$ex*$A, B --> C
```
Any symbols arising in the rate expression that aren't interpolated are treated as parameters, while any in the reaction part (`A + B --> C + D`) are treated as species. 

We could potentially make a (future) breaking release that tries to detect if a symbol is defined in the calling module, and if so uses it. If not defined, it defines it per the convention above (avoiding the need to use `$A` like above). I think it makes sense to add that for both this macro and the `@reaction_network` macro at the same time now that they are pretty much using the same code.

cc: @ChrisRackauckas 
