### PR TITLE
Elimination of conservation laws

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,50 @@
 # Breaking updates and feature summaries across releases
 
-## Catalyst unreleased (master branch) 
+## Catalyst unreleased (master branch)
+- **BREAKING:** Added the ability to eliminate conserved species when generating
+  ODEs, nonlinear problems, and steady-state problems via the
+  `remove_conserved=true` keyword that can be passed to `convert` or to
+  `ODEProblem`, `NonlinearProblem` or `SteadyStateProblem` when called with a
+  `ReactionSystem`. For example,
+  ```julia
+  rn = @reaction_network begin
+     k, A + B --> C
+     k2, C --> A + B
+     end k k2
+  osys = convert(ODESystem, rn; remove_conserved=true)
+  equations(osys)
+  ```
+  gives
+  ```
+  Differential(t)(A(t)) ~ k2*(_ConLaw[2] - A(t)) - k*(A(t) + _ConLaw[1])*A(t)
+  ```
+  Initial conditions should still be specified for all the species in `rn`, and
+  the conserved constants will then be calculated automatically. Eliminated
+  species are stored as observables in `osys` and still accessible via solution
+  objects. Breaking as this required modifications to the `ReactionSystem` type
+  signature.
+- **BREAKING:** Added an internal cache in `ReactionSystem`s for network properties, and
+  revamped many of the network analysis functions to use this cache (so just a
+  `ReactionSystem` can be passed in). Most of these functions will now only
+  calculate the chosen property the first time they are called, and in
+  subsequent calls will simply returned that cached value. Call
+  `reset_networkproperties!` to clear the cache and allow properties to be
+  recalculated. The new signatures for `rn` a `ReactionSystem` are
+  ```julia
+  reactioncomplexmap(rn)
+  reactioncomplexes(rn)
+  complexstoichmat(rn)
+  complexoutgoingmat(rn)
+  incidencematgraph(rn)
+  linkageclasses(rn)
+  deficiency(rn)
+  sns = subnetworks(rn)
+  linkagedeficiencies(rn)
+  isreversible(rn)
+  isweaklyreversible(rn, sns)
+  ```
+  Breaking as this required modifications to the `ReactionSystem` type
+  signature.
 
 ## Catalyst 10.8
 - Added the ability to use symbolic stoichiometry expressions via the DSL. This should now work
@@ -8,7 +52,7 @@
   rn = @reaction_network rs begin
     t*k, (α+k+B)*A --> B
     1.0, α*A + 2*B --> k*C + α*D
-  end k α 
+  end k α
   ```
   Here Catalyst will try to preserve the order of symbols within an expression,
   taking the rightmost as the species and everything multiplying that species as
@@ -18,9 +62,9 @@
   ```julia
   rn = @reaction_network rs begin
     1.0, 2X*(Y + Z) --> XYZ
-  end 
+  end
   ```
-  all of `X`, `Y` and `Z` will be registered as species, with substrates `(Y,Z)` having associated stoichiometries of 
+  all of `X`, `Y` and `Z` will be registered as species, with substrates `(Y,Z)` having associated stoichiometries of
   `(2X,2X)`. As for rate expressions, any symbols that appear and are not defined as parameters will be declared to be species.
 
   In contrast, when declaring reactions
@@ -105,7 +149,7 @@
   end α β
   setdefaults!(rn, [:S => 999.0, :I => 1.0, :R => 0.0, :α => 1e-4, :β => .01])
   op    = ODEProblem(rn, [], (0.0,250.0), [])
-  sol   = solve(op, Tsit5()) 
+  sol   = solve(op, Tsit5())
   ```
   To explicitly pass initial conditions and parameters using symbols we can do
   ```julia
@@ -116,7 +160,7 @@
   u0 = [:S => 999.0, :I => 1.0, :R => 0.0]
   p  = (:α => 1e-4, :β => .01)
   op    = ODEProblem(rn, u0, (0.0,250.0), p)
-  sol   = solve(op, Tsit5())  
+  sol   = solve(op, Tsit5())
   ```
   In each case ModelingToolkit symbolic variables can be used instead of
   `Symbol`s, e.g.
@@ -174,8 +218,8 @@
   ```
 - Added the ability to compose `ReactionSystem`s via subsystems, and include
   either `ODESystem`s or `NonlinearSystem`s as subsystems. Note, if using
-  non-`ReactionSystem` subsystems it is not currently possible to convert to 
-  a `JumpSystem` or `SDESystem`. It is also not possible to include either 
+  non-`ReactionSystem` subsystems it is not currently possible to convert to
+  a `JumpSystem` or `SDESystem`. It is also not possible to include either
   `SDESystem`s or `JumpSystems` as subsystems.
 - Added `extend(sys, reactionnetwork, name=nameof(sys))` to extend
   `ReactionSystem`s with constraint equations (algebraic equations or ODEs), or
@@ -213,7 +257,7 @@ reactions they participate in.
 If passed `sparse=true` a sparse matrix representation is generated, otherwise
 the default `sparse=false` value returns dense `Matrix` representations.
 
-## Catalyst 8.3 
+## Catalyst 8.3
 *1.* Network representations for the reaction complexes of a system along with
 associated graph functionality:
 ```julia
@@ -235,12 +279,12 @@ which gives
 
 ![rn_complexes](https://user-images.githubusercontent.com/9385167/130252763-4418ba5a-164f-47f7-b512-a768e4f73834.png)
 
-*2.* Support for units via ModelingToolkit and 
+*2.* Support for units via ModelingToolkit and
 [Uniftul.jl](https://github.com/PainterQubits/Unitful.jl) in directly constructed
 `ReactionSystem`s:
 ```julia
 # ]add Unitful
-using Unitful 
+using Unitful
 @parameters α [unit=u"μM/s"] β [unit=u"s"^(-1)] γ [unit=u"μM*s"^(-1)]
 @variables t [unit=u"s"] A(t) [unit=u"μM"] B(t) [unit=u"μM"] C(t) [unit=u"μM"]
 rxs = [Reaction(α, nothing, [A]),
@@ -259,7 +303,7 @@ which will print warnings and return `false` if either
 
 (Note, at this time the `@reaction_network` macro does not support units.)
 
-*3.* Calculation of conservation laws 
+*3.* Calculation of conservation laws
 ```julia
 rn = @reaction_network begin
   (k₊,k₋), A + B <--> C
@@ -295,13 +339,13 @@ network matrix representations.
 
 ## Catalyst 8.0
 **BREAKING:** This is a breaking release, with all ModelingToolkit `ReactionSystem` and
-`Reaction` functionality migrated to Catalyst. 
+`Reaction` functionality migrated to Catalyst.
 
 ## Catalyst 6.11
 *1.* Plain text arrows "<--" and "<-->" for backward and reversible reactions are
    available if using Julia 1.6 or higher:
 ```julia
-rn = @reaction_network begin 
+rn = @reaction_network begin
   (k1,k2), A + B <--> C
   k3, 0 <-- C
 end k1 k2 k3
@@ -311,7 +355,7 @@ end k1 k2 k3
 rn = @reaction_network Reversible_Reaction begin
   k1, A --> B
   k2, B --> A
-  end k1 k2 
+  end k1 k2
 nameof(rn) == :Reversible_Reaction
 ```
 Note, empty networks can no longer be created with parameters, i.e. only

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
 version = "10.8.0"
 
 [deps]
-AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqJump = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
@@ -20,7 +19,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-AbstractAlgebra = "0.21, 0.22, 0.23, 0.24, 0.25"
 DataStructures = "0.18"
 DiffEqBase = "6.54.0"
 DiffEqJump = "7.0, 8.0"

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -33,7 +33,7 @@ directly generate a collection of [`Reaction`](@ref)s and a corresponding
 SIR example how a system can be directly constructed, and demonstrate how to
 then generate from the [`ReactionSystem`](@ref) and solve corresponding chemical
 reaction ODE models, chemical Langevin equation SDE models, and stochastic
-chemical kinetics jump process models. 
+chemical kinetics jump process models.
 
 ```julia
 using Catalyst, OrdinaryDiffEq, StochasticDiffEq, DiffEqJump
@@ -91,9 +91,9 @@ sub-systems of `rn`, one can use the ModelingToolkit accessors (these provide
 direct access to the corresponding internal fields of the `ReactionSystem`)
 
 * `get_states(rn)` is a vector that collects all the species defined within
-  `rn`. 
+  `rn`.
 * `get_ps(rn)` is a vector that collects all the parameters defined *within*
-  reactions in `rn`. 
+  reactions in `rn`.
 * `get_eqs(rn)` is a vector that collects all the [`Reaction`](@ref)s defined
   within `rn`.
 * `get_iv(rn)` is the independent variable used in the system (usually `t` to
@@ -108,14 +108,14 @@ These are complemented by the Catalyst accessor
   none is defined will return `nothing`.
 
 The preceding accessors do not allocate, directly accessing internal fields of
-the `ReactionSystem`. 
+the `ReactionSystem`.
 
 To retrieve information from the full reaction network represented by a
 system `rn`, which corresponds to information within both `rn` and all
 sub-systems of type `ReactionSystem`, one can call:
 
 * [`species(rn)`](@ref) is a vector collecting all the chemical species within
-  the system and any sub-systems that are also `ReactionSystems`. 
+  the system and any sub-systems that are also `ReactionSystems`.
 * [`reactionparams(rn)`](@ref) is a vector of all the parameters within the
   system and any sub-systems that are also `ReactionSystem`s. These include all
   parameters that appear within some `Reaction`.
@@ -209,9 +209,10 @@ subnetworks
 linkagedeficiencies
 isreversible
 isweaklyreversible
+reset_networkproperties!
 ```
 
-## Network Comparison 
+## Network Comparison
 ```@docs
 ==(rn1::Reaction, rn2::Reaction)
 isequal_ignore_names

--- a/docs/src/tutorials/symbolic_stoich.md
+++ b/docs/src/tutorials/symbolic_stoich.md
@@ -99,7 +99,7 @@ As a second example, let's build the negative feedback model from [MomentClosure
 In our model `G₋` will denote the repressed state, and `G₊` the active state where the gene can transcribe. `P` will denote the protein product of the gene. We will assume that proteins are produced in bursts that produce `m` proteins, where `m` is a (shifted) geometric random variable with mean `b`. To define `m` we must register the `Distributions.Geometric` distribution from Distributions.jl with Symbolics.jl, after which we can use it in symbolic expressions:
 ```@example s1
 using Distributions: Geometric
-@register Geometric(b)
+@register_symbolic Geometric(b)
 @parameters b
 m = rand(Geometric(1/b)) + 1
 nothing # hide

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -21,6 +21,8 @@ import ModelingToolkit: check_variables, check_parameters, _iszero, _merge, chec
 
 import Base: (==), hash, size, getindex, setindex, isless, Sort.defalg, length, show
 import MacroTools, Graphs
+import DataStructures: OrderedDict, OrderedSet
+import Parameters: @with_kw_noshow
 
 # globals for the modulate
 const DEFAULT_IV = (@parameters t)[1]
@@ -73,8 +75,6 @@ export incidencematgraph, linkageclasses, deficiency, subnetworks, linkagedefici
 include("latexify_recipes.jl")
 
 # for making and saving graphs
-import DataStructures: OrderedDict, OrderedSet
-import Parameters: @with_kw_noshow
 include("graphs.jl")
 export Graph, savegraph, complexgraph
 

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -20,10 +20,9 @@ import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_v
 import ModelingToolkit: check_variables, check_parameters, _iszero, _merge, check_units, get_unit
 
 import Base: (==), hash, size, getindex, setindex, isless, Sort.defalg, length, show
-import MacroTools, Graphs, AbstractAlgebra
+import MacroTools, Graphs
 
 # globals for the modulate
-const AA = AbstractAlgebra
 const DEFAULT_IV = (@parameters t)[1]
 
 # as used in Catlab

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -43,7 +43,7 @@ function __init__()
 include("reactionsystem.jl")
 export Reaction, ReactionSystem, ismassaction, oderatelaw, jumpratelaw
 export ODEProblem, SDEProblem, JumpProblem, NonlinearProblem, DiscreteProblem, SteadyStateProblem
-export get_constraints
+export get_constraints, has_constraints, get_networkproperties
 
 # reaction_network macro
 const ExprValues = Union{Expr,Symbol,Float64,Int}

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -11,9 +11,9 @@ using LaTeXStrings, Latexify, Requires
 using ModelingToolkit; const MT = ModelingToolkit
 @reexport using ModelingToolkit
 using Symbolics
-using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems, 
+using ModelingToolkit: Symbolic, value, istree, get_states, get_ps, get_iv, get_systems,
                        get_eqs, get_defaults, toparam, get_var_to_name, get_observed, getvar
-import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_variables!, 
+import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_variables!,
                         modified_states!, validate, namespace_variables, namespace_parameters,
                         rename, renamespace, getname, flatten
 # internal but needed ModelingToolkit functions
@@ -43,7 +43,7 @@ function __init__()
 include("reactionsystem.jl")
 export Reaction, ReactionSystem, ismassaction, oderatelaw, jumpratelaw
 export ODEProblem, SDEProblem, JumpProblem, NonlinearProblem, DiscreteProblem, SteadyStateProblem
-export get_constraints, has_constraints, get_networkproperties
+export get_constraints, has_constraints
 
 # reaction_network macro
 const ExprValues = Union{Expr,Symbol,Float64,Int}
@@ -69,7 +69,7 @@ export params, numparams
 # network analysis functions
 export reactioncomplexmap, reactioncomplexes, reactionrates, complexstoichmat, complexoutgoingmat
 export incidencematgraph, linkageclasses, deficiency, subnetworks, linkagedeficiencies, isreversible, isweaklyreversible
-  
+
 # for Latex printing of ReactionSystems
 include("latexify_recipes.jl")
 

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -331,7 +331,7 @@ end
 function netstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
     isempty(get_systems(rn)) || error("netstoichmat does not currently support subsystems.")
 
-    nps = rn.networkproperties
+    nps = get_networkproperties(rn)
 
     # if it is already calculated and has the right type
     if (nps.netstoichmat !== nothing)
@@ -985,7 +985,7 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     end
 
     # cache in the system
-    nps = rn.networkproperties
+    nps = get_networkproperties(rn)
     nps.rank = r
     nps.nullity = nullity
     nps.indepspecs = Set(indepspecs)
@@ -1007,7 +1007,7 @@ Notes:
   returns the cached version.
 """
 function conservationlaws(rs::ReactionSystem)
-    nps = rs.networkproperties
+    nps = get_networkproperties(rs)
     (nps.conservationmat !== nothing) && (return nps.conservationmat)
     (nps.netstoichmat === nothing) && (nps.netstoichmat = netstoichmat(rs))
     nps.conservationmat = conservationlaws(nps.netstoichmat; col_order=nps.col_order)

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -974,8 +974,8 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     constantdefs = Equation[]
     for (i,depidx) in enumerate(depidxs)
         scaleby = (N[i,depidx] != 1) ? N[i,depidx] : one(eltype(N))
-        (scaleby != 0) || error("Error, found a zero in the conservation law matrix where \
-                                 one was not expected.")
+        (scaleby != 0) || error("Error, found a zero in the conservation law matrix where "
+                                 * "one was not expected.")
         coefs = @view N[i,indepidxs]
         terms = sum(p -> p[1]/scaleby * p[2], zip(coefs,indepspecs))
         eq = depspecs[i] ~ constants[i] - terms

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -334,11 +334,11 @@ function netstoichmat(rn::ReactionSystem; sparse=false, smap=speciesmap(rn))
     nps = rn.networkproperties
 
     # if it is already calculated and has the right type
-    if (nps.netstoichmat !== nothing) 
+    if (nps.netstoichmat !== nothing)
         (!xor(sparse, issparse(nps.netstoichmat))) && (return nps.netstoichmat)
     end
 
-	if sparse 
+	if sparse
         nps.netstoichmat = netstoichmat(SparseMatrixCSC{Int,Int}, rn; smap=smap)
     else
         nps.netstoichmat = netstoichmat(Matrix{Int}, rn; smap=smap)
@@ -953,9 +953,9 @@ function conservationlaws(nsm::AbstractMatrix; col_order=nothing)
     end
 
     # check we haven't overflowed
-    iszero(N' * nsm) || error("Calculation of the conservation law matrix was inaccurate, \
-                            likely due to numerical overflow. Please use a larger integer \
-                            type like Int128 or BigInt for the net stoichiometry matrix.")
+    iszero(N' * nsm) || error("Calculation of the conservation law matrix was inaccurate, "
+                            * "likely due to numerical overflow. Please use a larger integer "
+                            * "type like Int128 or BigInt for the net stoichiometry matrix.")
 
     N'
 end
@@ -991,7 +991,7 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     nps.indepspecs = Set(indepspecs)
     nps.depspecs = Set(depspecs)
     nps.conservedeqs = conservedeqs
-    nps.constantdefs = constantdefs    
+    nps.constantdefs = constantdefs
 
     nothing
 end
@@ -1007,10 +1007,10 @@ Notes:
   returns the cached version.
 """
 function conservationlaws(rs::ReactionSystem)
-    nps = rs.networkproperties    
+    nps = rs.networkproperties
     (nps.conservationmat !== nothing) && (return nps.conservationmat)
     (nps.netstoichmat === nothing) && (nps.netstoichmat = netstoichmat(rs))
-    nps.conservationmat = conservationlaws(nps.netstoichmat; col_order=nps.col_order)    
+    nps.conservationmat = conservationlaws(nps.netstoichmat; col_order=nps.col_order)
     cache_conservationlaw_eqs!(rs, nps.conservationmat, nps.col_order)
     nps.conservationmat
 end

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -97,7 +97,7 @@ Given a [`ReactionSystem`](@ref), return a vector of all `Reactions` in the syst
 Notes:
 - If `ModelingToolkit.get_systems(network)` is not empty, will allocate.
 """
-function reactions(network)    
+function reactions(network)
     rxs = get_eqs(network)
     systems = filter_nonrxsys(network)
     isempty(systems) && (return rxs)
@@ -140,12 +140,12 @@ end
     numspecies(network)
 
 Return the total number of species within the given [`ReactionSystem`](@ref) and
-subsystems that are `ReactionSystem`s. 
+subsystems that are `ReactionSystem`s.
 
 Notes
 - If there are no subsystems this will be fast.
 - As this calls [`species`](@ref), it can be slow and will allocate if there are
-  any subsystems. 
+  any subsystems.
 """
 function numspecies(network)
     length(species(network))
@@ -174,7 +174,7 @@ and subsystems that are `ReactionSystem`s.
 Notes
 - If there are no subsystems this will be fast.
 - As this calls [`reactionparams`](@ref), it can be slow and will allocate if
-  there are any subsystems. 
+  there are any subsystems.
 """
 function numreactionparams(network)
     length(reactionparams(network))
@@ -360,7 +360,7 @@ Notes:
 - Defaults can be specified in any iterable container of symbols to value pairs
   or symbolics to value pairs.
 """
-function setdefaults!(rn, newdefs) 
+function setdefaults!(rn, newdefs)
     defs = eltype(newdefs) <: Pair{Symbol} ? symmap_to_varmap(rn,newdefs) : newdefs
     rndefs = MT.get_defaults(rn)
     for (var,val) in defs
@@ -369,12 +369,12 @@ function setdefaults!(rn, newdefs)
     nothing
 end
 
-function __unpacksys(rn) 
+function __unpacksys(rn)
     ex = :(begin end)
     for key in keys(get_var_to_name(rn))
         var = MT.getproperty(rn, key, namespace=false)
         push!(ex.args, :($key = $var))
-    end    
+    end
     ex
 end
 
@@ -412,10 +412,10 @@ end
 
 # convert symbol of the form :sys.a.b.c to a symbolic a.b.c
 function _symbol_to_var(sys, sym)
-    if hasproperty(sys, sym)    
+    if hasproperty(sys, sym)
         var = getproperty(sys, sym, namespace=false)
     else
-        strs = split(String(sym), "₊")   # need to check if this should be split of not!!!        
+        strs = split(String(sym), "₊")   # need to check if this should be split of not!!!
         if length(strs) > 1
             var = getproperty(sys, Symbol(strs[1]), namespace=false)
             for str in view(strs, 2:length(strs))
@@ -480,16 +480,16 @@ function symmap_to_varmap(sys, symmap::Tuple)
     end
 end
 
-symmap_to_varmap(sys, symmap::AbstractArray{Pair{Symbol,T}}) where {T} = 
+symmap_to_varmap(sys, symmap::AbstractArray{Pair{Symbol,T}}) where {T} =
     [_symbol_to_var(sys,sym) => val for (sym,val) in symmap]
 
-symmap_to_varmap(sys, symmap::Dict{Symbol,T}) where {T} = 
+symmap_to_varmap(sys, symmap::Dict{Symbol,T}) where {T} =
     Dict(_symbol_to_var(sys,sym) => val for (sym,val) in symmap)
 
 # don't permute any other types and let varmap_to_vars handle erroring
 symmap_to_varmap(sys, symmap) = symmap
 #error("symmap_to_varmap requires a Dict, AbstractArray or Tuple to map Symbols to values.")
-    
+
 
 ######################## reaction complexes and reaction rates ###############################
 """
@@ -520,17 +520,17 @@ struct ReactionComplex{V<:Integer} <: AbstractVector{ReactionComplexElement{V}}
     speciesstoichs::Vector{V}
 end
 
-function (==)(a::ReactionComplex{V},b::ReactionComplex{V}) where {V <: Integer} 
+function (==)(a::ReactionComplex{V},b::ReactionComplex{V}) where {V <: Integer}
     (a.speciesids == b.speciesids) &&
-    (a.speciesstoichs == b.speciesstoichs) 
+    (a.speciesstoichs == b.speciesstoichs)
 end
 hash(rc::ReactionComplex,h::UInt) = Base.hash(rc.speciesids,Base.hash(rc.speciesstoichs,h))
 Base.size(rc::ReactionComplex) = size(rc.speciesids)
 Base.length(rc::ReactionComplex) = length(rc.speciesids)
-Base.getindex(rc::ReactionComplex, i...) = 
+Base.getindex(rc::ReactionComplex, i...) =
         ReactionComplexElement(getindex(rc.speciesids, i...), getindex(rc.speciesstoichs, i...))
-Base.setindex!(rc::ReactionComplex, t::ReactionComplexElement, i...) = 
-    (setindex!(rc.speciesids, t.speciesid, i...); setindex!(rc.speciesstoichs, t.speciesstoich, i...); rc) 
+Base.setindex!(rc::ReactionComplex, t::ReactionComplexElement, i...) =
+    (setindex!(rc.speciesids, t.speciesid, i...); setindex!(rc.speciesstoichs, t.speciesstoich, i...); rc)
 Base.isless(a::ReactionComplexElement, b::ReactionComplexElement) = isless(a.speciesid, b.speciesid)
 Base.Sort.defalg(::ReactionComplex{T}) where {T <: Integer} = Base.DEFAULT_UNSTABLE
 
@@ -598,11 +598,11 @@ function reactioncomplexes(::Type{Matrix{Int}}, rn::ReactionSystem, smap, comple
 end
 
 @doc raw"""
-    reactioncomplexes(network::ReactionSystem; sparse=false, smap=speciesmap(rn), 
+    reactioncomplexes(network::ReactionSystem; sparse=false, smap=speciesmap(rn),
                       complextorxsmap=reactioncomplexmap(rn; smap=smap))
 
 Calculate the reaction complexes and complex incidence matrix for the given
-[`ReactionSystem`](@ref). 
+[`ReactionSystem`](@ref).
 
 Notes:
 - returns a pair of a vector of [`ReactionComplex`](@ref)s and the complex
@@ -620,7 +620,7 @@ B_{i j} = \begin{cases}
 ```
 - Set sparse=true for a sparse matrix representation of the incidence matrix
 """
-function reactioncomplexes(rn::ReactionSystem; sparse=false, smap=speciesmap(rn), 
+function reactioncomplexes(rn::ReactionSystem; sparse=false, smap=speciesmap(rn),
                            complextorxsmap=reactioncomplexmap(rn; smap=smap))
     isempty(get_systems(rn)) || error("reactioncomplexes does not currently support subsystems.")
 	sparse ? reactioncomplexes(SparseMatrixCSC{Int,Int}, rn, smap, complextorxsmap) :
@@ -664,12 +664,12 @@ Notes:
 """
 function complexstoichmat(rn::ReactionSystem; sparse=false, rcs=keys(reactioncomplexmap(rn)))
     isempty(get_systems(rn)) || error("complexstoichmat does not currently support subsystems.")
-    sparse ? complexstoichmat(SparseMatrixCSC{Int,Int}, rn, rcs) : 
+    sparse ? complexstoichmat(SparseMatrixCSC{Int,Int}, rn, rcs) :
              complexstoichmat(Matrix{Int}, rn, rcs)
 end
 
 
-function complexoutgoingmat(::Type{SparseMatrixCSC{Int,Int}}, rn::ReactionSystem, B)    
+function complexoutgoingmat(::Type{SparseMatrixCSC{Int,Int}}, rn::ReactionSystem, B)
     n = size(B,2)
 	rows = rowvals(B)
 	vals = nonzeros(B)
@@ -679,9 +679,9 @@ function complexoutgoingmat(::Type{SparseMatrixCSC{Int,Int}}, rn::ReactionSystem
     sizehint!(Vs, div(length(vals),2))
 	for j = 1:n
 	   for i in nzrange(B, j)
-	      if vals[i] != one(eltype(vals)) 
+	      if vals[i] != one(eltype(vals))
             push!(Is, rows[i])
-            push!(Js, j) 
+            push!(Js, j)
             push!(Vs, vals[i])
           end
 	   end
@@ -704,7 +704,7 @@ matrix of size num of complexes by num of reactions that identifies substrate
 complexes.
 
 Notes:
-- The complex outgoing matrix, ``\Delta``, is defined by 
+- The complex outgoing matrix, ``\Delta``, is defined by
 ```math
 \Delta_{i j} = \begin{cases}
     = 0,    &\text{if } B_{i j} = 1, \\
@@ -715,13 +715,13 @@ Notes:
 """
 function complexoutgoingmat(rn::ReactionSystem; sparse=false, B=reactioncomplexes(rn,sparse=sparse)[2])
     isempty(get_systems(rn)) || error("complexoutgoingmat does not currently support subsystems.")
-    sparse ? complexoutgoingmat(SparseMatrixCSC{Int,Int}, rn, B) : 
+    sparse ? complexoutgoingmat(SparseMatrixCSC{Int,Int}, rn, B) :
              complexoutgoingmat(Matrix{Int}, rn, B)
 end
 
 
 """
-    incidencematgraph(incidencemat)   
+    incidencematgraph(incidencemat)
 
 Given an incidence matrix of a reaction-network, construct a directed simple
 graph where nodes correspond to reaction complexes and directed edges to
@@ -754,7 +754,7 @@ function incidencematgraph(incidencemat::Matrix{Int})
 end
 function incidencematgraph(incidencemat::SparseMatrixCSC{Int,Int})
     @assert all(∈([-1,0,1]) ,incidencemat)
-    m,n = size(incidencemat)  
+    m,n = size(incidencemat)
     graph = Graphs.DiGraph(m)
     rows = rowvals(incidencemat)
     vals = nonzeros(incidencemat)
@@ -795,16 +795,16 @@ end
 @doc raw"""
     deficiency(netstoich_mat, incidence_graph, linkage_classes)
 
-Calculate the deficiency of a reaction network. 
+Calculate the deficiency of a reaction network.
 
-Here the deficiency, ``\delta``, of a network with ``n`` reaction complexes, 
+Here the deficiency, ``\delta``, of a network with ``n`` reaction complexes,
 ``\ell`` linkage classes and a rank ``s`` stoichiometric matrix is
 
 ```math
 \delta = n - \ell - s
 ```
 
-For example, 
+For example,
 ```julia
 sir = @reaction_network SIR begin
     β, S + I --> 2I
@@ -837,7 +837,7 @@ function subnetworkmapping(linkageclass, allrxs, complextorxmap, p)
     end
     rxs, specs, newps   # reactions and species involved in reactions of subnetwork
 end
-	
+
 """
     subnetworks(network, linkage_classes ; rxs = reactions(network),
                   complextorxmap = collect(values(reactioncomplexmap(network))),
@@ -886,8 +886,8 @@ function linkagedeficiencies(subnets, lcs)
     end
     δ
 end
-	
-						
+
+
 """
     isreversible(incidencegraph)
 
@@ -915,34 +915,34 @@ function isweaklyreversible(subnets::Vector{ReactionSystem})
     igs = [incidencematgraph(reactioncomplexes(subrs)[2]) for subrs in subnets]
     all([Graphs.is_strongly_connected(ig) for ig in igs])
 end
-								
-								
-################################################################################################
+
+
+############################################################################################
 ######################## conservation laws ###############################
 
-""" 
+"""
     conservationlaws(netstoichmat::AbstractMatrix)::Matrix
 
 Given the net stoichiometry matrix of a reaction system, computes a matrix of
-conservation laws, each represented as a row in the output. 
+conservation laws, each represented as a row in the output.
 """
-function conservationlaws(nsm::AbstractMatrix)
+function conservationlaws(nsm::AbstractMatrix; col_order=nothing)
 
-    # We basically have to compute the left null space of the matrix
-    # over the integers. We do this using AbstractAlgebra's integer (ZZ) interface.
-    N   = AA.nullspace(AA.matrix(AA.ZZ, nsm'))[2]
-    
-    # to save allocations we manually take the adjoint when converting back
-    # to a Julia integer matrix from the Nemo matrix. 
-    ret = [convert(Int,N[i,j]) for j=1:size(N,2), i=1:size(N,1)]  
+    # compute the left null space of over the integers
+    N = MT.nullspace(nsm'; col_order)
 
-    # If all coefficients for a conservation law are negative
-    # we might as well flip them to become positive
-    for retrow in eachrow(ret)
-        all(r -> r <= 0, retrow) && (retrow .*= -1)
+    # if all coefficients for a conservation law are negative, make positive
+    for Nrow in eachcol(N)
+        all(r -> r <= 0, Nrow) && (Nrow .*= -1)
     end
-    
-    ret
+
+    # check we haven't overflowed
+    errstr =
+    iszero(N' * nsm) || error("Calculation of the conservation law matrix was inaccurate, \
+                            likely due to numerical overflow. Please use a larger integer \
+                            type like Int128 or BigInt for the net stoichiometry matrix.")
+
+    N'
 end
 
 """
@@ -951,6 +951,41 @@ end
 Compute conserved quantities for a system with the given conservation laws.
 """
 conservedquantities(state, cons_laws) = cons_laws * state
+
+function sub_dependent_species(rx, submap)
+    rl = substitute(rx.rate, submap)
+
+end
+
+function removeconstraints(rn::ReactionSystem, N::AbstractMatrix, col_order)
+    nullity = size(N,1)
+    r = numspecies(rn) - nullity     # rank of the netstoichmat
+    sts = species(rn)
+    indepidxs = col_order[begin:r]
+    indepspecs = sts[indepidxs]
+    depidxs = col_order[(r+1):end]
+    depspecs = sts[depidxs]
+    constants = MT.unwrap.(MT.scalarize((@parameters _ConLaw[1:nullity])[1]))
+
+    conservedeqs = Equation[]
+    constantdefs = Equation[]
+    for (i,depidx) in enumerate(depidxs)
+        scaleby = (N[i,depidx] != 1) ? N[i,depidx] : one(eltype(N))
+        (scaleby != 0) || error("Error, found a zero in the conservation law matrix where \
+                                 one was not expected.")
+        coefs = @view N[i,indepidxs]
+        terms = sum(p -> p[1]/scaleby * p[2], zip(coefs,indepspecs))
+        eq = depspecs[i] ~ constants[i] - terms
+        push!(conservedeqs, eq)
+        eq = constants[i] ~ depspecs[i] + terms
+        push!(constantdefs,eq)
+    end
+
+    submap = Dict((eq.lhs => eq.rhs for eq in conservedeqs))
+    rxs = [sub_dependent_species(rx,submap) for rx in reactions(rn)]
+
+    nothing
+end
 
 ######################## reaction network operators #######################
 
@@ -972,7 +1007,7 @@ function (==)(rx1::Reaction, rx2::Reaction)
     rx1.only_use_rate == rx2.only_use_rate
 end
 
-function hash(rx::Reaction, h::UInt) 
+function hash(rx::Reaction, h::UInt)
     h = Base.hash(rx.rate, h)
     h = Base.hash(rx.substrates, h)
     h = Base.hash(rx.products, h)
@@ -1090,8 +1125,8 @@ Given a [`ReactionSystem`](@ref) and a vector `neworder`, orders the states of `
 Notes:
 - Currently only supports `ReactionSystem`s without constraints or subsystems.
 """
-function reorder_states!(rn, neworder) 
-   (get_constraints(rn) === nothing) && isempty(get_systems(rn)) || 
+function reorder_states!(rn, neworder)
+   (get_constraints(rn) === nothing) && isempty(get_systems(rn)) ||
            error("Reordering of states is only supported for systems without constraints or subsystems.")
     permute!(get_states(rn), neworder)
 end
@@ -1170,12 +1205,12 @@ Notes:
 function Base.merge!(network1::ReactionSystem, network2::ReactionSystem)
     ((get_constraints(network1) === nothing) && (get_constraints(network2) === nothing)) ||
         error("merge! does not currently support ReactionSystems with constraints, consider ModelingToolkit.extend instead.")
-    isequal(get_iv(network1), get_iv(network2)) || 
+    isequal(get_iv(network1), get_iv(network2)) ||
         error("Reaction networks must have the same independent variable to be mergable.")
     append!(get_eqs(network1), get_eqs(network2))
     union!(get_states(network1), get_states(network2))
     union!(get_ps(network1), get_ps(network2))
-    append!(get_observed(network1), get_observed(network2))    
+    append!(get_observed(network1), get_observed(network2))
     append!(get_systems(network1), get_systems(network2))
     merge!(get_defaults(network1), get_defaults(network2))
     network1
@@ -1185,7 +1220,7 @@ end
 ###############################   units   #####################################
 
 """
-    validate(rx::Reaction; info::String = "")     
+    validate(rx::Reaction; info::String = "")
 
 Check that all substrates and products within the given [`Reaction`](@ref) have
 the same units, and that the units of the reaction's rate expression are
@@ -1193,9 +1228,9 @@ internally consistent (i.e. if the rate involves sums, each term in the sum has
 the same units).
 
 """
-function validate(rx::Reaction; info::String = "")     
+function validate(rx::Reaction; info::String = "")
     validated = MT._validate([rx.rate], [string(rx, ": rate")], info = info)
-    
+
     subunits = isempty(rx.substrates) ? nothing : get_unit(rx.substrates[1])
     for i in 2:length(rx.substrates)
         if get_unit(rx.substrates[i]) != subunits
@@ -1228,26 +1263,26 @@ that the rate laws of all reactions reduce to units of (species units) / (time
 units).
 
 Notes:
-- Does not check subsystems too. 
+- Does not check subsystems too.
 """
 function validate(rs::ReactionSystem, info::String="")
     specs = get_states(rs)
 
     # if there are no species we don't check units on the system
-    isempty(specs) && return true   
+    isempty(specs) && return true
 
     specunits = get_unit(specs[1])
     validated = true
     for spec in specs
         if get_unit(spec) != specunits
-            validated = false 
+            validated = false
             @warn(string("Species are expected to have units of ", specunits, " however, species ", spec, " has units ", get_unit(spec), "."))
         end
     end
     timeunits = get_unit(get_iv(rs))
 
     # no units for species, time or parameters then assume validated
-    (specunits in (MT.unitless,nothing)) && (timeunits in (MT.unitless,nothing)) && 
+    (specunits in (MT.unitless,nothing)) && (timeunits in (MT.unitless,nothing)) &&
         MT.all_dimensionless(get_ps(rs)) && return true
 
     rateunits = specunits / timeunits

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -928,7 +928,7 @@ conservation laws, each represented as a row in the output.
 """
 function conservationlaws(nsm::AbstractMatrix; col_order=nothing)
 
-    # compute the left null space of over the integers
+    # compute the left nullspace over the integers
     N = MT.nullspace(nsm'; col_order)
 
     # if all coefficients for a conservation law are negative, make positive
@@ -937,7 +937,6 @@ function conservationlaws(nsm::AbstractMatrix; col_order=nothing)
     end
 
     # check we haven't overflowed
-    errstr =
     iszero(N' * nsm) || error("Calculation of the conservation law matrix was inaccurate, \
                             likely due to numerical overflow. Please use a larger integer \
                             type like Int128 or BigInt for the net stoichiometry matrix.")

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -113,10 +113,7 @@ participate in `Reaction`s to their index within [`species(network)`](@ref).
 function speciesmap(network)
     nps = get_networkproperties(network)
     if isempty(nps.speciesmap)
-        nps.isempty = false
-        for (i,S) in enumerate(species(network))
-            nps.speciesmap[S] = i
-        end
+        nps.speciesmap = Dict(S => i for (i,S) in enumerate(species(network)))
     end
     nps.speciesmap
 end
@@ -526,7 +523,6 @@ Clears the cache of various properties (like the netstoichiometry matrix). Use i
 properties need to be recalculated for some reason.
 """
 function reset_networkproperties!(rn::ReactionSystem)
-    nps = get_networkproperties(rn)
     reset!(get_networkproperties(rn))
     nothing
 end
@@ -1146,6 +1142,7 @@ Notes:
   variable, as this will potentially leave the system in an undefined state.
 """
 function addspecies!(network::ReactionSystem, s::Symbolic; disablechecks=false)
+    reset_networkproperties!(network)
 
     # we don't check subsystems since we will add it to the top-level system...
     curidx = disablechecks ? nothing : findfirst(S -> isequal(S, s), get_states(network))
@@ -1204,6 +1201,8 @@ id of the parameter within the system.
   variable, as this will potentially leave the system in an undefined state.
 """
 function addparam!(network::ReactionSystem, p::Symbolic; disablechecks=false)
+    reset_networkproperties!(network)
+
     # we don't check subsystems since we will add it to the top-level system...
     if istree(p) && !(operation(p) isa Sym)
         error("If the passed in parameter is an expression, it must correspond to an underlying Variable.")
@@ -1245,6 +1244,7 @@ Notes:
     `network` using [`addspecies!`](@ref) and [`addparam!`](@ref).
 """
 function addreaction!(network::ReactionSystem, rx::Reaction)
+    reset_networkproperties!(network)
     push!(get_eqs(network), rx)
     length(get_eqs(network))
 end
@@ -1273,6 +1273,7 @@ function Base.merge!(network1::ReactionSystem, network2::ReactionSystem)
     append!(get_observed(network1), get_observed(network2))
     append!(get_systems(network1), get_systems(network2))
     merge!(get_defaults(network1), get_defaults(network2))
+    reset_networkproperties!(network1)
     network1
 end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -45,7 +45,7 @@ Example systems:
     my_hill_repression(x, v, k, n) = v*k^n/(k^n+x^n)
 
     # may be necessary to
-    # @register my_hill_repression(x, v, k, n)
+    # @register_symbolic my_hill_repression(x, v, k, n)
     # see https://mtk.sciml.ai/stable/tutorials/symbolic_functions/#Registering-Functions-1
 
     r = @reaction_network MyReactionType begin

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1076,12 +1076,14 @@ end
 # SDEProblem from AbstractReactionNetwork
 function DiffEqBase.SDEProblem(rs::ReactionSystem, u0, tspan, p=DiffEqBase.NullParameters(), args...;
                                noise_scaling=nothing, name=nameof(rs), combinatoric_ratelaws=true,
-                               include_zero_odes=true, checks = false, kwargs...)
+                               include_zero_odes=true, checks = false, check_length=false, kwargs...)
     u0map = symmap_to_varmap(rs, u0)
     pmap  = symmap_to_varmap(rs, p)
     p_matrix = zeros(length(get_states(rs)), length(get_eqs(rs)))
-    sde_sys  = convert(SDESystem, rs; noise_scaling, name, combinatoric_ratelaws, include_zero_odes, checks)
-    return SDEProblem(sde_sys, u0map, tspan, pmap, args...; noise_rate_prototype=p_matrix,kwargs...)
+    sde_sys  = convert(SDESystem, rs; noise_scaling, name, combinatoric_ratelaws,
+                                      include_zero_odes, checks)
+    return SDEProblem(sde_sys, u0map, tspan, pmap, args...; check_length,
+                                                            noise_rate_prototype=p_matrix, kwargs...)
 end
 
 # DiscreteProblem from AbstractReactionNetwork
@@ -1103,12 +1105,13 @@ end
 # SteadyStateProblem from AbstractReactionNetwork
 function DiffEqBase.SteadyStateProblem(rs::ReactionSystem, u0, p=DiffEqBase.NullParameters(), args...;
                                        check_length=false, name=nameof(rs), combinatoric_ratelaws=true,
-                                       include_zero_odes=true, checks=false, kwargs...)
+                                       remove_conserved=false, include_zero_odes=true, checks=false, kwargs...)
 
     u0map = symmap_to_varmap(rs, u0)
-    pmap  = symmap_to_varmap(rs, p)
-    osys =  convert(ODESystem, rs; name, combinatoric_ratelaws, include_zero_odes, checks)
-    return SteadyStateProblem(osys, u0map, pmap, args...; kwargs...)
+    pmap = symmap_to_varmap(rs, p)
+    osys = convert(ODESystem, rs; name, combinatoric_ratelaws, include_zero_odes, checks,
+                                  remove_conserved)
+    return SteadyStateProblem(osys, u0map, pmap, args...; check_length, kwargs...)
 end
 
 ####################### dependency graph utilities ########################

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -230,6 +230,8 @@ Base.@kwdef mutable struct NetworkProperties{I <: Integer, V <: Term}
     complexstoichmat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0.0)
     complexoutgoingmat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0.0)
     incidencegraph::Graphs.SimpleDiGraph{Int} = Graphs.DiGraph()
+    linkageclasses::Vector{Vector{Int}} = Vector{Vector{Int}}(undef,0)
+    deficiency::Int = 0
 end
 
 function Base.show(io::IO, nps::NetworkProperties)
@@ -265,6 +267,8 @@ function reset!(nps::NetworkProperties{I,V}) where {I,V}
     empty!(nps.complexstoichmat)
     empty!(nps.complexoutgoingmat)
     empty!(nps.incidencegraph)
+    empty!(linkageclasses)
+    nps.deficiency = 0
 
     # this needs to be last due to setproperty! setting it to false
     nps.isempty = true

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -224,11 +224,11 @@ Base.@kwdef mutable struct NetworkProperties{I <: Integer, V <: Term}
     conservedeqs::Vector{Equation} = Equation[]
     constantdefs::Vector{Equation} = Equation[]
     speciesmap::Dict{V,Int} = Dict{V,Int}()
-    complextorxsmap::OrderedDict{ReactionComplex{V},Vector{Pair{Int,Int}}} = OrderedDict{ReactionComplex{V},Vector{Pair{Int,Int}}}()
-    complexes::Vector{ReactionComplex{V}} = Vector{ReactionComplex{V}}(undef,0)
-    incidencemat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0.0)
-    complexstoichmat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0.0)
-    complexoutgoingmat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0.0)
+    complextorxsmap::OrderedDict{ReactionComplex{Int},Vector{Pair{Int,Int}}} = OrderedDict{ReactionComplex{Int},Vector{Pair{Int,Int}}}()
+    complexes::Vector{ReactionComplex{Int}} = Vector{ReactionComplex{Int}}(undef,0)
+    incidencemat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0,0)
+    complexstoichmat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0,0)
+    complexoutgoingmat::Union{Matrix{Int},SparseMatrixCSC{Int,Int}} = Matrix{Int}(undef,0,0)
     incidencegraph::Graphs.SimpleDiGraph{Int} = Graphs.DiGraph()
     linkageclasses::Vector{Vector{Int}} = Vector{Vector{Int}}(undef,0)
     deficiency::Int = 0
@@ -251,7 +251,7 @@ end
 
 function reset!(nps::NetworkProperties{I,V}) where {I,V}
     nps.isempty && return
-    nps.netstoichmat = Matrix{I}(undef,0,0)
+    nps.netstoichmat = Matrix{Int}(undef,0,0)
     nps.conservationmat = Matrix{I}(undef,0,0)
     empty!(nps.col_order)
     nps.rank = 0
@@ -263,11 +263,11 @@ function reset!(nps::NetworkProperties{I,V}) where {I,V}
     empty!(nps.speciesmap)
     empty!(nps.complextorxsmap)
     empty!(nps.complexes)
-    empty!(nps.incidencemat)
-    empty!(nps.complexstoichmat)
-    empty!(nps.complexoutgoingmat)
-    empty!(nps.incidencegraph)
-    empty!(linkageclasses)
+    nps.incidencemat = Matrix{Int}(undef,0,0)
+    nps.complexstoichmat = Matrix{Int}(undef,0,0)
+    nps.complexoutgoingmat = Matrix{Int}(undef,0,0)
+    nps.incidencegraph = Graphs.DiGraph()
+    empty!(nps.linkageclasses)
     nps.deficiency = 0
 
     # this needs to be last due to setproperty! setting it to false

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -851,8 +851,8 @@ function Base.convert(::Type{<:NonlinearSystem}, rs::ReactionSystem;
                       remove_conserved=false, checks=false, kwargs...)
     fullrs = Catalyst.flatten(rs)
     remove_conserved && conservationlaws(fullrs)
-    eqs = assemble_drift(fullrs; combinatoric_ratelaws=combinatoric_ratelaws, as_odes=false,
-                                 include_zero_odes=include_zero_odes)
+    eqs = assemble_drift(fullrs; combinatoric_ratelaws, remove_conserved, as_odes=false,
+                                 include_zero_odes)
     error_if_constraint_odes(NonlinearSystem, fullrs)
     eqs,sts,ps,obs,defs = addconstraints!(eqs, fullrs; remove_conserved)
     NonlinearSystem(eqs, sts, ps; name, defaults=defs, observed=obs, checks, kwargs...)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -232,6 +232,7 @@ Base.@kwdef mutable struct NetworkProperties{I <: Integer, V <: Term}
     incidencegraph::Graphs.SimpleDiGraph{Int} = Graphs.DiGraph()
     linkageclasses::Vector{Vector{Int}} = Vector{Vector{Int}}(undef,0)
     deficiency::Int = 0
+    subnetworks::Vector{ReactionSystem} = ReactionSystem[]
 end
 
 function Base.show(io::IO, nps::NetworkProperties)
@@ -269,6 +270,7 @@ function reset!(nps::NetworkProperties{I,V}) where {I,V}
     empty!(nps.incidencegraph)
     empty!(linkageclasses)
     nps.deficiency = 0
+    empty!(nps.subnetworks)
 
     # this needs to be last due to setproperty! setting it to false
     nps.isempty = true

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -232,7 +232,6 @@ Base.@kwdef mutable struct NetworkProperties{I <: Integer, V <: Term}
     incidencegraph::Graphs.SimpleDiGraph{Int} = Graphs.DiGraph()
     linkageclasses::Vector{Vector{Int}} = Vector{Vector{Int}}(undef,0)
     deficiency::Int = 0
-    subnetworks::Vector{ReactionSystem} = ReactionSystem[]
 end
 
 function Base.show(io::IO, nps::NetworkProperties)
@@ -270,7 +269,6 @@ function reset!(nps::NetworkProperties{I,V}) where {I,V}
     empty!(nps.incidencegraph)
     empty!(linkageclasses)
     nps.deficiency = 0
-    empty!(nps.subnetworks)
 
     # this needs to be last due to setproperty! setting it to false
     nps.isempty = true

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -786,6 +786,7 @@ function addconstraints!(eqs, rs::ReactionSystem; remove_conserved=false)
     if csys !== nothing
         sts = vcat(sts, get_states(csys))
         ps = vcat(ps, get_ps(csys))
+        ceqs = get_eqs(csys)
         (!isempty(ceqs)) && append!(eqs,ceqs)
         defs = merge(defs, MT.defaults(csys))
         obs = vcat(obs, MT.observed(csys))

--- a/src/registered_functions.jl
+++ b/src/registered_functions.jl
@@ -4,7 +4,7 @@
 A Michaelis-Menten rate function.
 """
 mm(X,v,K) = v*X / (X + K)
-@register mm(X,v,K);
+@register_symbolic mm(X,v,K);
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{1}) = (args[2]*args[3]) / (args[1]+args[3])^2
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{2}) = args[1]/(args[1]+args[3])
 Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{3}) = - args[2]*args[1]/(args[1]+args[3])^2
@@ -16,7 +16,7 @@ Symbolics.derivative(::typeof(mm), args::NTuple{3,Any}, ::Val{3}) = - args[2]*ar
 A repressive Michaelis-Menten rate function.
 """
 mmr(X,v,K) = v*K / (X + K)
-@register mmr(X,v,K); 
+@register_symbolic mmr(X,v,K); 
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{1}) = - (args[2]*args[3]) / (args[1]+args[3])^2
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{2}) = args[3]/(args[1]+args[3])
 Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{3}) = args[2]*args[1]/(args[1]+args[3])^2
@@ -28,7 +28,7 @@ Symbolics.derivative(::typeof(mmr), args::NTuple{3,Any}, ::Val{3}) = args[2]*arg
 A Hill rate function.
 """
 hill(X,v,K,n) = v*(X^n) / (X^n + K^n)
-@register hill(X,v,K,n);
+@register_symbolic hill(X,v,K,n);
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{1}) = args[2] * args[4] * (args[3]^args[4]) * (args[1]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{2}) = (args[1]^args[4])  /  (args[1]^args[4] + args[3]^args[4])
 Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{3}) = - args[2] * args[4] * (args[1]^args[4]) * (args[3]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
@@ -40,7 +40,7 @@ Symbolics.derivative(::typeof(hill), args::NTuple{4,Any}, ::Val{4}) = args[2] * 
 A repressive Hill rate function.
 """
 hillr(X,v,K,n) = v*(K^n) / (X^n + K^n)
-@register hillr(X,v,K,n);
+@register_symbolic hillr(X,v,K,n);
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{1}) = - args[2] * args[4] * (args[3]^args[4]) * (args[1]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{2}) = (args[3]^args[4])  /  (args[1]^args[4] + args[3]^args[4])
 Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{3}) = args[2] * args[4] * (args[1]^args[4]) * (args[3]^(args[4]-1))  /  (args[1]^args[4] + args[3]^args[4])^2
@@ -52,7 +52,7 @@ Symbolics.derivative(::typeof(hillr), args::NTuple{4,Any}, ::Val{4}) = args[2] *
 An activation/repressing Hill rate function.
 """
 hillar(X,Y,v,K,n) = v*(X^n) / (X^n + Y^n + K^n)
-@register hillar(X,Y,v,K,n);
+@register_symbolic hillar(X,Y,v,K,n);
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{1}) = args[3] * args[5] * (args[1]^(args[5]-1)) * (args[2]^args[5]+args[4]^args[5])  /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])^2
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{2}) = - args[3] * args[5] * (args[2]^(args[5]-1)) * (args[1]^args[5])  /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])^2
 Symbolics.derivative(::typeof(hillar), args::NTuple{5,Any}, ::Val{3}) = (args[1]^args[5])   /  (args[1]^args[5] + args[2]^args[5] + args[4]^args[5])

--- a/test/api.jl
+++ b/test/api.jl
@@ -90,7 +90,7 @@ pmat = [0 1;
         0 2]
 @test smat == substoichmat(rnmat) == Matrix(substoichmat(rnmat, sparse=true))
 @test pmat == prodstoichmat(rnmat) == Matrix(prodstoichmat(rnmat, sparse=true))
-              
+
 ############## testing newly added intermediate complexes reaction networks##############
 
 function testnetwork(rn, B, Z, Δ, lcs, d, subrn, lcd)
@@ -101,7 +101,7 @@ function testnetwork(rn, B, Z, Δ, lcs, d, subrn, lcd)
     ig = incidencematgraph(B)
     lcs2 = linkageclasses(ig)
     @test lcs2 == linkageclasses(incidencematgraph(sparse(B))) == lcs
-    @test deficiency(netstoichmat(rn), ig, lcs) == d   
+    @test deficiency(netstoichmat(rn), ig, lcs) == d
     @test all(issetequal.(subrn, reactions.(subnetworks(rn, lcs))))
     @test linkagedeficiencies(subnetworks(rn, lcs), lcs) == lcd
     @test sum(linkagedeficiencies(subnetworks(rn, lcs),lcs)) <= deficiency(netstoichmat(rn), ig, lcs)
@@ -579,7 +579,7 @@ p     = [.1/1000, .01]
 tspan = (0.0,250.0)
 u0    = [999.0,1.0,0.0]
 op    = ODEProblem(rn, species(rn) .=> u0, tspan, parameters(rn) .=> p)
-sol   = solve(op, Tsit5())  # old style 
+sol   = solve(op, Tsit5())  # old style
 setdefaults!(rn, [:S => 999.0, :I => 1.0, :R => 0.0, :α => 1e-4, :β => .01])
 op = ODEProblem(rn, [], tspan, [])
 sol2 = solve(op, Tsit5())
@@ -603,7 +603,7 @@ function unpacktest(rn)
     u₀ = [S1 => 999.0, I1 => 1.0, R1 => 0.0]
     p = [α1 => 1e-4, β1 => .01]
     op = ODEProblem(rn, u₀, (0.0, 250.0), p)
-    solve(op, Tsit5())    
+    solve(op, Tsit5())
 end
 rn = @reaction_network begin
     α1, S1 + I1 --> 2I1
@@ -638,3 +638,20 @@ pmap = (:β => 1e-4, :ν => .01)
 op = ODEProblem(sir, u0map, tspan, pmap)
 sol5 = solve(op, Tsit5())
 @test norm(sol.u - sol5.u) ≈ 0
+
+
+# test conservation law elimination
+let
+    rn = @reaction_network begin
+        (k1,k2), A + B <--> C
+        (m1,m2), D <--> E
+        b12, F1 --> F2
+        b23, F2 --> F3
+        b31, F3 --> F1
+    end k1 k2 m1 m2 b12 b23 b31
+
+
+
+
+
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -91,20 +91,20 @@ pmat = [0 1;
 @test smat == substoichmat(rnmat) == Matrix(substoichmat(rnmat, sparse=true))
 @test pmat == prodstoichmat(rnmat) == Matrix(prodstoichmat(rnmat, sparse=true))
 
-############## testing newly added intermediate complexes reaction networks##############
+############## testing intermediate complexes reaction networks##############
 
 function testnetwork(rn, B, Z, Δ, lcs, d, subrn, lcd)
     B2 = reactioncomplexes(rn)[2]
     @test B == B2 == Matrix(reactioncomplexes(rn, sparse=true)[2])
     @test Z == complexstoichmat(rn) == Matrix(complexstoichmat(rn, sparse=true))
     @test Δ == complexoutgoingmat(rn) == Matrix(complexoutgoingmat(rn, sparse=true))
-    ig = incidencematgraph(B)
-    lcs2 = linkageclasses(ig)
+    ig = incidencematgraph(rn)
+    lcs2 = linkageclasses(rn)
     @test lcs2 == linkageclasses(incidencematgraph(sparse(B))) == lcs
-    @test deficiency(netstoichmat(rn), ig, lcs) == d
-    @test all(issetequal.(subrn, reactions.(subnetworks(rn, lcs))))
-    @test linkagedeficiencies(subnetworks(rn, lcs), lcs) == lcd
-    @test sum(linkagedeficiencies(subnetworks(rn, lcs),lcs)) <= deficiency(netstoichmat(rn), ig, lcs)
+    @test deficiency(rn) == d
+    @test all(issetequal.(subrn, reactions.(subnetworks(rn))))
+    @test linkagedeficiencies(rn) == lcd
+    @test sum(linkagedeficiencies(rn)) <= deficiency(rn)
 end
 
 rns  = Vector{ReactionSystem}(undef,6)
@@ -270,10 +270,9 @@ testnetwork(rns[6], B, Z, Δ, lcs, 0,subrn,lcd)
 
 ###########Testing reversibility###############
 function testreversibility(rn, B, rev, weak_rev)
-    ig = incidencematgraph(B)
-    subrn = subnetworks(rn, linkageclasses(ig))
-    @test isreversible(ig) == rev
-    @test isweaklyreversible(subrn) == weak_rev
+    @test isreversible(rn) == rev
+    subrn = subnetworks(rn)
+    @test isweaklyreversible(rn,subrn) == weak_rev
 end
 rxs = Vector{ReactionSystem}(undef, 10)
 rxs[1] = @reaction_network begin

--- a/test/api.jl
+++ b/test/api.jl
@@ -649,9 +649,22 @@ let
         b23, F2 --> F3
         b31, F3 --> F1
     end k1 k2 m1 m2 b12 b23 b31
+    osys = convert(ODESystem, rn; remove_conserved=true)
+    @unpack A,B,C,D,E,F1,F2,F3,k1,k2,m1,m2,b12,b23,b31 = osys
+    u0 = [A => 10.0, B => 10.0, C => 0.0, D => 10.0, E => 0.0, F1 => 8.0, F2 => 0.0, F3 => 0.0]
+    p = [k1 => 1.0, k2 => .1, m1 => 1.0, m2 => 2.0, b12 => 1.0, b23 => 2.0, b31 => .1]
+    tspan = (0.0,20.0)
+    oprob = ODEProblem(osys, u0, tspan, symmap_to_varmap(osys,p))
+    sol = solve(oprob, Tsit5())
+    oprob2 = ODEProblem(rn, u0, tspan, p)
+    sol2 = solve(oprob, Tsit5())
+    oprob3 = ODEProblem(rn, u0, tspan, symmap_to_varmap(osys,p); remove_conserved=true)
+    sol3 = solve(oprob3, Tsit5())
 
-
-
-
-
+    tv = range(tspan[1], tspan[2], length=101)
+    nps = get_networkproperties(rn)
+    for s in species(rn)
+        @test norm(sol(tv, idxs=s) .- sol2(tv, idxs=s)) ≈ 0
+        @test norm(sol2(tv, idxs=s) .- sol2(tv, idxs=s)) ≈ 0
+    end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -667,4 +667,16 @@ let
         @test norm(sol(tv, idxs=s) .- sol2(tv, idxs=s)) ≈ 0
         @test norm(sol2(tv, idxs=s) .- sol2(tv, idxs=s)) ≈ 0
     end
+
+    nsys = convert(NonlinearSystem, rn; remove_conserved=true)
+    nprob = NonlinearProblem{true}(nsys, u0, p)
+    nsol = solve(nprob, NewtonRaphson(); tol = 1e-9)
+    nprob2 = NonlinearProblem(rn, u0, p)
+    nsol2 = solve(nprob, NewtonRaphson(); tol=1e-9)
+    nprob3 = NonlinearProblem(rn, u0, p; remove_conserved=true)
+    nsol3 = solve(nprob, NewtonRaphson(); tol=1e-9)
+    for s in species(rn)
+        @test norm(nsol[s] .- nsol2[s]) ≈ 0
+        @test norm(nsol2[s] .- nsol2[s]) ≈ 0
+    end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -654,7 +654,7 @@ let
     u0 = [A => 10.0, B => 10.0, C => 0.0, D => 10.0, E => 0.0, F1 => 8.0, F2 => 0.0, F3 => 0.0]
     p = [k1 => 1.0, k2 => .1, m1 => 1.0, m2 => 2.0, b12 => 1.0, b23 => 2.0, b31 => .1]
     tspan = (0.0,20.0)
-    oprob = ODEProblem(osys, u0, tspan, symmap_to_varmap(osys,p))
+    oprob = ODEProblem(osys, u0, tspan, p)
     sol = solve(oprob, Tsit5())
     oprob2 = ODEProblem(rn, u0, tspan, p)
     sol2 = solve(oprob, Tsit5())

--- a/test/api.jl
+++ b/test/api.jl
@@ -662,7 +662,6 @@ let
     sol3 = solve(oprob3, Tsit5())
 
     tv = range(tspan[1], tspan[2], length=101)
-    nps = get_networkproperties(rn)
     for s in species(rn)
         @test norm(sol(tv, idxs=s) .- sol2(tv, idxs=s)) ≈ 0
         @test norm(sol2(tv, idxs=s) .- sol2(tv, idxs=s)) ≈ 0

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,4 +1,4 @@
-using Catalyst, DiffEqBase, ModelingToolkit, Test, OrdinaryDiffEq
+using Catalyst, DiffEqBase, ModelingToolkit, Test, OrdinaryDiffEq, NonlinearSolve
 using LinearAlgebra: norm
 using SparseArrays
 using ModelingToolkit: value

--- a/test/conslaws.jl
+++ b/test/conslaws.jl
@@ -4,8 +4,8 @@ using LinearAlgebra
 include("test_networks.jl")
 
 rn = @reaction_network begin
-    (1, 2), A + B <--> C 
-    (3, 2), D <--> E 
+    (1, 2), A + B <--> C
+    (3, 2), D <--> E
     (0.1, 0.2), E <--> F
     6, F --> G
     7, H --> G
@@ -28,7 +28,7 @@ D = [ 1 -1 0 0 0 0 0 0 0 0;
 
 C = conservationlaws(rn)
 @test size(C,1) == 3
-@test get_networkproperties(rn).nullity == 3
+@test Catalyst.get_networkproperties(rn).nullity == 3
 @test any(b == C[i,:] for i in 1:size(C,1))
 @test any(D[j,:] == C[i,:] for i in 1:size(C,1), j in 1:size(D,1))
 

--- a/test/conslaws.jl
+++ b/test/conslaws.jl
@@ -15,9 +15,7 @@ end
 
 S = netstoichmat(rn)
 C = conservationlaws(S)
-
 @test size(C,1) == 3
-
 b = [ 0, 0, 0, 1, 1, 1, 1, 1, 0, 0 ]
 @test any(b == C[i,:] for i in 1:size(C,1))
 
@@ -28,19 +26,21 @@ D = [ 1 -1 0 0 0 0 0 0 0 0;
       0  1 1 0 0 0 0 0 0 0 ]
 @test any(D[j,:] == C[i,:] for i in 1:size(C,1), j in 1:size(D,1))
 
-Ss_standard = map(netstoichmat, reaction_networks_standard)
-Cs_standard = map(conservationlaws, Ss_standard)
+C = conservationlaws(rn)
+@test size(C,1) == 3
+@test get_networkproperties(rn).nullity == 3
+@test any(b == C[i,:] for i in 1:size(C,1))
+@test any(D[j,:] == C[i,:] for i in 1:size(C,1), j in 1:size(D,1))
+
+
+Cs_standard = map(conservationlaws, reaction_networks_standard)
 @test all(size(C, 1) == 0 for C in Cs_standard)
 
-Ss_hill = map(netstoichmat, reaction_networks_hill)
-Cs_hill = map(conservationlaws, Ss_hill)
+Cs_hill = map(conservationlaws, reaction_networks_hill)
 @test all(size(C, 1) == 0 for C in Cs_hill)
 
 function consequiv(A, B)
     rank([A; B]) == rank(A) == rank(B)
 end
-
-Ss_constraint = map(netstoichmat, reaction_networks_constraint)
-Cs_constraint = map(conservationlaws, Ss_constraint)
-
+Cs_constraint = map(conservationlaws, reaction_networks_constraint)
 @test all(consequiv.(Matrix{Int}.(Cs_constraint), reaction_network_constraints))

--- a/test/model_modification.jl
+++ b/test/model_modification.jl
@@ -18,7 +18,7 @@ eqs,iv,ps,name,systems = unpacksys(empty_network_1)
 @test length(get_states(empty_network_1)) == 0
 @test length(ps) == 0
 
-empty_network_2 = @reaction_network 
+empty_network_2 = @reaction_network
 @variables p1 p2 p3 p4 p5
 addparam!(empty_network_2, p1)
 addparam!(empty_network_2, p2)
@@ -187,13 +187,13 @@ for networks in identical_networks
     @test networks[1] == networks[2]
     for factor in [1e-2, 1e-1, 1e0, 1e1]
         u0 = factor*rand(rng,length(get_states(networks[1])))
-        p = factor*rand(rng,length(get_ps(networks[1])))
+        pp = factor*rand(rng,length(get_ps(networks[1])))
 
         # needed because this code assumes an ordering of the parameters and species...
-        p2 = permute_ps(p, networks[1], networks[2])
+        pp2 = permute_ps(pp, networks[1], networks[2])
         t = rand(rng)
-        @test all(abs.(f1(u0,p,t) .- f2(u0,p2,t)) .< 1000*eps())
-        @test all(abs.(f1.jac(u0,p,t) .- f2.jac(u0,p2,t)) .< 1000*eps())
-        @test all(abs.(g1(u0,p,t) .- g2(u0,p2,t)) .< 1000*eps())
+        @test all(abs.(f1(u0,pp,t) .- f2(u0,pp2,t)) .< 1000*eps())
+        @test all(abs.(f1.jac(u0,pp,t) .- f2.jac(u0,pp2,t)) .< 1000*eps())
+        @test all(abs.(g1(u0,pp,t) .- g2(u0,pp2,t)) .< 1000*eps())
     end
 end


### PR DESCRIPTION
`ReactionSystem`s store a new (internal) field, `networkproperties`, that caches all the needed info for the various `convert` methods to eliminate out conservation laws (along with also being used to cache various network properties in the API). I left it this way as it didn't really seem to make sense to try to eliminate species at the `ReactionSystem` level (i.e. reactions would then contain algebraic expressions for the eliminated species as their substrates). Happy to consider alternative designs if there are better / more standard approaches.

TODO:
- [x] Add `NetworkProperties` structure for storing cached properties
- [x] Update various API functions to use this structure consistently.
- [x] drop AbstractAlgebra dependency. 
- [x] Calculate symbolic equations and substitutions for conservation laws.
- [x] Update `convert`s with appropriate kwarg that generates reduced systems.
- [x] Add tests
- [x] Update API tests 

```julia
rn = @reaction_network begin
       k, A + B --> C
       k2, C --> A + B
       end k k2
conservationlaws(rn)
get_networkproperties(rn)
```
giving
```
Conserved Equations: 
B(t) ~ A(t) + _ConLaw[1]
C(t) ~ _ConLaw[2] - A(t)

Net stoichiometry matrix: 
[-1 1; -1 1; 1 -1]
```
