### PR TITLE
Implement spatial ODE simulations

### DIFF
--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -30,7 +30,8 @@ import ModelingToolkit: check_variables, check_parameters, _iszero, _merge, chec
                         get_unit, check_equations
 
 import Base: (==), hash, size, getindex, setindex, isless, Sort.defalg, length, show
-import MacroTools, Graphs
+import MacroTools
+import Graphs, Graphs.DiGraph, Graphs.SimpleGraph, Graphs.vertices, Graphs.edges
 import DataStructures: OrderedDict, OrderedSet
 import Parameters: @with_kw_noshow
 
@@ -91,5 +92,9 @@ include("latexify_recipes.jl")
 # for making and saving graphs
 include("graphs.jl")
 export Graph, savegraph, complexgraph
+
+# for spatial simulations.
+include("spatial_reaction_network.jl")
+export LatticeReactionSystem, SpatialReaction, diffusion_reaction
 
 end # module

--- a/src/spatial_reaction_network.jl
+++ b/src/spatial_reaction_network.jl
@@ -1,0 +1,109 @@
+### Spatial Reaction Structure. ###
+# Describing a spatial reaction that involves species from two neighbouring compartments.
+# Currently only permit constant rate.
+struct SpatialReaction
+    rate::Symbol
+    substrates::Tuple{Vector{Pair{Symbol,Int64}},Vector{Pair{Symbol,Int64}}}
+    products::Tuple{Vector{Pair{Symbol,Int64}},Vector{Pair{Symbol,Int64}}}
+    net_stoich_src::Vector{Pair{Symbol, Int64}}
+    net_stoich_dst::Vector{Pair{Symbol, Int64}}
+
+    function SpatialReaction(rate::Symbol, substrates_in::Tuple{Vector,Vector}, products_in::Tuple{Vector,Vector})
+        substrates = process_sr_species.(substrates_in)
+        products = process_sr_species.(products_in)
+        new(rate, substrates, products, net_stoich(substrates,products,1), net_stoich(substrates,products,2))
+    end
+end
+process_sr_species(species::Vector) = map(s -> (s isa Symbol) ? s => 1 : s, species);
+function net_stoich(substrates, products, idx)
+    sub_dict = Dict(Pair.(first.(substrates[idx]), -last.(substrates[idx])))
+    prod_dict = Dict(products[idx])
+    return collect(mergewith(-, prod_dict, sub_dict))
+end;
+
+function diffusion_reaction(rate, species)
+    return SpatialReaction(rate, ([species], []), ([]), [species])
+end;
+
+### Lattice Reaction Network Structure ###
+# Couples:
+# A reaction network (that is simulated within each compartment).
+# A set of spatial reactions (denoting interaction between comaprtments).
+# A network of compartments (a meta graph that can contain some additional infro for each compartment).
+# The lattice is a DiGraph, normals graphs are converted to DiGraphs (with one edge in each direction).
+struct LatticeReactionSystem # <: MT.AbstractTimeDependentSystem # Adding this part messes up show, disabling me from creating LRSs
+    """The spatial reactions defined between individual nodes."""
+    rs::ReactionSystem
+    """The spatial reactions defined between individual nodes."""
+    spatial_reactions::Vector{SpatialReaction}
+    """The graph on which the lattice is defined."""
+    lattice::DiGraph
+    """Dependent (state) variables representing amount of each species. Must not contain the
+    independent variable."""
+    
+    function LatticeReactionSystem(rs, spatial_reactions, lattice::DiGraph)
+        return new(rs, spatial_reactions, lattice)
+    end
+    function LatticeReactionSystem(rs, spatial_reactions, lattice::SimpleGraph)
+        return new(rs, spatial_reactions, DiGraph(lattice))
+    end
+end
+
+### ODEProblem ###
+# Creates an ODEProblem from a LatticeReactionSystem.
+function DiffEqBase.ODEProblem(lrs::LatticeReactionSystem, u0, tspan,
+                               p = DiffEqBase.NullParameters(), args...;
+                               kwargs...)
+    @unpack rs, spatial_reactions, lattice = lrs       
+                        
+    spatial_params = unique(getfield.(spatial_reactions, :rate))
+    pV_in, pE_in = split_parameters(p, spatial_params)
+    nV, nE = length.([vertices(lattice), edges(lattice)])
+    u_idxs = Dict(reverse.(enumerate(Symbol.(getfield.(states(rs), :f)))))
+    pV_idxes = Dict(reverse.(enumerate(Symbol.(parameters(rs)))))
+    pE_idxes = Dict(reverse.(enumerate(unique(getfield.(spatial_reactions, :rate)))))
+
+    u0 = matrix_form(u0, nV, u_idxs)
+    pV = matrix_form(pV_in, nV, pV_idxes)
+    pE = matrix_form(pE_in, nE, pE_idxes);
+
+    return ODEProblem(build_f(lrs, u_idxs, pE_idxes), u0, tspan, (pV,pE), args...; kwargs...)
+end
+
+# Splits parameters into those for the compartments and those for the connections.
+split_parameters(parameters::Tuple, spatial_params) = parameters
+split_parameters(parameters::Vector, spatial_params) = filter(p -> !in(p[1], spatial_params), parameters), filter(p -> in(p[1], spatial_params), parameters);
+
+# Converts species and parameters to matrices form.
+matrix_form(input::Matrix, args...) = input
+matrix_form(input::Vector{Pair{Symbol,Vector{Float64}}}, n, index_dict) = mapreduce(permutedims, vcat, last.(sort(input, by=i -> index_dict[i[1]])))
+matrix_form(input::Vector, n, index_dict) = matrix_form(map(i -> (i[2] isa Vector) ? i[1] => i[2] : i[1] => fill(i[2], n), input), n, index_dict);
+
+# Creates a function for simulating the spatial ODE with spatial reactions.
+function build_f(lrs::LatticeReactionSystem, u_idxs::Dict{Symbol,Int64}, pE_idxes::Dict{Symbol,Int64})
+    ofunc = ODEFunction(convert(ODESystem, lrs.rs))
+
+    return function internal___spatial___f(du, u, p, t)
+        # Updates for non-spatial reactions.
+        for comp_i in 1:size(u,2)
+            ofunc((@view du[:,comp_i]), (@view u[:,comp_i]), p[1], t)
+        end
+        
+        # Updates for spatial reactions.
+        for comp_i in 1:size(u,2)
+            for comp_j::Int64 in (lrs.lattice.fadjlist::Vector{Vector{Int64}})[comp_i], sr::SpatialReaction in lrs.spatial_reactions::Vector{SpatialReaction}
+                rate = get_rate(sr,p[2],(@view u[:,comp_i]),(@view u[:,comp_j]), u_idxs, pE_idxes)
+                foreach(stoich -> du[u_idxs[stoich[1]],comp_i] += rate*stoich[2], sr.net_stoich_src)
+                foreach(stoich -> du[u_idxs[stoich[1]],comp_j] += rate*stoich[2], sr.net_stoich_dst)
+            end
+        end
+    end
+end
+
+# Get the rate of a specific reaction.
+function get_rate(sr, pE, u_src, u_dst, u_idxs, pE_idxes)
+    product = pE[pE_idxes[sr.rate]]
+    !isempty(sr.substrates[1]) && (product *= prod(u_src[u_idxs[subs[1]]]^subs[2] / factorial(subs[2]) for subs in sr.substrates[1]))
+    !isempty(sr.substrates[2]) && (product *= prod(u_dst[u_idxs[subs[1]]]^subs[2] / factorial(subs[2]) for subs in sr.substrates[2]))
+    return product::Float64
+end

--- a/src/spatial_reaction_network.jl
+++ b/src/spatial_reaction_network.jl
@@ -59,7 +59,7 @@ function DiffEqBase.ODEProblem(lrs::LatticeReactionSystem, u0, tspan,
     spatial_params = unique(getfield.(spatial_reactions, :rate))
     pV_in, pE_in = split_parameters(p, spatial_params)
     nV, nE = length.([vertices(lattice), edges(lattice)])
-    u_idxs = Dict(reverse.(enumerate(Symbol.(getfield.(states(rs), :f)))))
+    u_idxs = Dict(reverse.(enumerate(Symbolics.getname.(states(rs)))))
     pV_idxes = Dict(reverse.(enumerate(Symbol.(parameters(rs)))))
     pE_idxes = Dict(reverse.(enumerate(unique(getfield.(spatial_reactions, :rate)))))
 

--- a/src/spatial_reaction_network.jl
+++ b/src/spatial_reaction_network.jl
@@ -20,13 +20,30 @@ struct SpatialReaction
     Currently only `false`, is supported.
     """
     only_use_rate::Bool
-    function SpatialReaction(rate, substrates, products, substoich, prodstoich;
+    function SpatialReaction(rate, substrates::Tuple{Vector, Vector}, products::Tuple{Vector, Vector}, substoich::Tuple{Vector{Int64}, Vector{Int64}}, prodstoich::Tuple{Vector{Int64}, Vector{Int64}};
                              only_use_rate = false)
-        products::Tuple{Vector, Vector}
         new(rate, substrates, products, substoich, prodstoich,
             get_netstoich.(substrates, products, substoich, prodstoich), only_use_rate)
     end
 end
+
+"""
+    DiffusionReaction(rate,species)
+
+Simple function to create a diffusion spatial reaction. 
+    Equivalent to SpatialReaction(rate,([species],[]),([],[species]),([1],[]),([],[1]))
+"""
+DiffusionReaction(rate,species) = SpatialReaction(rate,([species],[]),([],[species]),([1],[]),([],[1]))
+
+"""
+    OnewaySpatialReaction(rate, substrates, products, substoich, prodstoich)
+
+Simple function to create a spatial reactions where all substrates are in teh soruce compartment, and all products in the destination.
+Equivalent to SpatialReaction(rate,(substrates,[]),([],products),(substoich,[]),([],prodstoich))
+"""
+OnewaySpatialReaction(rate, substrates::Vector, products::Vector, substoich::Vector{Int64}, prodstoich::Vector{Int64}) = SpatialReaction(rate,(substrates,[]),([],products),(substoich,[]),([],prodstoich))
+
+
 
 ### Lattice Reaction Network Structure ###
 # Couples:

--- a/src/spatial_reaction_network.jl
+++ b/src/spatial_reaction_network.jl
@@ -5,28 +5,28 @@ struct SpatialReaction
     """The rate function (excluding mass action terms). Currentl only cosntants supported"""
     rate::Any
     """Reaction substrates (source and destination)."""
-    substrates::Tuple{Vector,Vector}
+    substrates::Tuple{Vector, Vector}
     """Reaction products (source and destination)."""
-    products::Tuple{Vector,Vector}
+    products::Tuple{Vector, Vector}
     """The stoichiometric coefficients of the reactants (source and destination)."""
-    substoich::Tuple{Vector{Int64},Vector{Int64}}
+    substoich::Tuple{Vector{Int64}, Vector{Int64}}
     """The stoichiometric coefficients of the products (source and destination)."""
-    prodstoich::Tuple{Vector{Int64},Vector{Int64}}
+    prodstoich::Tuple{Vector{Int64}, Vector{Int64}}
     """The net stoichiometric coefficients of all species changed by the reaction (source and destination)."""
-    netstoich::Tuple{Vector{Pair},Vector{Pair}}
+    netstoich::Tuple{Vector{Pair}, Vector{Pair}}
     """
     `false` (default) if `rate` should be multiplied by mass action terms to give the rate law.
     `true` if `rate` represents the full reaction rate law.
     Currently only `false`, is supported.
     """
     only_use_rate::Bool
-    function SpatialReaction(rate, substrates, products, substoich, prodstoich; only_use_rate=false)
-    products::Tuple{Vector,Vector}
-        new(rate, substrates, products, substoich, prodstoich, get_netstoich.(substrates,products,substoich,prodstoich), only_use_rate)
+    function SpatialReaction(rate, substrates, products, substoich, prodstoich;
+                             only_use_rate = false)
+        products::Tuple{Vector, Vector}
+        new(rate, substrates, products, substoich, prodstoich,
+            get_netstoich.(substrates, products, substoich, prodstoich), only_use_rate)
     end
 end
-
-
 
 ### Lattice Reaction Network Structure ###
 # Couples:
@@ -43,7 +43,7 @@ struct LatticeReactionSystem # <: MT.AbstractTimeDependentSystem # Adding this p
     lattice::DiGraph
     """Dependent (state) variables representing amount of each species. Must not contain the
     independent variable."""
-    
+
     function LatticeReactionSystem(rs, spatial_reactions, lattice::DiGraph)
         return new(rs, spatial_reactions, lattice)
     end
@@ -57,8 +57,8 @@ end
 function DiffEqBase.ODEProblem(lrs::LatticeReactionSystem, u0, tspan,
                                p = DiffEqBase.NullParameters(), args...;
                                kwargs...)
-    @unpack rs, spatial_reactions, lattice = lrs       
-                        
+    @unpack rs, spatial_reactions, lattice = lrs
+
     spatial_params = unique(getfield.(spatial_reactions, :rate))
     pV_in, pE_in = split_parameters(p, spatial_params)
     nV, nE = length.([vertices(lattice), edges(lattice)])
@@ -68,36 +68,51 @@ function DiffEqBase.ODEProblem(lrs::LatticeReactionSystem, u0, tspan,
 
     u0 = matrix_form(u0, nV, u_idxs)
     pV = matrix_form(pV_in, nV, pV_idxes)
-    pE = matrix_form(pE_in, nE, pE_idxes);
+    pE = matrix_form(pE_in, nE, pE_idxes)
 
-    return ODEProblem(build_f(lrs, u_idxs, pE_idxes), u0, tspan, (pV,pE), args...; kwargs...)
+    return ODEProblem(build_f(lrs, u_idxs, pE_idxes), u0, tspan, (pV, pE), args...;
+                      kwargs...)
 end
 
 # Splits parameters into those for the compartments and those for the connections.
 split_parameters(parameters::Tuple, spatial_params) = parameters
-split_parameters(parameters::Vector, spatial_params) = filter(p -> !in(p[1], spatial_params), parameters), filter(p -> in(p[1], spatial_params), parameters);
+function split_parameters(parameters::Vector, spatial_params)
+    filter(p -> !in(p[1], spatial_params), parameters),
+    filter(p -> in(p[1], spatial_params), parameters)
+end;
 
 # Converts species and parameters to matrices form.
 matrix_form(input::Matrix, args...) = input
-matrix_form(input::Vector{Pair{Symbol,Vector{Float64}}}, n, index_dict) = mapreduce(permutedims, vcat, last.(sort(input, by=i -> index_dict[i[1]])))
-matrix_form(input::Vector, n, index_dict) = matrix_form(map(i -> (i[2] isa Vector) ? i[1] => i[2] : i[1] => fill(i[2], n), input), n, index_dict);
+function matrix_form(input::Vector{Pair{Symbol, Vector{Float64}}}, n, index_dict)
+    mapreduce(permutedims, vcat, last.(sort(input, by = i -> index_dict[i[1]])))
+end
+function matrix_form(input::Vector, n, index_dict)
+    matrix_form(map(i -> (i[2] isa Vector) ? i[1] => i[2] : i[1] => fill(i[2], n), input),
+                n, index_dict)
+end;
 
 # Creates a function for simulating the spatial ODE with spatial reactions.
-function build_f(lrs::LatticeReactionSystem, u_idxs::Dict{Symbol,Int64}, pE_idxes::Dict{Symbol,Int64})
+function build_f(lrs::LatticeReactionSystem, u_idxs::Dict{Symbol, Int64},
+                 pE_idxes::Dict{Symbol, Int64})
     ofunc = ODEFunction(convert(ODESystem, lrs.rs))
 
     return function internal___spatial___f(du, u, p, t)
         # Updates for non-spatial reactions.
-        for comp_i in 1:size(u,2)
-            ofunc((@view du[:,comp_i]), (@view u[:,comp_i]), p[1], t)
+        for comp_i in 1:size(u, 2)
+            ofunc((@view du[:, comp_i]), (@view u[:, comp_i]), p[1], t)
         end
-        
+
         # Updates for spatial reactions.
-        for comp_i in 1:size(u,2)
-            for comp_j::Int64 in (lrs.lattice.fadjlist::Vector{Vector{Int64}})[comp_i], sr::SpatialReaction in lrs.spatial_reactions::Vector{SpatialReaction}
-                rate = get_rate(sr,p[2],(@view u[:,comp_i]),(@view u[:,comp_j]), u_idxs, pE_idxes)
-                foreach(stoich -> du[u_idxs[stoich[1]],comp_i] += rate*stoich[2], sr.netstoich[1])
-                foreach(stoich -> du[u_idxs[stoich[1]],comp_j] += rate*stoich[2], sr.netstoich[2])
+        for comp_i in 1:size(u, 2)
+            for comp_j::Int64 in (lrs.lattice.fadjlist::Vector{Vector{Int64}})[comp_i],
+                sr::SpatialReaction in lrs.spatial_reactions::Vector{SpatialReaction}
+
+                rate = get_rate(sr, p[2], (@view u[:, comp_i]), (@view u[:, comp_j]),
+                                u_idxs, pE_idxes)
+                foreach(stoich -> du[u_idxs[stoich[1]], comp_i] += rate * stoich[2],
+                        sr.netstoich[1])
+                foreach(stoich -> du[u_idxs[stoich[1]], comp_j] += rate * stoich[2],
+                        sr.netstoich[2])
             end
         end
     end
@@ -106,15 +121,11 @@ end
 # Get the rate of a specific reaction.
 function get_rate(sr, pE, u_src, u_dst, u_idxs, pE_idxes)
     product = pE[pE_idxes[sr.rate]]
-    !isempty(sr.substrates[1]) && (product *= prod(u_src[u_idxs[subs[1]]]^subs[2] / factorial(subs[2]) for subs in Pair.(sr.substrates[1],sr.substoich[1])))
-    !isempty(sr.substrates[2]) && (product *= prod(u_dst[u_idxs[subs[1]]]^subs[2] / factorial(subs[2]) for subs in Pair.(sr.substrates[2],sr.substoich[2])))
+    !isempty(sr.substrates[1]) &&
+        (product *= prod(u_src[u_idxs[subs[1]]]^subs[2] / factorial(subs[2])
+                         for subs in Pair.(sr.substrates[1], sr.substoich[1])))
+    !isempty(sr.substrates[2]) &&
+        (product *= prod(u_dst[u_idxs[subs[1]]]^subs[2] / factorial(subs[2])
+                         for subs in Pair.(sr.substrates[2], sr.substoich[2])))
     return product::Float64
 end
-
-# Get the rate of a specific reaction.
-#function get_rate(sr, pE, u_src, u_dst, u_idxs, pE_idxes)
-#    product = pE[pE_idxes[sr.rate]]
-#    !isempty(sr.substrates[1]) && (product *= prod(u_src[u_idxs[subs[1]]]^subs[2] / factorial(subs[2]) for subs in sr.substrates[1]))
-#    !isempty(sr.substrates[2]) && (product *= prod(u_dst[u_idxs[subs[1]]]^subs[2] / factorial(subs[2]) for subs in sr.substrates[2]))
-#    return product::Float64
-#end

--- a/src/spatial_reaction_network.jl
+++ b/src/spatial_reaction_network.jl
@@ -3,17 +3,17 @@
 # Currently only permit constant rate.
 struct SpatialReaction
     """The rate function (excluding mass action terms). Currentl only cosntants supported"""
-    rate::Any
+    rate::Symbol
     """Reaction substrates (source and destination)."""
-    substrates::Tuple{Vector, Vector}
+    substrates::Tuple{Vector{Symbol}, Vector{Symbol}}
     """Reaction products (source and destination)."""
-    products::Tuple{Vector, Vector}
+    products::Tuple{Vector{Symbol}, Vector{Symbol}}
     """The stoichiometric coefficients of the reactants (source and destination)."""
     substoich::Tuple{Vector{Int64}, Vector{Int64}}
     """The stoichiometric coefficients of the products (source and destination)."""
     prodstoich::Tuple{Vector{Int64}, Vector{Int64}}
     """The net stoichiometric coefficients of all species changed by the reaction (source and destination)."""
-    netstoich::Tuple{Vector{Pair}, Vector{Pair}}
+    netstoich::Tuple{Vector{Pair{Symbol,Int64}}, Vector{Pair{Symbol,Int64}}}
     """
     `false` (default) if `rate` should be multiplied by mass action terms to give the rate law.
     `true` if `rate` represents the full reaction rate law.

--- a/src/spatial_reaction_network.jl
+++ b/src/spatial_reaction_network.jl
@@ -20,10 +20,31 @@ struct SpatialReaction
     Currently only `false`, is supported.
     """
     only_use_rate::Bool
-    function SpatialReaction(rate, substrates::Tuple{Vector, Vector}, products::Tuple{Vector, Vector}, substoich::Tuple{Vector{Int64}, Vector{Int64}}, prodstoich::Tuple{Vector{Int64}, Vector{Int64}};
-                             only_use_rate = false)
-        new(rate, substrates, products, substoich, prodstoich,
-            get_netstoich.(substrates, products, substoich, prodstoich), only_use_rate)
+
+    """These are similar to substrates, products, and netstoich, but ses species index (instead ) """
+    function SpatialReaction(rate, substrates::Tuple{Vector, Vector}, products::Tuple{Vector, Vector}, substoich::Tuple{Vector{Int64}, Vector{Int64}}, prodstoich::Tuple{Vector{Int64}, Vector{Int64}}; only_use_rate = false)
+        new(rate, substrates, products, substoich, prodstoich, get_netstoich.(substrates, products, substoich, prodstoich), only_use_rate)
+    end
+end
+
+# As a spatial reaction, but replaces the species (and parameter) symbols with their index.
+# For internal use only (to avoid having to constantly look up species indexes).
+struct SpatialReactionIndexed
+    rate::Int64
+    substrates::Tuple{Vector{Int64}, Vector{Int64}}
+    products::Tuple{Vector{Int64}, Vector{Int64}}
+    substoich::Tuple{Vector{Int64}, Vector{Int64}}
+    prodstoich::Tuple{Vector{Int64}, Vector{Int64}}
+    netstoich::Tuple{Vector{Pair{Int64,Int64}}, Vector{Pair{Int64,Int64}}}
+    only_use_rate::Bool
+
+    function SpatialReactionIndexed(sr::SpatialReaction, species_list::Vector{Symbol}, param_list::Vector{Symbol})
+        get_s_idx(species::Symbol) = findfirst(species .== (species_list))
+        rate = findfirst(sr.rate .== (param_list))
+        substrates = Tuple([get_s_idx.(sr.substrates[i]) for i in 1:2])
+        products = Tuple([get_s_idx.(sr.products[i]) for i in 1:2])
+        netstoich = Tuple([Pair.(get_s_idx.(first.(sr.netstoich[i])), last.(sr.netstoich[i])) for i in 1:2])
+        new(rate, substrates, products, sr.substoich, sr.prodstoich, netstoich, sr.only_use_rate)
     end
 end
 
@@ -73,30 +94,31 @@ end
 # Creates an ODEProblem from a LatticeReactionSystem.
 function DiffEqBase.ODEProblem(lrs::LatticeReactionSystem, u0, tspan,
                                p = DiffEqBase.NullParameters(), args...;
-                               kwargs...)
+                               sparse=true, kwargs...)
     @unpack rs, spatial_reactions, lattice = lrs
 
     spatial_params = unique(getfield.(spatial_reactions, :rate))
     pV_in, pE_in = split_parameters(p, spatial_params)
-    nV, nE = length.([vertices(lattice), edges(lattice)])
     u_idxs = Dict(reverse.(enumerate(Symbolics.getname.(states(rs)))))
     pV_idxes = Dict(reverse.(enumerate(Symbol.(parameters(rs)))))
     pE_idxes = Dict(reverse.(enumerate(spatial_params)))
 
-    u0 = matrix_form(u0, nV, u_idxs)
+    nS,nV,nE = length.([states(lrs.rs), vertices(lrs.lattice), edges(lrs.lattice)])
+    u0 = Vector(reshape(matrix_form(u0, nV, u_idxs),1:nS*nV))
+
     pV = matrix_form(pV_in, nV, pV_idxes)
     pE = matrix_form(pE_in, nE, pE_idxes)
 
-    return ODEProblem(build_f(lrs, u_idxs, pE_idxes), u0, tspan, (pV, pE), args...;
-                      kwargs...)
+    ofun = build_odefunction(lrs, sparse, spatial_params)
+    return ODEProblem(ofun, u0, tspan, (pV, pE), args...; kwargs...)
 end
 
 # Splits parameters into those for the compartments and those for the connections.
-split_parameters(parameters::Tuple, spatial_params) = parameters
-function split_parameters(parameters::Vector, spatial_params)
+split_parameters(parameters::Tuple, spatial_params::Vector{Symbol}) = parameters
+function split_parameters(parameters::Vector, spatial_params::Vector{Symbol})
     filter(p -> !in(p[1], spatial_params), parameters),
     filter(p -> in(p[1], spatial_params), parameters)
-end;
+end
 
 # Converts species and parameters to matrices form.
 matrix_form(input::Matrix, args...) = input
@@ -106,30 +128,38 @@ end
 function matrix_form(input::Vector, n, index_dict)
     matrix_form(map(i -> (i[2] isa Vector) ? i[1] => i[2] : i[1] => fill(i[2], n), input),
                 n, index_dict)
-end;
+end
+
+# Builds an ODEFunction.
+function build_odefunction(lrs::LatticeReactionSystem, sparse::Bool, spatial_params::Vector{Symbol})
+    ofunc = ODEFunction(convert(ODESystem, lrs.rs); jac=true)
+    nS,nV = length.([states(lrs.rs), vertices(lrs.lattice)])
+    spatial_reactions = [SpatialReactionIndexed(sr, Symbol.(getfield.(states(lrs.rs), :f)), spatial_params) for sr in lrs.spatial_reactions]
+
+    f = build_f(ofunc, nS, nV, spatial_reactions, lrs.lattice.fadjlist)
+    jac = build_jac(ofunc,nS,nV,spatial_reactions, lrs.lattice.fadjlist)
+    jac_prototype = build_jac_prototype(nS,nV,spatial_reactions, lrs)
+
+    return ODEFunction(f; jac=jac, jac_prototype=(sparse ? SparseArrays.sparse(jac_prototype) : jac_prototype))
+end
 
 # Creates a function for simulating the spatial ODE with spatial reactions.
-function build_f(lrs::LatticeReactionSystem, u_idxs::Dict{Symbol, Int64},
-                 pE_idxes::Dict{Symbol, Int64})
-    ofunc = ODEFunction(convert(ODESystem, lrs.rs))
-
-    return function internal___spatial___f(du, u, p, t)
+function build_f(ofunc::SciMLBase.AbstractODEFunction{true}, nS::Int64, nV::Int64, spatial_reactions::Vector{SpatialReactionIndexed}, adjlist::Vector{Vector{Int64}})
+    return function(du, u, p, t)
         # Updates for non-spatial reactions.
-        for comp_i in 1:size(u, 2)
-            ofunc((@view du[:, comp_i]), (@view u[:, comp_i]), p[1], t)
+        for comp_i in 1:nV
+            ofunc((@view du[get_indexes(comp_i,nS)]), (@view u[get_indexes(comp_i,nS)]), (@view p[1][:,comp_i]), t)
         end
-
+    
         # Updates for spatial reactions.
-        for comp_i in 1:size(u, 2)
-            for comp_j::Int64 in (lrs.lattice.fadjlist::Vector{Vector{Int64}})[comp_i],
-                sr::SpatialReaction in lrs.spatial_reactions::Vector{SpatialReaction}
-
-                rate = get_rate(sr, p[2], (@view u[:, comp_i]), (@view u[:, comp_j]), u_idxs, pE_idxes)
+        for comp_i in 1:nV
+            for comp_j in adjlist[comp_i], sr in spatial_reactions
+                rate = get_rate(sr, p[2], (@view u[get_indexes(comp_i,nS)]), (@view u[get_indexes(comp_j,nS)]))
                 for stoich in sr.netstoich[1]
-                    du[u_idxs[stoich[1]], comp_i] += rate * stoich[2]
+                    du[get_index(comp_i,stoich[1],nS)] += rate * stoich[2]
                 end
                 for stoich in sr.netstoich[2]
-                    du[u_idxs[stoich[1]], comp_j] += rate * stoich[2]
+                    du[get_index(comp_j,stoich[1],nS)] += rate * stoich[2]
                 end
             end
         end
@@ -137,13 +167,95 @@ function build_f(lrs::LatticeReactionSystem, u_idxs::Dict{Symbol, Int64},
 end
 
 # Get the rate of a specific reaction.
-function get_rate(sr, pE, u_src, u_dst, u_idxs, pE_idxes)
-    product = pE[pE_idxes[sr.rate]]
+function get_rate(sr::SpatialReactionIndexed, pE::Matrix{Float64}, u_src, u_dst)
+    product = pE[sr.rate]
     !isempty(sr.substrates[1]) && for (sub,stoich) in zip(sr.substrates[1], sr.substoich[1])
-        product *= prod(u_src[u_idxs[sub]]^stoich / factorial(stoich))
+        product *= u_src[sub]^stoich / factorial(stoich)
     end
     !isempty(sr.substrates[2]) && for (sub,stoich) in zip(sr.substrates[2], sr.substoich[2])
-        product *= prod(u_dst[u_idxs[sub]]^stoich / factorial(stoich))
+        product *= u_dst[sub]^stoich / factorial(stoich)
     end
     return product
 end
+
+function build_jac(ofunc::SciMLBase.AbstractODEFunction{true}, nS::Int64, nV::Int64, spatial_reactions::Vector{SpatialReactionIndexed}, adjlist::Vector{Vector{Int64}})
+    base_zero = zeros(nS*nV,nS*nV)
+    return function(J, u, p, t)
+        J .= base_zero
+
+        # Updates for non-spatial reactions.
+        for comp_i in 1:nV
+            ofunc.jac((@view J[get_indexes(comp_i,nS),get_indexes(comp_i,nS)]), (@view u[get_indexes(comp_i,nS)]), (@view p[1][:,comp_i]), t)
+        end
+    
+        # Updates for spatial reactions.
+        for comp_i in 1:nV
+            for comp_j in adjlist[comp_i], sr in spatial_reactions
+                for sub in sr.substrates[1]
+                    rate = get_rate_differential(sr, p[2], sub, (@view u[get_indexes(comp_i,nS)]), (@view u[get_indexes(comp_j,nS)]))
+                    for stoich in sr.netstoich[1]
+                        J[get_index(comp_i,stoich[1],nS),get_index(comp_i,sub,nS)] += rate * stoich[2]
+                    end
+                    for stoich in sr.netstoich[2]
+                        J[get_index(comp_j,stoich[1],nS),get_index(comp_i,sub,nS)] += rate * stoich[2]
+                    end
+                end
+                for sub in sr.substrates[2]
+                    rate = get_rate_differential(sr, p[2], sub, (@view u[get_indexes(comp_j,nS)]), (@view u[get_indexes(comp_i,nS)]))
+                    for stoich in sr.netstoich[1]
+                        J[get_index(comp_i,stoich[1],nS),get_index(comp_j,sub,nS)] += rate * stoich[2]
+                    end
+                    for stoich in sr.netstoich[2]
+                        J[get_index(comp_j,stoich[1],nS),get_index(comp_j,sub,nS)] += rate * stoich[2]
+                    end
+                end
+            end
+        end
+    end
+end
+
+function get_rate_differential(sr::SpatialReactionIndexed, pE::Matrix{Float64}, diff_species::Int64, u_src, u_dst)
+    product = pE[sr.rate]
+    !isempty(sr.substrates[1]) && for (sub,stoich) in zip(sr.substrates[1], sr.substoich[1])
+        if diff_species==sub
+            product *= stoich*u_src[sub]^(stoich-1) / factorial(stoich)
+        else
+            product *= u_src[sub]^stoich / factorial(stoich)
+        end
+    end
+    !isempty(sr.substrates[2]) && for (sub,stoich) in zip(sr.substrates[2], sr.substoich[2])
+        product *= u_dst[sub]^stoich / factorial(stoich)
+    end
+    return product
+end
+
+function build_jac_prototype(nS::Int64, nV::Int64, spatial_reactions::Vector{SpatialReactionIndexed}, adjlist::Vector{Vector{Int64}})
+    jac_prototype = zeros(nS*nV,nS*nV)
+
+    # Sets non-spatial reactions.
+    foreach(comp_i -> jac_prototype[get_indexes(comp_i,nS),get_indexes(comp_i,nS)] = ones(nS,nS), 1:nV)
+    # Tries to utilise sparsity within each comaprtment, currently not working, not sure if useful.
+    # for comp_i in 1:nV, reaction in reactions(lrs.rs)        
+    #     for substrate in reaction.substrates, ns in reaction.netstoich
+    #         sub_idx = findfirst(isequal(substrate), states(lrs.rs))
+    #         spec_idx = findfirst(isequal(ns[1]), states(lrs.rs))
+    #         jac_prototype[spec_idx, sub_idx] = 1
+    #     end
+    # end
+
+    # Updates for spatial reactions.
+    for comp_i in 1:nV
+        for comp_j in adjlist[comp_i], sr in spatial_reactions
+            for (idx1, comp1) in [(1,comp_i),(2,comp_j)], sub in sr.substrates[idx1]
+                for (idx2, comp2) in [(1,comp_i),(2,comp_j)], stoich in sr.netstoich[idx2]
+                    jac_prototype[get_index(comp2,stoich[1],nS),get_index(comp1,sub,nS)] = 1
+                end
+            end
+        end
+    end
+    return jac_prototype
+end
+
+# Gets the index of a species (or a node's species) in the u array.
+get_index(container::Int64,species::Int64,nS) = (container-1)*nS + species
+get_indexes(container::Int64,nS) = (container-1)*nS+1:container*nS

--- a/test/lattice_reaction_systems.jl
+++ b/test/lattice_reaction_systems.jl
@@ -1,0 +1,20 @@
+### Very simple tests to have during development ###
+
+using Catalyst, OrdinaryDiffEq, Graphs
+
+rs = @reaction_network begin
+    A, ∅ → X
+    1, 2X + Y → 3X
+    B, X → Y
+    1, X → ∅
+end A B
+srs = [SpatialReaction(:D, ([:X], []), ([], [:X]), ([1], []), ([], [1]))]
+lattice = grid([20, 20])
+lrs = LatticeReactionSystem(rs, srs, lattice);
+
+u0_in = [:X => 10 * rand(nv(lattice)), :Y => 10 * rand(nv(lattice))]
+tspan = (0.0, 100.0)
+p_in = [:A => 1.0, :B => 4.0, :D => 0.2]
+
+oprob = ODEProblem(lrs, u0_in, tspan, p_in)
+@test solve(oprob, Tsit5()).retcode == :Success


### PR DESCRIPTION
New implementation of spatial ODE simulations. Instead of being based on MTK we now just write a new f function for our given spatial system, that loops through all compartments and connections. The advantage of this is that we no longer need to store a big equation, which helps with simulations over a large number of cells.

When making a spatial simulation:
`u0` is a NxM matrix, where N is the number of species in the (non-spatial) reaction network, and M is the number of compartments.
`p` is a tupple `(pV,pE)`, 
`pV` is a LxM matrix, where L is the number of parameters in the (non-spatial) reaction network, and M is the number of compartments.
`pE` is a RxS matrix, where R is the number of parameters tied to spatial reactions, and S is the number of connections.

Sample code:
```julia
using Catalyst, OrdinaryDiffEq, Graphs

rs = @reaction_network begin
    A, ∅ → X
    1, 2X + Y → 3X
    B, X → Y
    1, X → ∅
end A B
srs = [SpatialReaction(:D, ([:X], []), ([], [:X]))]
lattice = grid([20, 20])
lrs = LatticeReactionSystem(rs, srs, lattice);

u0_in = [:X => 10 * rand(nv(lattice)), :Y => 10 * rand(nv(lattice))]
tspan = (0.0, 100.0)
p_in = [:A => 1.0, :B => 4.0, :D => 0.2]

@time oprob = ODEProblem(lrs, u0_in, tspan, p_in)
@time sol = solve(oprob, Tsit5());
```

Plotting is not added to Catalyst right now, but running this code:
```julia
using GLMakie
using Makie.Colors
using GraphMakie
function animate_spatial_sol(sol, x_pos, y_pos; animation_name="spatial_animation.mp4", framerate=100, min_val=nothing, max_val=nothing, var=1, node_size=2.0, node_marker=:circle, edge_width=0.0, timetitle=true)
    trajectories = map(vals -> vals[var, :], sol.u)
    mini, maxi = extrema(vcat(trajectories...))
    !isnothing(min_val) && (mini = min_val)
    !isnothing(max_val) && (maxi = min_val)
    fixed_layout(_) = map(i -> (x_pos[i], y_pos[i]), 1:length(trajectories[1]))

    idx = Observable(1)
    colors = @lift map(val -> RGB{Float64}(val, val, 0.0), (trajectories[$idx] .- mini) ./ maxi)
    title = timetitle ? @lift("t = $(sol.t[($idx)])") : ""
    fig = graphplot(lattice, layout=fixed_layout, node_size=node_size, node_marker=node_marker, edge_width=edge_width, node_color=colors,
        axis=(title=title,))

    record(fig, animation_name, 1:length(sol.t);
        framerate=framerate) do i
        idx[] = i
    end
end
```
enable us to create a plot through:
```julia
x_pos = vcat(fill(1:20, 20)...)
y_pos = vcat(map(i -> fill(i, 20), 1:20)...)
@time animate_spatial_sol(sol, x_pos, y_pos; node_size=40.0, node_marker=:rect)
```
which show spatial effects in the Brusselator:
https://user-images.githubusercontent.com/18099310/205381134-b72f02bd-c24a-4264-a238-41d0d8fa2420.mp4
(I've never used Makie before, so still some things to iron out there to make the animation prettier)
