### PR TITLE
[v14 ready] RDME and graph SSAs

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -18,7 +18,7 @@ pages = Any[
         "model_creation/network_analysis.md",
         "model_creation/chemistry_related_functionality.md",
         "Model creation examples" => Any[
-            "model_creation/examples/basic_CRN_library.md",
+            #"model_creation/examples/basic_CRN_library.md",
             "model_creation/examples/programmatic_generative_linear_pathway.md",
             "model_creation/examples/hodgkin_huxley_equation.md",
             "model_creation/examples/smoluchowski_coagulation_equation.md"
@@ -29,9 +29,9 @@ pages = Any[
         # Simulation introduction.
         "model_simulation/simulation_plotting.md",
         "model_simulation/simulation_structure_interfacing.md",
-        "model_simulation/ensemble_simulations.md",
+        #"model_simulation/ensemble_simulations.md",
         # Stochastic simulation statistical analysis.
-        "model_simulation/ode_simulation_performance.md",
+        #"model_simulation/ode_simulation_performance.md",
         # ODE Performance considerations/advice.
         # SDE Performance considerations/advice.
         # Jump Performance considerations/advice.
@@ -39,7 +39,7 @@ pages = Any[
     ],
     "Steady state analysis" => Any[
         "steady_state_functionality/homotopy_continuation.md",
-        "steady_state_functionality/nonlinear_solve.md",
+        #"steady_state_functionality/nonlinear_solve.md",
         "steady_state_functionality/steady_state_stability_computation.md",        
         "steady_state_functionality/bifurcation_diagrams.md",
         "steady_state_functionality/dynamical_systems.md"

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -166,20 +166,21 @@ export make_si_ode
 
 ### Spatial Reaction Networks ###
 
-# spatial reactions
+# Spatial reactions.
 include("spatial_reaction_systems/spatial_reactions.jl")
 export TransportReaction, TransportReactions, @transport_reaction
 export isedgeparameter
 
-# lattice reaction systems
+# Lattice reaction systems
 include("spatial_reaction_systems/lattice_reaction_systems.jl")
 export LatticeReactionSystem
 export spatial_species, vertex_parameters, edge_parameters
 
-# variosu utility functions
+# Various utility functions
 include("spatial_reaction_systems/utility.jl")
 
-# spatial lattice ode systems.
+# Specific spatial problem types.
 include("spatial_reaction_systems/spatial_ODE_systems.jl")
+include("spatial_reaction_systems/lattice_jump_systems.jl")
 
 end # module

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -6,9 +6,9 @@ module Catalyst
 using DocStringExtensions
 using SparseArrays, DiffEqBase, Reexport, Setfield
 using LaTeXStrings, Latexify, Requires
-using JumpProcesses: JumpProcesses,
-                     JumpProblem, MassActionJump, ConstantRateJump,
-                     VariableRateJump
+using JumpProcesses: JumpProcesses, JumpProblem, 
+                     MassActionJump, ConstantRateJump, VariableRateJump,
+                     SpatialMassActionJump
 
 # ModelingToolkit imports and convenience functions we use
 using ModelingToolkit

--- a/src/spatial_reaction_systems/utility.jl
+++ b/src/spatial_reaction_systems/utility.jl
@@ -295,3 +295,99 @@ end
 function matrix_expand_component_values(values::Vector{<:Vector}, n)
     reshape(expand_component_values(values, n), length(values), n)
 end
+
+# For an expression, computes its values using the provided state and parameter vectors.
+# The expression is assumed to be valid in edges (and can have edges parameter components).
+# If some component is non-uniform, output is a vector of length equal to the number of vertexes.
+# If all components are uniform, the output is a length one vector.
+function compute_edge_value(exp, lrs::LatticeReactionSystem, edge_ps)
+    # Finds the symbols in the expression. Checks that all correspond to edge parameters.
+    relevant_syms = Symbolics.get_variables(exp)
+    if !all(any(isequal(sym, p) for p in edge_parameters(lrs)) for sym in relevant_syms) 
+        error("An non-edge parameter was encountered in expressions: $exp. Here, only edge parameters are expected.")
+    end
+
+    # Creates a Function tha computes the expressions value for a parameter set.
+    exp_func = drop_expr(@RuntimeGeneratedFunction(build_function(exp, relevant_syms...)))
+    # Creates a dictionary with the value(s) for all edge parameters.
+    sym_val_dict = vals_to_dict(edge_parameters(lrs), edge_ps)
+
+    # If all values are uniform, compute value once. Else, do it at all edges.
+    if !has_spatial_edge_component(exp, lrs, edge_ps)
+        return [exp_func([sym_val_dict[sym][1] for sym in relevant_syms]...)]
+    end
+    return [exp_func([get_component_value(sym_val_dict[sym], idxE) for sym in relevant_syms]...) 
+                                                                            for idxE in 1:lrs.num_edges]
+end
+
+# For an expression, computes its values using the provided state and parameter vectors.
+# The expression is assumed to be valid in vertexes (and can have vertex parameter and state components).
+# If at least one component is non-uniform, output is a vector of length equal to the number of vertexes.
+# If all components are uniform, the output is a length one vector.
+function compute_vertex_value(exp, lrs::LatticeReactionSystem; u=nothing, vert_ps=nothing)
+    # Finds the symbols in the expression. Checks that all correspond to states or vertex parameters.
+    relevant_syms = Symbolics.get_variables(exp)
+    if any(any(isequal(sym) in edge_parameters(lrs)) for sym in relevant_syms) 
+        error("An edge parameter was encountered in expressions: $exp. Here, on vertex-based components are expected.")
+    end
+    # Creates a Function tha computes the expressions value for a parameter set.
+    exp_func = drop_expr(@RuntimeGeneratedFunction(build_function(exp, relevant_syms...)))
+    # Creates a dictionary with the value(s) for all edge parameters.
+    if !isnothing(u) && !isnothing(vert_ps)
+        all_syms = [species(lrs); vertex_parameters(lrs)]
+        all_vals = [u; vert_ps]
+    elseif !isnothing(u) && isnothing(vert_ps)
+        all_syms = species(lrs)
+        all_vals = u
+
+    elseif isnothing(u) && !isnothing(vert_ps)
+        all_syms = vertex_parameters(lrs)
+        all_vals = vert_ps
+    else
+        error("Either u or vertex_ps have to be provided to has_spatial_vertex_component.")
+    end
+    sym_val_dict = vals_to_dict(all_syms, all_vals)
+    
+    # If all values are uniform, compute value once. Else, do it at all edges.
+    if !has_spatial_vertex_component(exp, lrs; u, vert_ps)
+        return [exp_func([sym_val_dict[sym][1] for sym in relevant_syms]...)]
+    end
+    return [exp_func([get_component_value(sym_val_dict[sym], idxV) for sym in relevant_syms]...) 
+                                                                            for idxV in 1:lrs.num_verts]
+end
+
+### System Property Checks ###
+
+# For a Symbolic expression, a LatticeReactionSystem, and a parameter list of the internal format:
+# Checks if any edge parameter in the expression have a spatial component (that is, is not uniform).
+function has_spatial_edge_component(exp, lrs::LatticeReactionSystem, edge_ps)
+    # Finds the edge parameters in the expression. Computes their indexes.
+    exp_syms = Symbolics.get_variables(exp)
+    exp_edge_ps = filter(sym -> any(isequal(sym), edge_parameters(lrs)), exp_syms)
+    p_idxs = [findfirst(isequal(sym, edge_p) for edge_p in edge_parameters(lrs)) for sym in exp_syms]
+    # Checks if any of the corresponding value vectors have length != 1 (that is, is not uniform).
+    return any(length(edge_ps[p_idx]) != 1 for p_idx in p_idxs)
+end
+
+# For a Symbolic expression, a LatticeReactionSystem, and a parameter list of the internal format (vector of vectors):
+# Checks if any vertex parameter in the expression have a spatial component (that is, is not uniform).
+function has_spatial_vertex_component(exp, lrs::LatticeReactionSystem; u=nothing, vert_ps=nothing)
+    # Finds all the symbols in the expression.
+    exp_syms = Symbolics.get_variables(exp)
+
+    # If vertex parameter values where given, checks if any of these have non-uniform values.
+    if !isnothing(vert_ps)
+        exp_vert_ps = filter(sym -> any(isequal(sym), vertex_parameters(lrs)), exp_syms)
+        p_idxs = [ModelingToolkit.parameter_index(lrs.rs, sym) for sym in exp_vert_ps]
+        any(length(vert_ps[p_idx]) != 1 for p_idx in p_idxs) && return true
+    end
+
+    # If states values where given, checks if any of these have non-uniform values.
+    if !isnothing(u)
+        exp_u = filter(sym -> any(isequal(sym), species(lrs)), exp_syms)
+        u_idxs = [ModelingToolkit.variable_index(lrs.rs, sym) for sym in exp_u]
+        any(length(u[u_idx]) != 1 for u_idx in u_idxs) && return true
+    end
+
+    return false
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ using SafeTestsets, Test
         @time @safetestset "PDE Systems Simulations" begin include("spatial_modelling/simulate_PDEs.jl") end
         @time @safetestset "Lattice Reaction Systems" begin include("spatial_modelling/lattice_reaction_systems.jl") end
         @time @safetestset "ODE Lattice Systems Simulations" begin include("spatial_modelling/lattice_reaction_systems_ODEs.jl") end
+        @time @safetestset "Jump Lattice Systems Simulations" begin include("spatial_reaction_systems/lattice_reaction_systems_jumps.jl") end
     #end
 
     #if GROUP == "All" || GROUP == "Visualisation-Extensions"

--- a/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
@@ -7,7 +7,8 @@ using Random, Statistics, SparseArrays, Test
 # Fetch test networks.
 include("../spatial_test_networks.jl")
 
-### Correctness Tests ###
+
+### General Tests ###
 
 # Tests that there are no errors during runs for a variety of input forms.
 let
@@ -42,6 +43,7 @@ let
         end
     end
 end
+
 
 ### Input Handling Tests ###
 
@@ -101,6 +103,7 @@ let
         end
     end
 end
+
 
 ### Tests taken from JumpProcesses ###
 

--- a/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
@@ -1,0 +1,157 @@
+### Preparations ###
+
+# Fetch packages.
+using JumpProcesses
+using Random, Statistics, SparseArrays, Test
+
+# Fetch test networks.
+include("../spatial_test_networks.jl")
+
+### Correctness Tests ###
+
+# Tests that there are no errors during runs for a variety of input forms.
+let
+    for grid in [small_2d_grid, short_path, small_directed_cycle]
+        for srs in [Vector{TransportReaction}(), SIR_srs_1, SIR_srs_2]
+            lrs = LatticeReactionSystem(SIR_system, srs, grid)
+            u0_1 = [:S => 999, :I => 1, :R => 0]
+            u0_2 = [:S => round.(Int64, 500.0 .+ 500.0 * rand_v_vals(lrs.lattice)), :I => 1, :R => 0, ]
+            u0_3 = [:S => 950, :I => round.(Int64, 50 * rand_v_vals(lrs.lattice)), :R => round.(Int64, 50 * rand_v_vals(lrs.lattice))]
+            u0_4 = [:S => round.(500.0 .+ 500.0 * rand_v_vals(lrs.lattice)), :I => round.(50 * rand_v_vals(lrs.lattice)), :R => round.(50 * rand_v_vals(lrs.lattice))]
+            u0_5 = make_u0_matrix(u0_3, vertices(lrs.lattice), map(s -> Symbol(s.f), species(lrs.rs)))
+            for u0 in [u0_1, u0_2, u0_3, u0_4, u0_5]
+                p1 = [:α => 0.1 / 1000, :β => 0.01]
+                p2 = [:α => 0.1 / 1000, :β => 0.02 * rand_v_vals(lrs.lattice)]
+                p3 = [
+                    :α => 0.1 / 2000 * rand_v_vals(lrs.lattice),
+                    :β => 0.02 * rand_v_vals(lrs.lattice),
+                ]
+                p4 = make_u0_matrix(p1, vertices(lrs.lattice), Symbol.(parameters(lrs.rs)))
+                for pV in [p1] #, p2, p3, p4] # Removed until spatial non-diffusion parameters are supported.
+                    pE_1 = map(sp -> sp => 0.01, ModelingToolkit.getname.(edge_parameters(lrs)))
+                    pE_2 = map(sp -> sp => 0.01, ModelingToolkit.getname.(edge_parameters(lrs)))
+                    pE_3 = map(sp -> sp => rand_e_vals(lrs.lattice, 0.01), ModelingToolkit.getname.(edge_parameters(lrs)))
+                    pE_4 = make_u0_matrix(pE_3, edges(lrs.lattice), ModelingToolkit.getname.(edge_parameters(lrs)))
+                    for pE in [pE_1, pE_2, pE_3, pE_4]
+                        dprob = DiscreteProblem(lrs, u0, (0.0, 100.0), (pV, pE))
+                        jprob = JumpProblem(lrs, dprob, NSM())
+                        @test SciMLBase.successful_retcode(solve(jprob, SSAStepper()))
+                    end
+                end
+            end
+        end
+    end
+end
+
+### Input Handling Tests ###
+
+# Tests that the correct hopping rates and initial conditions are generated.
+# In this base case, hopping rates should be on the form D_{s,i,j}.
+let
+    # Prepares the system.
+    lrs = LatticeReactionSystem(SIR_system, SIR_srs_2, small_2d_grid)
+
+    # Prepares various u0 input types.
+    u0_1 = [:I => 2.0, :S => 1.0, :R => 3.0]
+    u0_2 = [:I => fill(2., nv(small_2d_grid)), :S => 1.0, :R => 3.0]
+    u0_3 = [1.0, 2.0, 3.0]
+    u0_4 = [1.0, fill(2., nv(small_2d_grid)), 3.0]
+    u0_5 = permutedims(hcat(fill(1., nv(small_2d_grid)), fill(2., nv(small_2d_grid)), fill(3., nv(small_2d_grid))))
+
+    # Prepare various (compartment) parameter input types.
+    pV_1 = [:β => 0.2, :α => 0.1]
+    pV_2 = [:β => fill(0.2, nv(small_2d_grid)), :α => 1.0]
+    pV_3 = [0.1, 0.2]
+    pV_4 = [0.1, fill(0.2, nv(small_2d_grid))]
+    pV_5 = permutedims(hcat(fill(0.1, nv(small_2d_grid)), fill(0.2, nv(small_2d_grid))))
+
+    # Prepare various (diffusion) parameter input types.
+    pE_1 = [:dI => 0.02, :dS => 0.01, :dR => 0.03]
+    pE_2 = [:dI => 0.02, :dS => fill(0.01, ne(small_2d_grid)), :dR => 0.03]
+    pE_3 = [0.01, 0.02, 0.03]
+    pE_4 = [fill(0.01, ne(small_2d_grid)), 0.02, 0.03]
+    pE_5 = permutedims(hcat(fill(0.01, ne(small_2d_grid)), fill(0.02, ne(small_2d_grid)), fill(0.03, ne(small_2d_grid))))
+
+    # Checks hopping rates and u0 are correct.
+    true_u0 = [fill(1.0, 1, 25); fill(2.0, 1, 25); fill(3.0, 1, 25)]
+    true_hopping_rates = cumsum.([fill(dval, length(v)) for dval in [0.01,0.02,0.03], v in small_2d_grid.fadjlist])
+    true_maj_scaled_rates = [0.1, 0.2]
+    true_maj_reactant_stoch = [[1 => 1, 2 => 1], [2 => 1]]
+    true_maj_net_stoch = [[1 => -1, 2 => 1], [2 => -1, 3 => 1]]
+    for u0 in [u0_1, u0_2, u0_3, u0_4, u0_5]
+        # Provides parameters as a tupple.
+        for pV in [pV_1, pV_3], pE in [pE_1, pE_2, pE_3, pE_4, pE_5]
+            dprob = DiscreteProblem(lrs, u0, (0.0, 100.0), (pV,pE))
+            jprob = JumpProblem(lrs, dprob, NSM())
+            @test jprob.prob.u0 == true_u0
+            @test jprob.discrete_jump_aggregation.hop_rates.hop_const_cumulative_sums == true_hopping_rates
+            @test jprob.massaction_jump.scaled_rates == true_maj_scaled_rates
+            @test jprob.massaction_jump.reactant_stoch  == true_maj_reactant_stoch
+            @test jprob.massaction_jump.net_stoch == true_maj_net_stoch
+        end
+        # Provides parameters as a combined vector.
+        for pV in [pV_1], pE in [pE_1, pE_2]
+            dprob = DiscreteProblem(lrs, u0, (0.0, 100.0), [pE; pV])
+            jprob = JumpProblem(lrs, dprob, NSM())
+            @test jprob.prob.u0 == true_u0
+            @test jprob.discrete_jump_aggregation.hop_rates.hop_const_cumulative_sums == true_hopping_rates
+            @test jprob.massaction_jump.scaled_rates == true_maj_scaled_rates
+            @test jprob.massaction_jump.reactant_stoch  == true_maj_reactant_stoch
+            @test jprob.massaction_jump.net_stoch == true_maj_net_stoch
+        end
+    end
+end
+
+### ABC Model Test (from JumpProcesses) ###
+let 
+    # Preparations (stuff used in JumpProcesses examples ported over here, could be written directly into code).
+    Nsims = 100
+    reltol = 0.05
+    non_spatial_mean = [65.7395, 65.7395, 434.2605] #mean of 10,000 simulations
+    dim = 1
+    linear_size = 5
+    num_nodes = linear_size^dim
+    dims = Tuple(repeat([linear_size], dim))
+    domain_size = 1.0 #μ-meter
+    mesh_size = domain_size / linear_size
+    rates = [0.1 / mesh_size, 1.0]
+    diffusivity = 1.0
+    num_species = 3
+
+    # Make model.
+    rn = @reaction_network begin
+        (kB,kD), A + B <--> C
+    end
+    tr_1 = @transport_reaction D A
+    tr_2 = @transport_reaction D B
+    tr_3 = @transport_reaction D C
+    lattice = Graphs.grid(dims)
+    lrs = LatticeReactionSystem(rn, [tr_1, tr_2, tr_3], lattice)
+
+    # Set simulation parameters and create problems
+    u0 = [:A => [0,0,500,0,0], :B => [0,0,500,0,0], :C => 0]
+    tspan = (0.0, 10.0)
+    pV = [:kB => rates[1], :kD => rates[2]]
+    pE = [:D => diffusivity]
+    dprob = DiscreteProblem(lrs, u0, tspan, (pV, pE))
+    jump_problems = [JumpProblem(lrs, dprob, alg(); save_positions = (false, false)) for alg in [NSM, DirectCRDirect]] # NRM doesn't work. Might need Cartesian grid.
+
+    # Tests.
+    function get_mean_end_state(jump_prob, Nsims)
+        end_state = zeros(size(jump_prob.prob.u0))
+        for i in 1:Nsims
+            sol = solve(jump_prob, SSAStepper())
+            end_state .+= sol.u[end]
+        end
+        end_state / Nsims
+    end
+    for jprob in jump_problems
+        solution = solve(jprob, SSAStepper())
+        mean_end_state = get_mean_end_state(jprob, Nsims)
+        mean_end_state = reshape(mean_end_state, num_species, num_nodes)
+        diff = sum(mean_end_state, dims = 2) - non_spatial_mean
+        for (i, d) in enumerate(diff)
+            @test abs(d) < reltol * non_spatial_mean[i]
+        end
+    end
+end

--- a/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
@@ -102,17 +102,19 @@ let
     end
 end
 
-### ABC Model Test (from JumpProcesses) ###
+### Tests taken from JumpProcesses ###
+
+# ABC Model Test
 let 
     # Preparations (stuff used in JumpProcesses examples ported over here, could be written directly into code).
     Nsims = 100
     reltol = 0.05
-    non_spatial_mean = [65.7395, 65.7395, 434.2605] #mean of 10,000 simulations
+    non_spatial_mean = [65.7395, 65.7395, 434.2605] # Mean of 10,000 simulations.
     dim = 1
     linear_size = 5
     num_nodes = linear_size^dim
     dims = Tuple(repeat([linear_size], dim))
-    domain_size = 1.0 #μ-meter
+    domain_size = 1.0 # μ-meter.
     mesh_size = domain_size / linear_size
     rates = [0.1 / mesh_size, 1.0]
     diffusivity = 1.0
@@ -128,15 +130,16 @@ let
     lattice = Graphs.grid(dims)
     lrs = LatticeReactionSystem(rn, [tr_1, tr_2, tr_3], lattice)
 
-    # Set simulation parameters and create problems
+    # Set simulation parameters and create problems.
     u0 = [:A => [0,0,500,0,0], :B => [0,0,500,0,0], :C => 0]
     tspan = (0.0, 10.0)
     pV = [:kB => rates[1], :kD => rates[2]]
     pE = [:D => diffusivity]
     dprob = DiscreteProblem(lrs, u0, tspan, (pV, pE))
-    jump_problems = [JumpProblem(lrs, dprob, alg(); save_positions = (false, false)) for alg in [NSM, DirectCRDirect]] # NRM doesn't work. Might need Cartesian grid.
+    # NRM could be added, but doesn't work. Might need Cartesian grid.
+    jump_problems = [JumpProblem(lrs, dprob, alg(); save_positions = (false, false)) for alg in [NSM, DirectCRDirect]] 
 
-    # Tests.
+    # Run tests.
     function get_mean_end_state(jump_prob, Nsims)
         end_state = zeros(size(jump_prob.prob.u0))
         for i in 1:Nsims

--- a/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems_jumps.jl
@@ -87,9 +87,8 @@ let
             jprob = JumpProblem(lrs, dprob, NSM())
             @test jprob.prob.u0 == true_u0
             @test jprob.discrete_jump_aggregation.hop_rates.hop_const_cumulative_sums == true_hopping_rates
-            @test jprob.massaction_jump.scaled_rates == true_maj_scaled_rates
             @test jprob.massaction_jump.reactant_stoch  == true_maj_reactant_stoch
-            @test jprob.massaction_jump.net_stoch == true_maj_net_stoch
+            @test all(issetequal(ns1, ns2) for (ns1, ns2) in zip(jprob.massaction_jump.net_stoch, true_maj_net_stoch))
         end
         # Provides parameters as a combined vector.
         for pV in [pV_1], pE in [pE_1, pE_2]
@@ -97,9 +96,8 @@ let
             jprob = JumpProblem(lrs, dprob, NSM())
             @test jprob.prob.u0 == true_u0
             @test jprob.discrete_jump_aggregation.hop_rates.hop_const_cumulative_sums == true_hopping_rates
-            @test jprob.massaction_jump.scaled_rates == true_maj_scaled_rates
             @test jprob.massaction_jump.reactant_stoch  == true_maj_reactant_stoch
-            @test jprob.massaction_jump.net_stoch == true_maj_net_stoch
+            @test all(issetequal(ns1, ns2) for (ns1, ns2) in zip(jprob.massaction_jump.net_stoch, true_maj_net_stoch))
         end
     end
 end


### PR DESCRIPTION
To avoid rebasing hell this is simply a new version of https://github.com/SciML/Catalyst.jl/pull/663. You might have some input on simpler ways to compute the (non-spatial) mass action Jumps @isaacsas, but otherwise, this is good to go. Currently vertex parameters must be uniform across the grid (and this is enforced). Once @Vilin97 have his PRs merged over at JumpProcesses, this requirement can be lightened. 

I have added support for spatial jumps. Creating and solving a problem is relatively easy:
```julia
using Catalyst, Graphs, JumpProcesses

# Make model.
SIR_system = @reaction_network begin
    α, S + I --> 2I
    β, I --> R
end
trS = @transport_reaction dS S
trI = @transport_reaction dI I
lattice = Graphs.grid([2, 2])
lrs = LatticeReactionSystem(SIR_system, [trS, trI], lattice)

# Parameter values and initial conditions.
u0 = [:S => [999, 1000, 1000, 1000], :I => [1, 0, 0, 0], :R => 0]
pV = [:α => 0.1 / 1000, :β => 0.01]
pE = [:dS => [0.1, 0.1, 0.1, 0.2], :dI => [0.01, 0.01, 0.01, 0.02]]

# Create the problem.
dprob = DiscreteProblem(lrs, u0, (0.0,100.0), (pV,pE))
jprob = JumpProblem(lrs, dprob, NSM())
sol = solve(jprob, SSAStepper())
```

Current limitations:
- Cartesian grids are not supported, only Graphs.
- Of the 5 forms of the hopping rates, we now convert to the most general one (D_{s,i,j}). Once this is merged, I will introduce a routine which detects which is the most compact form that can be provided, and uses that one. To keep this PR short, I am currently holding of on uploading those changes,
- Currently, the constant rate jumps in each compartment must have the same parameter values. Once this is supported in JumpProcesses I will add support for it here as well.