### PR TITLE
Add `form` option to latexify

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -176,13 +176,19 @@ function chemical_arrows(rn::ReactionSystem; expand = true,
     return latexstr
 end
 
-@latexrecipe function f(sys::ReactionSystem)
-    # Set default option values.
-    env --> :chem
-    cdot --> false
-
-    return sys
+@latexrecipe function f(rs::ReactionSystem; form=:reactions)
+    if form==:reactions    # Returns chemical reaction network code.
+        cdot --> false
+        env --> :chem
+        return rs
+    elseif form==:ode      # Returns ODE system code.
+        return convert(ODESystem,rs)
+    elseif form==:sde      # Returns SDE system code.
+        return convert(SDESystem,rs)
+    end
+    error("Unrecognised form argument given: $form. This should be either reactions (default), :ode, or :sde.")
 end
+
 
 function Latexify.infer_output(env, rs::ReactionSystem, args...)
     env in [:arrows, :chem, :chemical, :arrow] && return chemical_arrows

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -122,3 +122,18 @@ raw"\begin{align*}
 \ce{ Y &->[$Y k$] \varnothing}
 \end{align*}
 ", "\r\n"=>"\n")
+
+# Tests the `form` option
+for rn in reaction_networks_standard
+    @test latexify(rn)==latexify(rn; form=:reactions)
+end
+
+rn = @reaction_network begin 
+    (p,d), 0 <--> X
+    (kB,kD), 2X <--> X2
+end
+@test latexify(rn; form=:ode) == raw"$\begin{align}
+\frac{\mathrm{d} X\left( t \right)}{\mathrm{d}t} =& p - \left( X\left( t \right) \right)^{2} kB - d X\left( t \right) + 2 kD \mathrm{X2}\left( t \right) \\
+\frac{\mathrm{d} \mathrm{X2}\left( t \right)}{\mathrm{d}t} =& \frac{1}{2} \left( X\left( t \right) \right)^{2} kB - kD \mathrm{X2}\left( t \right)
+\end{align}
+$"


### PR DESCRIPTION
This add an option form to `latexify(rs::ReactionSystem)` so that
```julia
using Catalyst, Latexify

rn = @reaction_network begin 
    (p,d), 0 <--> X
    (kB,kD), 2X <--> X2
end

latexify(rn; form=:ode)
```
returns the ODE form and 
```julia
latexify(rn; form=:sde)
```
returns the side form.

This saves us from having to do 
```julia
latexify(convert(ODESystem,rn)
```
all the time (especially as the ODE form is probably the most common thing one wants to do when doing latexify).

This will also save us from having to do this in the doc, so we can move to introduce ODESystem forward (in case we want to).
