### PR TITLE
Enable `=>` and `<=` to ignore law of mass action in DSL

### DIFF
--- a/docs/src/faqs.md
+++ b/docs/src/faqs.md
@@ -193,11 +193,11 @@ rn = @reaction_network begin
 end k
 ```
 occurs at the (ODE) rate ``d[X]/dt = -k[X]``, it is possible to override this by
-using any of the following non-filled arrows when declaring the reaction: `⇐`,
-`⟽`, `⇒`, `⟾`, `⇔`, `⟺`. This means that the reaction
+using any of the following non-filled arrows when declaring the reaction: `<=`, `⇐`,
+`⟽`, `=>`, `⇒`, `⟾`, `⇔`, `⟺` (`<=>` currently not possible due to Julia langauge technical reasons). This means that the reaction
 ```julia
 rn = @reaction_network begin
-  k, X ⇒ ∅
+  k, X => ∅
 end k
 ```
 will occur at rate ``d[X]/dt = -k`` (which might become a problem since ``[X]``

--- a/docs/src/tutorials/advanced.md
+++ b/docs/src/tutorials/advanced.md
@@ -24,12 +24,12 @@ rn = @reaction_network begin
 end k
 ```
 occurs at the rate ``d[X]/dt = -k[X]``, it is possible to ignore this by using
-any of the following non-filled arrows when declaring the reaction: `⇐`, `⟽`,
-`⇒`, `⟾`, `⇔`, `⟺`. This means that the reaction
+any of the following non-filled arrows when declaring the reaction: `<=`, `⇐`, `⟽`,
+`⇒`, `⟾`, `=>`, `⇔`, `⟺` (`<=>` currently not possible due to Julia langauge technical reasons). This means that the reaction
 
 ```julia
 rn = @reaction_network begin
-  k, X ⇒ ∅
+  k, X => ∅
 end k
 ```
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -60,11 +60,11 @@ Example systems:
 
 # Declare various arrow types symbols used for the empty set (also 0).
 const empty_set = Set{Symbol}([:∅])
-const fwd_arrows = Set{Symbol}([:>, :→, :↣, :↦, :⇾, :⟶, :⟼, :⥟, :⥟, :⇀, :⇁, :⇒, :⟾])
-const bwd_arrows = Set{Symbol}([:<, :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :↼, :↽, :⇐, :⟽,
+const fwd_arrows = Set{Symbol}([:>, :(=>), :→, :↣, :↦, :⇾, :⟶, :⟼, :⥟, :⥟, :⇀, :⇁, :⇒, :⟾])
+const bwd_arrows = Set{Symbol}([:<, :(<=), :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :↼, :↽, :⇐, :⟽,
                                    Symbol("<--")])
 const double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇌, :⇋, :⇔, :⟺, Symbol("<-->")])
-const pure_rate_arrows = Set{Symbol}([:⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
+const pure_rate_arrows = Set{Symbol}([:(=>), :(<=), :⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
 
 # Declares symbols which may neither be used as parameters not varriables.
 forbidden_symbols = [:t, :π, :pi, :ℯ, :im, :nothing, :∅]

--- a/test/make_model.jl
+++ b/test/make_model.jl
@@ -162,6 +162,15 @@ differently_written_7 = @reaction_network begin
 end p1 p2 p3 k1 k2 k3 v1 K1 d1 d2 d3 d4 d5
 push!(identical_networks_2, reaction_networks_standard[7] => differently_written_7)
 
+# Ignore mass action new arrows.
+differently_written_8 = @reaction_network begin
+    (p1, p2, p3), ∅ => (X1, X2, X3)
+    (k1 * X1 * X2^2 / 2, k2 * X4), X1 + 2X2 ⟺ X4
+    (mm(X3, v1, K1) * X4, k3 * X5), X4 ⇔ X5
+    (d1 * X1, d2 * X2, d3 * X3, d4 * X4, d5 * X5), ∅ <= (X1, X2, X3, X4, X5)
+end p1 p2 p3 k1 k2 k3 v1 K1 d1 d2 d3 d4 d5
+push!(identical_networks_2, reaction_networks_standard[7] => differently_written_8)
+
 for networks in identical_networks_2
     f1 = ODEFunction(convert(ODESystem, networks[1]), jac = true)
     f2 = ODEFunction(convert(ODESystem, networks[2]), jac = true)


### PR DESCRIPTION
Since these can be written on a normal keyboard, `=>` and `<=` are now enabled when ignoring the law of mass action and only using the rate. I've added tests and updated the docs, should all should be ready.

I would have added `<=>` as well, but unfortunately `X <=> X` is not a valid Julai expression. If we are really keen on this we could try to moot for this (like `<-->` and `<--`, although these were way more important additions).