### PR TITLE
Documentation of initial conditions that depend on a parameter

### DIFF
--- a/docs/src/catalyst_functionality/dsl_description.md
+++ b/docs/src/catalyst_functionality/dsl_description.md
@@ -412,6 +412,26 @@ sol = solve(oprob)
 plot(sol)
 ```
 
+## Setting initial conditions that depend on parameters
+It is possible to set the initial condition of one (or several) species so that they depend on some system parameter. This is done in a similar way as default initial conditions, but giving the parameter instead of a value. When doing this, we also need to ensure that the initial condition parameter is a variable of the system:
+```@example tut2
+rn = @reaction_network begin
+  @species X(t)=X0
+  @parameters X0
+  p, 0 --> X
+  d, X --> ∅
+end
+```
+We can now simulate the network without providing any initial conditions:
+```@example tut2
+u0 = []
+tspan = (0.0, 10.0)
+p = [:p => 2.0, :d => .1, :X0 => 1.0]  
+oprob = ODEProblem(rn, u0, tspan, p)
+sol = solve(oprob)
+plot(sol)
+```
+
 ## Naming the generated `ReactionSystem`
 ModelingToolkit uses system names to allow for compositional and hierarchical
 models. To specify a name for the generated `ReactionSystem` via the

--- a/docs/src/catalyst_functionality/dsl_description.md
+++ b/docs/src/catalyst_functionality/dsl_description.md
@@ -416,8 +416,8 @@ plot(sol)
 It is possible to set the initial condition of one (or several) species so that they depend on some system parameter. This is done in a similar way as default initial conditions, but giving the parameter instead of a value. When doing this, we also need to ensure that the initial condition parameter is a variable of the system:
 ```@example tut2
 rn = @reaction_network begin
-  @species X(t)=X0
   @parameters X0
+  @species X(t)=X0
   p, 0 --> X
   d, X --> ∅
 end

--- a/test/reactionsystem_structure/reactionsystem.jl
+++ b/test/reactionsystem_structure/reactionsystem.jl
@@ -631,6 +631,17 @@ let
     @test issetequal(parameters(rs), [k, b])
 end
 
+# Test parameteric initial conditions.
+let
+    @parameters d X0
+    @variables t
+    @species X(t)=X0
+    rx = Reaction(d, [X], nothing, [1], nothing)
+    @named rs = ReactionSystem([rx], t)
+    prob = ODEProblem(rs, [], (0.0, 1.0), [d => 1.0, X0 => 7.6])
+    @test prob[X] == 7.6
+end
+
 # Test balanced_bc_check.
 let
     @variables t


### PR DESCRIPTION
It is possible for an initial condition to be a parameter:
```julia
using Catlyst
rn = @reaction_network begin
  @species X(t)=1.0
  @parameters p=1.0 d=0.1
  p, 0 --> X
  d, X --> ∅
end

using DifferentialEquations, Plots
u0 = []
tspan = (0.0, 10.0)
p = []
oprob = ODEProblem(rn, u0, tspan, p)
sol = solve(oprob)
plot(sol)
```
which is actually quite neat. We don't document (or test) this feature though, so I have added both.