### PR TITLE
Update CI strategy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core


### PR DESCRIPTION
Add entry:
```
    strategy:
      fail-fast: false
```
to CI file.

After consultation with Avik. Currently, if v1.6 CI fails, the v1 CI is stopped. Especially now when we get random coverall errors on v1.6 (which Avik don't know how to fix more than restarting) this seems good.