### PR TITLE
[skip ci] doc compats

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main()
+          CompatHelper.main(;subdirs=["", "docs"])
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Why is this compat helper script much more complicated than e.g [LinearSolve.jl](https://github.com/SciML/LinearSolve.jl/blob/main/.github/workflows/CompatHelper.yml )?
Would any of the other SciML packages benefit from the extra complexity here?