### PR TITLE
use dependency graph to classify VariableRateJumps

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1060,7 +1060,7 @@ function assemble_jumps(rs; combinatoric_ratelaws = true)
     rxs = get_eqs(rs)
     isvrjvec = falses(length(rxs))
     havevrjs = false
-    for (i,rx) in enumerate(rxs)
+    for (i, rx) in enumerate(rxs)
         empty!(rxvars)
         (rx.rate isa Symbolic) && get_variables!(rxvars, rx.rate)
         @inbounds for rxvar in rxvars
@@ -1084,13 +1084,13 @@ function assemble_jumps(rs; combinatoric_ratelaws = true)
         end
     end
 
-    for (i,rx) in enumerate(rxs)
+    for (i, rx) in enumerate(rxs)
         empty!(rxvars)
         (rx.rate isa Symbolic) && get_variables!(rxvars, rx.rate)
 
         isvrj = isvrjvec[i]
         if (!isvrj) && ismassaction(rx, rs; rxvars = rxvars, haveivdep = false,
-                                    stateset = stateset)
+                        stateset = stateset)
             push!(meqs, makemajump(rx, combinatoric_ratelaw = combinatoric_ratelaws))
         else
             rl = jumpratelaw(rx, combinatoric_ratelaw = combinatoric_ratelaws)
@@ -1477,7 +1477,6 @@ function ModelingToolkit.modified_states!(mstates, rx::Reaction, sts::AbstractVe
     end
     mstates
 end
-
 
 ########################## Compositional Tooling ###########################
 function getsubsyseqs!(eqs::Vector{Equation}, sys)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1458,7 +1458,8 @@ end
 function ModelingToolkit.get_variables!(deps::Set, rx::Reaction, variables)
     (rx.rate isa Symbolic) && get_variables!(deps, rx.rate, variables)
     for s in rx.substrates
-        push!(deps, s)
+        # parametric stoichiometry means may have a parameter as a substrate
+        any(isequal(s), variables) && push!(deps, s)
     end
     deps
 end

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -551,10 +551,10 @@ let
     rn = @reaction_network begin
         t, A --> B          # vrj
         1.0, B --> D        # vrj
-        k*D, H --> I + H    # vrj
+        k * D, H --> I + H  # vrj
         k2, I --> L         # vrj
         k, E --> F          # maj
-        k*E, E --> G        # crj
+        k * E, E --> G      # crj
         k2, G --> H         # maj
         k2, G --> A + B     # maj
     end k k2

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -177,78 +177,103 @@ G2 = sf.g(u, p, t)
 @test norm(G - G2) < 100 * eps()
 
 # test with JumpSystem
-js = convert(JumpSystem, rs)
+let p = p
+    @variables t A(t) B(t) C(t) D(t) E(t) F(t)
+    rxs = [Reaction(k[1], nothing, [A]),            # 0 -> A
+        Reaction(k[2], [B], nothing),            # B -> 0
+        Reaction(k[3], [A], [C]),                  # A -> C
+        Reaction(k[4], [C], [A, B]),              # C -> A + B
+        Reaction(k[5], [C], [A], [1], [2]),      # C -> A + A
+        Reaction(k[6], [A, B], [C]),              # A + B -> C
+        Reaction(k[7], [B], [A], [2], [1]),      # 2B -> A
+        Reaction(k[8], [A, B], [A, C]),            # A + B -> A + C
+        Reaction(k[9], [A, B], [C, D]),            # A + B -> C + D
+        Reaction(k[10], [A], [C, D], [2], [1, 1]), # 2A -> C + D
+        Reaction(k[11], [A], [A, B], [2], [1, 1]), # 2A -> A + B
+        Reaction(k[12], [A, B, C], [C, D], [1, 3, 4], [2, 3]),          # A+3B+4C -> 2C + 3D
+        Reaction(k[13], [A, B], nothing, [3, 1], nothing),           # 3A+B -> 0
+        Reaction(k[14], nothing, [A], nothing, [2]),               # 0 -> 2A
+        Reaction(k[15] * A / (2 + A), [A], nothing; only_use_rate = true), # A -> 0 with custom rate
+        Reaction(k[16], [A], [B]; only_use_rate = true),             # A -> B with custom rate.
+        Reaction(k[17] * A * exp(B), [C], [D], [2], [1]),              # 2C -> D with non constant rate.
+        Reaction(k[18] * B, nothing, [B], nothing, [2]),             # 0 -> 2B with non constant rate.
+        Reaction(k[19] * t, [D], [E]),                                # D -> E with non constant rate.
+        Reaction(k[20] * t * A, [D, E], [F], [2, 1], [2]),                  # 2D + E -> 2F with non constant rate.
+    ]
+    @named rs = ReactionSystem(rxs, t, [A, B, C, D, E, F], k)
+    js = convert(JumpSystem, rs)
 
-midxs = 1:14
-cidxs = 15:18
-vidxs = 19:20
-@test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.MassActionJump, midxs))
-@test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.ConstantRateJump, cidxs))
-@test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.VariableRateJump, vidxs))
+    midxs = 1:14
+    cidxs = 15:18
+    vidxs = 19:20
+    @test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.MassActionJump, midxs))
+    @test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.ConstantRateJump, cidxs))
+    @test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.VariableRateJump, vidxs))
 
-pars = rand(length(k));
-u0 = rand(1:10, 4);
-ttt = rand();
-jumps = Vector{Union{ConstantRateJump, MassActionJump, VariableRateJump}}(undef,
-                                                                          length(rxs))
+    pars = rand(length(k));
+    u0 = rand(2:10, 6);
+    ttt = rand();
+    jumps = Vector{Union{ConstantRateJump, MassActionJump, VariableRateJump}}(undef,
+                                                                            length(rxs))
 
-jumps[1] = MassActionJump(pars[1], Vector{Pair{Int, Int}}(), [1 => 1]);
-jumps[2] = MassActionJump(pars[2], [2 => 1], [2 => -1]);
-jumps[3] = MassActionJump(pars[3], [1 => 1], [1 => -1, 3 => 1]);
-jumps[4] = MassActionJump(pars[4], [3 => 1], [1 => 1, 2 => 1, 3 => -1]);
-jumps[5] = MassActionJump(pars[5], [3 => 1], [1 => 2, 3 => -1]);
-jumps[6] = MassActionJump(pars[6], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1]);
-jumps[7] = MassActionJump(pars[7], [2 => 2], [1 => 1, 2 => -2]);
-jumps[8] = MassActionJump(pars[8], [1 => 1, 2 => 1], [2 => -1, 3 => 1]);
-jumps[9] = MassActionJump(pars[9], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1, 4 => 1]);
-jumps[10] = MassActionJump(pars[10], [1 => 2], [1 => -2, 3 => 1, 4 => 1]);
-jumps[11] = MassActionJump(pars[11], [1 => 2], [1 => -1, 2 => 1]);
-jumps[12] = MassActionJump(pars[12], [1 => 1, 2 => 3, 3 => 4],
-                           [1 => -1, 2 => -3, 3 => -2, 4 => 3]);
-jumps[13] = MassActionJump(pars[13], [1 => 3, 2 => 1], [1 => -3, 2 => -1]);
-jumps[14] = MassActionJump(pars[14], Vector{Pair{Int, Int}}(), [1 => 2]);
+    jumps[1] = MassActionJump(pars[1], Vector{Pair{Int, Int}}(), [1 => 1]);
+    jumps[2] = MassActionJump(pars[2], [2 => 1], [2 => -1]);
+    jumps[3] = MassActionJump(pars[3], [1 => 1], [1 => -1, 3 => 1]);
+    jumps[4] = MassActionJump(pars[4], [3 => 1], [1 => 1, 2 => 1, 3 => -1]);
+    jumps[5] = MassActionJump(pars[5], [3 => 1], [1 => 2, 3 => -1]);
+    jumps[6] = MassActionJump(pars[6], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1]);
+    jumps[7] = MassActionJump(pars[7], [2 => 2], [1 => 1, 2 => -2]);
+    jumps[8] = MassActionJump(pars[8], [1 => 1, 2 => 1], [2 => -1, 3 => 1]);
+    jumps[9] = MassActionJump(pars[9], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1, 4 => 1]);
+    jumps[10] = MassActionJump(pars[10], [1 => 2], [1 => -2, 3 => 1, 4 => 1]);
+    jumps[11] = MassActionJump(pars[11], [1 => 2], [1 => -1, 2 => 1]);
+    jumps[12] = MassActionJump(pars[12], [1 => 1, 2 => 3, 3 => 4],
+                            [1 => -1, 2 => -3, 3 => -2, 4 => 3]);
+    jumps[13] = MassActionJump(pars[13], [1 => 3, 2 => 1], [1 => -3, 2 => -1]);
+    jumps[14] = MassActionJump(pars[14], Vector{Pair{Int, Int}}(), [1 => 2]);
 
-jumps[15] = ConstantRateJump((u, p, t) -> p[15] * u[1] / (2 + u[1]),
-                             integrator -> (integrator.u[1] -= 1))
-jumps[16] = ConstantRateJump((u, p, t) -> p[16],
-                             integrator -> (integrator.u[1] -= 1; integrator.u[2] += 1))
-jumps[17] = ConstantRateJump((u, p, t) -> p[17] * u[1] * exp(u[2]) * binomial(u[3], 2),
-                             integrator -> (integrator.u[3] -= 2; integrator.u[4] += 1))
-jumps[18] = ConstantRateJump((u, p, t) -> p[18] * u[2],
-                             integrator -> (integrator.u[2] += 2))
+    jumps[15] = ConstantRateJump((u, p, t) -> p[15] * u[1] / (2 + u[1]),
+                                integrator -> (integrator.u[1] -= 1))
+    jumps[16] = ConstantRateJump((u, p, t) -> p[16],
+                                integrator -> (integrator.u[1] -= 1; integrator.u[2] += 1))
+    jumps[17] = ConstantRateJump((u, p, t) -> p[17] * u[1] * exp(u[2]) * binomial(u[3], 2),
+                                integrator -> (integrator.u[3] -= 2; integrator.u[4] += 1))
+    jumps[18] = ConstantRateJump((u, p, t) -> p[18] * u[2],
+                                integrator -> (integrator.u[2] += 2))
 
-jumps[19] = VariableRateJump((u, p, t) -> p[19] * u[1] * t,
-                             integrator -> (integrator.u[1] -= 1; integrator.u[2] += 1))
-jumps[20] = VariableRateJump((u, p, t) -> p[20] * t * u[1] * binomial(u[2], 2) * u[3],
-                             integrator -> (integrator.u[2] -= 2; integrator.u[3] -= 1; integrator.u[4] += 2))
+    jumps[19] = VariableRateJump((u, p, t) -> p[19] * u[4] * t,
+                                integrator -> (integrator.u[4] -= 1; integrator.u[5] += 1))
+    jumps[20] = VariableRateJump((u, p, t) -> p[20] * t * u[1] * binomial(u[4], 2) * u[5],
+                                integrator -> (integrator.u[4] -= 2; integrator.u[5] -= 1; integrator.u[6] += 2))
 
-statetoid = Dict(state => i for (i, state) in enumerate(states(js)))
-jspmapper = ModelingToolkit.JumpSysMajParamMapper(js, pars)
-symmaj = ModelingToolkit.assemble_maj(equations(js).x[1], statetoid, jspmapper)
-maj = MassActionJump(symmaj.param_mapper(pars), symmaj.reactant_stoch, symmaj.net_stoch,
-                     symmaj.param_mapper, scale_rates = false)
-for i in midxs
-    @test abs(jumps[i].scaled_rates - maj.scaled_rates[i]) < 100 * eps()
-    @test jumps[i].reactant_stoch == maj.reactant_stoch[i]
-    @test jumps[i].net_stoch == maj.net_stoch[i]
-end
-for i in cidxs
-    crj = ModelingToolkit.assemble_crj(js, equations(js)[i], statetoid)
-    @test isapprox(crj.rate(u0, p, ttt), jumps[i].rate(u0, p, ttt))
-    fake_integrator1 = (u = zeros(4), p = p, t = 0)
-    fake_integrator2 = deepcopy(fake_integrator1)
-    crj.affect!(fake_integrator1)
-    jumps[i].affect!(fake_integrator2)
-    @test fake_integrator1 == fake_integrator2
-end
-for i in vidxs
-    crj = ModelingToolkit.assemble_vrj(js, equations(js)[i], statetoid)
-    @test isapprox(crj.rate(u0, p, ttt), jumps[i].rate(u0, p, ttt))
-    fake_integrator1 = (u = zeros(4), p = p, t = 0.0)
-    fake_integrator2 = deepcopy(fake_integrator1)
-    crj.affect!(fake_integrator1)
-    jumps[i].affect!(fake_integrator2)
-    @test fake_integrator1 == fake_integrator2
+    statetoid = Dict(state => i for (i, state) in enumerate(states(js)))
+    jspmapper = ModelingToolkit.JumpSysMajParamMapper(js, pars)
+    symmaj = ModelingToolkit.assemble_maj(equations(js).x[1], statetoid, jspmapper)
+    maj = MassActionJump(symmaj.param_mapper(pars), symmaj.reactant_stoch, symmaj.net_stoch,
+                        symmaj.param_mapper, scale_rates = false)
+    for i in midxs
+        @test abs(jumps[i].scaled_rates - maj.scaled_rates[i]) < 100 * eps()
+        @test jumps[i].reactant_stoch == maj.reactant_stoch[i]
+        @test jumps[i].net_stoch == maj.net_stoch[i]
+    end
+    for i in cidxs
+        crj = ModelingToolkit.assemble_crj(js, equations(js)[i], statetoid)
+        @test isapprox(crj.rate(u0, p, ttt), jumps[i].rate(u0, p, ttt))
+        fake_integrator1 = (u = zeros(6), p = p, t = 0.0)
+        fake_integrator2 = deepcopy(fake_integrator1)
+        crj.affect!(fake_integrator1)
+        jumps[i].affect!(fake_integrator2)
+        @test fake_integrator1 == fake_integrator2
+    end
+    for i in vidxs
+        crj = ModelingToolkit.assemble_vrj(js, equations(js)[i], statetoid)
+        @test isapprox(crj.rate(u0, p, ttt), jumps[i].rate(u0, p, ttt))
+        fake_integrator1 = (u = zeros(6), p = p, t = 0.0)
+        fake_integrator2 = deepcopy(fake_integrator1)
+        crj.affect!(fake_integrator1)
+        jumps[i].affect!(fake_integrator2)
+        @test fake_integrator1 == fake_integrator2
+    end
 end
 
 # test for https://github.com/SciML/ModelingToolkit.jl/issues/436
@@ -451,20 +476,24 @@ let
     jsys = convert(JumpSystem, rs)
     @test issetequal(states(jsys), [B, C, D, E])
     @test issetequal(parameters(jsys), [k1, k2, A])
-    majrates = [k1 * A, k2, k1, k2]
-    majrs = [[], [B => 1], [C => 1, D => 1], [C => 1, E => 1]]
-    majns = [[B => 1], [B => -1], [D => -1, E => 1], [D => 1, E => -1]]
+    majrates = [k1 * A, k1, k2]
+    majrs = [[], [C => 1, D => 1], [C => 1, E => 1]]
+    majns = [[B => 1], [D => -1, E => 1], [D => 1, E => -1]]
     for (i, maj) in enumerate(equations(jsys).x[1])
         @test isequal(maj.scaled_rates, majrates[i])
         @test issetequal(maj.reactant_stoch, majrs[i])
         @test issetequal(maj.net_stoch, majns[i])
     end
-    crj = equations(jsys).x[2][1]
-    @test isequal(crj.rate, k1 * B * A * (A - 1) / 2 * C)
-    @test issetequal(crj.affect!, [B ~ B + 1])
-    vrj = equations(jsys).x[3][1]
-    @test isequal(vrj.rate, k1 * t * A * C)
-    @test issetequal(vrj.affect!, [B ~ B + 1])
+    @test isempty(equations(jsys).x[2])
+    vrj1 = equations(jsys).x[3][1]
+    @test isequal(vrj1.rate, k2*B)
+    @test issetequal(vrj1.affect!, [B ~ B - 1])
+    vrj2 = equations(jsys).x[3][2]
+    @test isequal(vrj2.rate, k1 * t * A * C)
+    @test issetequal(vrj2.affect!, [B ~ B + 1])
+    vrj3 = equations(jsys).x[3][3]
+    @test isequal(vrj3.rate, k1 * B * A * (A - 1) / 2 * C)
+    @test issetequal(vrj3.affect!, [B ~ B + 1])
 end
 
 # test that jump solutions actually run correctly for constants and BCs

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -592,4 +592,7 @@ let
     @test count(j -> j isa VariableRateJump, jumps) == 4
     @test count(j -> j isa ConstantRateJump, jumps) == 1
     @test count(j -> j isa MassActionJump, jumps) == 3
+    dg = [[1, 2], [2, 3], [4], [4], [5, 6], [5, 6, 7, 8], [3, 7, 8], [1, 2, 7, 8]]
+    dgact = Catalyst.get_depgraph(rn)
+    @test dg == dgact
 end

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -210,47 +210,47 @@ let p = p
     @test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.ConstantRateJump, cidxs))
     @test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.VariableRateJump, vidxs))
 
-    pars = rand(length(k));
-    u0 = rand(2:10, 6);
-    ttt = rand();
+    pars = rand(length(k))
+    u0 = rand(2:10, 6)
+    ttt = rand()
     jumps = Vector{Union{ConstantRateJump, MassActionJump, VariableRateJump}}(undef,
-                                                                            length(rxs))
+                                                                              length(rxs))
 
-    jumps[1] = MassActionJump(pars[1], Vector{Pair{Int, Int}}(), [1 => 1]);
-    jumps[2] = MassActionJump(pars[2], [2 => 1], [2 => -1]);
-    jumps[3] = MassActionJump(pars[3], [1 => 1], [1 => -1, 3 => 1]);
-    jumps[4] = MassActionJump(pars[4], [3 => 1], [1 => 1, 2 => 1, 3 => -1]);
-    jumps[5] = MassActionJump(pars[5], [3 => 1], [1 => 2, 3 => -1]);
-    jumps[6] = MassActionJump(pars[6], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1]);
-    jumps[7] = MassActionJump(pars[7], [2 => 2], [1 => 1, 2 => -2]);
-    jumps[8] = MassActionJump(pars[8], [1 => 1, 2 => 1], [2 => -1, 3 => 1]);
-    jumps[9] = MassActionJump(pars[9], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1, 4 => 1]);
-    jumps[10] = MassActionJump(pars[10], [1 => 2], [1 => -2, 3 => 1, 4 => 1]);
-    jumps[11] = MassActionJump(pars[11], [1 => 2], [1 => -1, 2 => 1]);
+    jumps[1] = MassActionJump(pars[1], Vector{Pair{Int, Int}}(), [1 => 1])
+    jumps[2] = MassActionJump(pars[2], [2 => 1], [2 => -1])
+    jumps[3] = MassActionJump(pars[3], [1 => 1], [1 => -1, 3 => 1])
+    jumps[4] = MassActionJump(pars[4], [3 => 1], [1 => 1, 2 => 1, 3 => -1])
+    jumps[5] = MassActionJump(pars[5], [3 => 1], [1 => 2, 3 => -1])
+    jumps[6] = MassActionJump(pars[6], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1])
+    jumps[7] = MassActionJump(pars[7], [2 => 2], [1 => 1, 2 => -2])
+    jumps[8] = MassActionJump(pars[8], [1 => 1, 2 => 1], [2 => -1, 3 => 1])
+    jumps[9] = MassActionJump(pars[9], [1 => 1, 2 => 1], [1 => -1, 2 => -1, 3 => 1, 4 => 1])
+    jumps[10] = MassActionJump(pars[10], [1 => 2], [1 => -2, 3 => 1, 4 => 1])
+    jumps[11] = MassActionJump(pars[11], [1 => 2], [1 => -1, 2 => 1])
     jumps[12] = MassActionJump(pars[12], [1 => 1, 2 => 3, 3 => 4],
-                            [1 => -1, 2 => -3, 3 => -2, 4 => 3]);
-    jumps[13] = MassActionJump(pars[13], [1 => 3, 2 => 1], [1 => -3, 2 => -1]);
-    jumps[14] = MassActionJump(pars[14], Vector{Pair{Int, Int}}(), [1 => 2]);
+                               [1 => -1, 2 => -3, 3 => -2, 4 => 3])
+    jumps[13] = MassActionJump(pars[13], [1 => 3, 2 => 1], [1 => -3, 2 => -1])
+    jumps[14] = MassActionJump(pars[14], Vector{Pair{Int, Int}}(), [1 => 2])
 
     jumps[15] = ConstantRateJump((u, p, t) -> p[15] * u[1] / (2 + u[1]),
-                                integrator -> (integrator.u[1] -= 1))
+                                 integrator -> (integrator.u[1] -= 1))
     jumps[16] = ConstantRateJump((u, p, t) -> p[16],
-                                integrator -> (integrator.u[1] -= 1; integrator.u[2] += 1))
+                                 integrator -> (integrator.u[1] -= 1; integrator.u[2] += 1))
     jumps[17] = ConstantRateJump((u, p, t) -> p[17] * u[1] * exp(u[2]) * binomial(u[3], 2),
-                                integrator -> (integrator.u[3] -= 2; integrator.u[4] += 1))
+                                 integrator -> (integrator.u[3] -= 2; integrator.u[4] += 1))
     jumps[18] = ConstantRateJump((u, p, t) -> p[18] * u[2],
-                                integrator -> (integrator.u[2] += 2))
+                                 integrator -> (integrator.u[2] += 2))
 
     jumps[19] = VariableRateJump((u, p, t) -> p[19] * u[4] * t,
-                                integrator -> (integrator.u[4] -= 1; integrator.u[5] += 1))
+                                 integrator -> (integrator.u[4] -= 1; integrator.u[5] += 1))
     jumps[20] = VariableRateJump((u, p, t) -> p[20] * t * u[1] * binomial(u[4], 2) * u[5],
-                                integrator -> (integrator.u[4] -= 2; integrator.u[5] -= 1; integrator.u[6] += 2))
+                                 integrator -> (integrator.u[4] -= 2; integrator.u[5] -= 1; integrator.u[6] += 2))
 
     statetoid = Dict(state => i for (i, state) in enumerate(states(js)))
     jspmapper = ModelingToolkit.JumpSysMajParamMapper(js, pars)
     symmaj = ModelingToolkit.assemble_maj(equations(js).x[1], statetoid, jspmapper)
     maj = MassActionJump(symmaj.param_mapper(pars), symmaj.reactant_stoch, symmaj.net_stoch,
-                        symmaj.param_mapper, scale_rates = false)
+                         symmaj.param_mapper, scale_rates = false)
     for i in midxs
         @test abs(jumps[i].scaled_rates - maj.scaled_rates[i]) < 100 * eps()
         @test jumps[i].reactant_stoch == maj.reactant_stoch[i]
@@ -486,7 +486,7 @@ let
     end
     @test isempty(equations(jsys).x[2])
     vrj1 = equations(jsys).x[3][1]
-    @test isequal(vrj1.rate, k2*B)
+    @test isequal(vrj1.rate, k2 * B)
     @test issetequal(vrj1.affect!, [B ~ B - 1])
     vrj2 = equations(jsys).x[3][2]
     @test isequal(vrj2.rate, k1 * t * A * C)

--- a/test/reactionsystem.jl
+++ b/test/reactionsystem.jl
@@ -545,3 +545,22 @@ let
     @test_throws ErrorException ReactionSystem([rx], t; name = :rs)
     @named rs = ReactionSystem([rx], t; balanced_bc_check = false)
 end
+
+# test for classification of jump types
+let
+    rn = @reaction_network begin
+        t, A --> B          # vrj
+        1.0, B --> D        # vrj
+        k*D, H --> I + H    # vrj
+        k2, I --> L         # vrj
+        k, E --> F          # maj
+        k*E, E --> G        # crj
+        k2, G --> H         # maj
+        k2, G --> A + B     # maj
+    end k k2
+    jsys = convert(JumpSystem, rn)
+    jumps = Catalyst.assemble_jumps(rn)
+    @test count(j -> j isa VariableRateJump, jumps) == 4
+    @test count(j -> j isa ConstantRateJump, jumps) == 1
+    @test count(j -> j isa MassActionJump, jumps) == 3
+end

--- a/test/symbolic_stoich.jl
+++ b/test/symbolic_stoich.jl
@@ -145,7 +145,7 @@ function affect1!(integrator)
 end
 ttt = 1.5
 j1 = VariableRateJump(r1, affect1!)
-vrj = ModelingToolkit.assemble_vrj(js, equations(js)[2], statetoid)
+vrj = ModelingToolkit.assemble_vrj(js, equations(js)[1], statetoid)
 @test isapprox(vrj.rate(u0, p, ttt), r1(u0, p, ttt))
 fake_integrator1 = (u = copy(u0), p = p, t = ttt);
 fake_integrator2 = deepcopy(fake_integrator1);
@@ -172,12 +172,12 @@ function affect2!(integrator)
     integrator.u[4] += α
     nothing
 end
-j2 = ConstantRateJump(r2, affect2!)
-crj = ModelingToolkit.assemble_crj(js, equations(js)[1], statetoid)
-@test isapprox(crj.rate(u0, p, ttt), r2(u0, p, ttt))
+j2 = VariableRateJump(r2, affect2!)
+vrj = ModelingToolkit.assemble_vrj(js, equations(js)[2], statetoid)
+@test isapprox(vrj.rate(u0, p, ttt), r2(u0, p, ttt))
 fake_integrator1 = (u = copy(u0), p = p, t = ttt);
 fake_integrator2 = deepcopy(fake_integrator1);
-crj.affect!(fake_integrator1);
+vrj.affect!(fake_integrator1);
 affect2!(fake_integrator2);
 @test fake_integrator1 == fake_integrator2
 


### PR DESCRIPTION
Should close https://github.com/SciML/Catalyst.jl/issues/528.

This can definitely be better optimized, and `ModelingToolkit.JumpSystem` should get updated to be able to take dependency graphs as an optional input (since we are already calculating them here). I'll plan to circle back and better optimize down the line.