### PR TITLE
Allow float stoichiometry

### DIFF
--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -398,7 +398,7 @@ function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues
 end
 
 #Recursive function that loops through the reaction line and finds the reactants and their stoichiometry. Recursion makes it able to handle weird cases like 2(X+Y+3(Z+XY)).
-function recursive_find_reactants!(ex::ExprValues, mult::Int, reactants::Vector{ReactantStruct})
+function recursive_find_reactants!(ex::ExprValues, mult::Number, reactants::Vector{ReactantStruct})
     if typeof(ex)!=Expr || (ex.head == :escape)
         (ex == 0 || in(ex,empty_set)) && (return reactants)
         if in(ex, getfield.(reactants,:reactant))

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -111,10 +111,10 @@ function print_rxside(io::IO, specs, stoich)
         print(io, "∅")
     else
         for (i,spec) in enumerate(specs)
-            if stoich[i] == one(eltype(stoich))
+            if isequal(stoich[i],one(eltype(stoich)))
                 print(io, ModelingToolkit.operation(spec))
             else
-                print(io, stoich[i], ModelingToolkit.operation(spec))
+                print(io, stoich[i], "*", ModelingToolkit.operation(spec))
             end
 
             (i < length(specs)) && print(io, " + ")
@@ -151,7 +151,7 @@ function get_netstoich(subs, prods, sstoich, pstoich)
     end
 
     # stoichiometry as a vector
-    ns = [el for el in nsdict if el[2] != zero(el[2])]
+    ns = [el for el in nsdict if !isequal(el[2],_iszero(el[2]))]
 
     ns
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -151,7 +151,7 @@ function get_netstoich(subs, prods, sstoich, pstoich)
     end
 
     # stoichiometry as a vector
-    ns = [el for el in nsdict if !isequal(el[2],_iszero(el[2]))]
+    ns = [el for el in nsdict if !isequal(el[2],zero(el[2]))]
 
     ns
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -430,7 +430,7 @@ function oderatelaw(rx; combinatoric_ratelaw=true)
 
     # if the stoichiometric coefficients are not integers error if asking to scale rates
     !(eltype(substoich) <: Integer) && (combinatoric_ratelaw==true) && 
-        error("Non-integer stoichiometric coefficients require the combinatoric_ratelaw=false keyword to oderatelaw, or passing combinatoric_ratelaws=false to convert.")
+        error("Non-integer stoichiometric coefficients require the combinatoric_ratelaw=false keyword to oderatelaw, or passing combinatoric_ratelaws=false to convert or ODEProblem.")
 
     if !only_use_rate
         coef = one(eltype(substoich))

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -422,15 +422,15 @@ Notes:
 - `combinatoric_ratelaw=true` uses factorial scaling factors in calculating the
     rate law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
     `combinatoric_ratelaw=false` then the ratelaw is `k*S^2`, i.e. the scaling
-    factor is ignored. It is also ignored *for an individual reaction* if the
-    stoichiometric coefficients are non-integer.
+    factor is ignored. 
 """
 function oderatelaw(rx; combinatoric_ratelaw=true)
     @unpack rate, substrates, substoich, only_use_rate = rx
     rl = rate
 
-    # if the stoichiometric coefficients are not integers don't scale the rate
-    !(eltype(substoich) <: Integer) && (combinatoric_ratelaw=false)
+    # if the stoichiometric coefficients are not integers error if asking to scale rates
+    !(eltype(substoich) <: Integer) && (combinatoric_ratelaw==true) && 
+        error("Non-integer stoichiometric coefficients require the combinatoric_ratelaw=false keyword to oderatelaw, or passing combinatoric_ratelaws=false to convert.")
 
     if !only_use_rate
         coef = one(eltype(substoich))

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -151,7 +151,7 @@ function get_netstoich(subs, prods, sstoich, pstoich)
     end
 
     # stoichiometry as a vector
-    ns = [el for el in nsdict if !isequal(el[2],zero(el[2]))]
+    ns = [el for el in nsdict if !_iszero(el[2])]
 
     ns
 end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -64,30 +64,42 @@ end
 
 function Reaction(rate, subs, prods, substoich, prodstoich;
                   netstoich=nothing, only_use_rate=false,
-                  kwargs...)
-
+                  kwargs...) 
+    
     (isnothing(prods)&&isnothing(subs)) && error("A reaction requires a non-nothing substrate or product vector.")
     (isnothing(prodstoich)&&isnothing(substoich)) && error("Both substrate and product stochiometry inputs cannot be nothing.")
     if isnothing(subs)
         subs = Vector{Term}()
         !isnothing(substoich) && error("If substrates are nothing, substrate stiocihometries have to be so too.")
-        substoich = typeof(prodstoich)()
+        substoich = typeof(prodstoich)()        
     end
+    S = eltype(substoich)        
+
     if isnothing(prods)
         prods = Vector{Term}()
         !isnothing(prodstoich) && error("If products are nothing, product stiocihometries have to be so too.")
         prodstoich = typeof(substoich)()
     end
+    T = eltype(prodstoich)
+
     subs = value.(subs)
     prods = value.(prods)
-    ns = isnothing(netstoich) ? get_netstoich(subs, prods, substoich, prodstoich) : netstoich
-    Reaction(value(rate), subs, prods, substoich, prodstoich, ns, only_use_rate)
+
+    stoich_type = promote_type(S,T)
+    substoich′ = (S == stoich_type) ? substoich : convert.(stoich_type, substoich)
+    prodstoich′ = (T == stoich_type) ? prodstoich : convert.(stoich_type, prodstoich)    
+    ns = if netstoich === nothing
+        get_netstoich(subs, prods, substoich′, prodstoich′) 
+    else
+        (netstoich_stoichtype(netstoich) != stoich_type) ? 
+            convert.(stoich_type, netstoich) : netstoich
+    end
+    Reaction(value(rate), subs, prods, substoich′, prodstoich′, ns, only_use_rate)
 end
 
 
 # three argument constructor assumes stoichiometric coefs are one and integers
 function Reaction(rate, subs, prods; kwargs...)
-
     sstoich = isnothing(subs) ? nothing : ones(Int,length(subs))
     pstoich = isnothing(prods) ? nothing : ones(Int,length(prods))
     Reaction(rate, subs, prods, sstoich, pstoich; kwargs...)
@@ -99,7 +111,7 @@ function print_rxside(io::IO, specs, stoich)
         print(io, "∅")
     else
         for (i,spec) in enumerate(specs)
-            if stoich[i] == 1
+            if stoich[i] == one(eltype(stoich))
                 print(io, ModelingToolkit.operation(spec))
             else
                 print(io, stoich[i], ModelingToolkit.operation(spec))
@@ -126,6 +138,8 @@ function ModelingToolkit.namespace_equation(rx::Reaction, name)
              subs, prods, rx.substoich, rx.prodstoich,
              [namespace_expr(n[1],name) => n[2] for n in rx.netstoich], rx.only_use_rate)
 end
+
+netstoich_stoichtype(::Vector{Pair{S,T}}) where {S,T} = T
 
 # calculates the net stoichiometry of a reaction as a vector of pairs (sub,substoich)
 function get_netstoich(subs, prods, sstoich, pstoich)
@@ -396,8 +410,8 @@ generated ODEs for the reaction. Note, for a reaction defined by
 
 `k*X*Y, X+Z --> 2X + Y`
 
-the expression that is returned will be `k*X(t)^2*Y(t)*Z(t)`. For a reaction
-of the form
+the expression that is returned will be `k*X(t)^2*Y(t)*Z(t)`. For a reaction of
+the form
 
 `k, 2X+3Y --> Z`
 
@@ -405,19 +419,24 @@ the expression that is returned will be `k * (X(t)^2/2) * (Y(t)^3/6)`.
 
 Notes:
 - Allocates
-- `combinatoric_ratelaw=true` uses factorial scaling factors in calculating the rate
-    law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
-    `combinatoric_ratelaw=false` then the ratelaw is `k*S^2`, i.e. the scaling factor is
-    ignored.
+- `combinatoric_ratelaw=true` uses factorial scaling factors in calculating the
+    rate law, i.e. for `2S -> 0` at rate `k` the ratelaw would be `k*S^2/2!`. If
+    `combinatoric_ratelaw=false` then the ratelaw is `k*S^2`, i.e. the scaling
+    factor is ignored. It is also ignored *for an individual reaction* if the
+    stoichiometric coefficients are non-integer.
 """
 function oderatelaw(rx; combinatoric_ratelaw=true)
     @unpack rate, substrates, substoich, only_use_rate = rx
     rl = rate
+
+    # if the stoichiometric coefficients are not integers don't scale the rate
+    !(eltype(substoich) <: Integer) && (combinatoric_ratelaw=false)
+
     if !only_use_rate
         coef = one(eltype(substoich))
         for (i,stoich) in enumerate(substoich)
-            coef *= factorial(stoich)
-            rl   *= isone(stoich) ? substrates[i] : substrates[i]^stoich
+            combinatoric_ratelaw && (coef *= factorial(stoich))
+            rl *= isone(stoich) ? substrates[i] : substrates[i]^stoich
         end
         combinatoric_ratelaw && (!isone(coef)) && (rl /= coef)
     end

--- a/test/dsl.jl
+++ b/test/dsl.jl
@@ -114,3 +114,18 @@ V  = A
 rx = @reaction b+$ex, 2*$V + C--> ∅
 @parameters b
 @test rx == Reaction(b+ex, [A,C], nothing, [2,1], nothing)
+
+### test floating point stoichiometry work ###
+@parameters k 
+@variables t B(t) C(t) D(t)
+rx1 = Reaction(k,[B,C],[B,D], [2.5,1],[3.5, 2.5])
+rx2 = Reaction(2*k, [B], [D], [1], [2.5])
+rx3 = Reaction(2*k, [B], [D], [2.5], [2])
+@named mixedsys = ReactionSystem([rx1,rx2,rx3],t,[B,C,D],[k])
+osys = convert(ODESystem, mixedsys; combinatoric_ratelaws=false)
+rn = @reaction_network mixedsys begin
+    k, 2.5*B + C --> 3.5*B + 2.5*D
+    2*k, B --> 2.5*D
+    2*k, 2.5*B --> 2*D
+end k
+@test rn == mixedsys

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -290,3 +290,12 @@ obs = [Equation(L, 2*x + y)]
 L2 = L
 @unpack L = rs3
 @test isequal(L,L2)
+
+# test non-integer stoichiometry goes through
+@parameters k b
+@variables t A(t) B(t) C(t) D(t)
+rx1 = Reaction(k,[B,C],[B,D], [2.5,1],[3.5, 2.5])
+rx2 = Reaction(2*k, [B], [D], [1], [2.5])
+rx3 = Reaction(2*k, [B], [D], [2.5], [2])
+@named mixedsys = ReactionSystem([rx1,rx2,rx3],t,[A,B,C,D],[k,b])
+osys = convert(ODESystem, mixedsys; combinatoric_ratelaws=false)

--- a/test/solve_ODEs.jl
+++ b/test/solve_ODEs.jl
@@ -127,3 +127,23 @@ for factor in [1e0, 1e1, 1e2]
     sol = solve(prob,Rosenbrock23())
     @test abs.(sol.u[end][1] - 1.5/2) < 1e-8
 end
+
+
+### test solving with floating point stoichiometry ###
+function oderhs(du,u,p,t)
+    du[1] = -2.5*p[1]*u[1]^2.5
+    du[2] = 3*p[1]*u[1]^2.5
+    nothing
+end
+rn = @reaction_network begin
+    k, 2.5*A --> 3*B
+end
+u0 = [:A => 1.0,:B => 0.0]
+tspan = (0.0,1.0)
+p = [:k => 1.0]
+oprob = ODEProblem(rn, u0, tspan, p; combinatoric_ratelaws=false)
+du1 = du2 = zeros(2)
+u = rand(2)
+oprob.f(du1,u,[1.0],0.0)
+oderhs(du2,u,[1.0],0.0)
+@test isapprox(du1, du2, rtol=1e3*eps()) 

--- a/test/solve_ODEs.jl
+++ b/test/solve_ODEs.jl
@@ -137,7 +137,7 @@ function oderhs(du,u,p,t)
 end
 rn = @reaction_network begin
     k, 2.5*A --> 3*B
-end
+end k
 u0 = [:A => 1.0,:B => 0.0]
 tspan = (0.0,1.0)
 p = [:k => 1.0]


### PR DESCRIPTION
There is a decision to be made on the default conventions. 

Prior to this PR we always scaled ODE and jump rates by a combinatorial factor, treating the rate constants as microscopic rate constants. In this way our ODE models are the mean-field of our jump models.

However, such a scaling doesn't seem to me to make sense when having non-integer stoichiometry coefficients (unless we want to restrict non-integer stoichiometry to products and not allow for reactants, or scale by a gamma function which seems weird). 

In this PR I set the conventions as:
1. All the reactant and product stoichiometry of a given reaction are promoted to the same type.
2. If this type is an integer we rescale by default as we currently do.
3. If this type is not integer we error if the user does not explicitly turn off rescaling.

We could alternatively just rescale silently for the rate law of an individual reaction that involves non-integer stoichiometry. The problem is then users will get a mix of rescaled and not rescaled rate laws, which seems worse than giving them a useful error and forcing them to understand that they must turn off rescaling.

edit: This will also only work for ODEs currently, but I think that is fine as it is unclear to me what a non-integer stoichiometry even means in the stochastic case (i.e. what are the jump model's rate laws).