### PR TITLE
Latexify improvement

### DIFF
--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -251,6 +251,8 @@ latexify(rn; form=:sde)
 (As of writing this, an upstream bug causes the SDE form to be erroneously
 displayed as the ODE form)
 
+Finally, another optional argument (`expand_functions=true`) automatically expands by_catalyst defined functions (such as `mm`). To disable this, set `expand_functions=false`.
+
 If [Graphviz](https://graphviz.org/) is installed and commandline accessible, it
 can be used to create and save network diagrams using [`Graph`](@ref) and
 [`savegraph`](@ref).

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -7,33 +7,6 @@ end
 
 const LATEX_DEFS = CatalystLatexParams()
 
-# Implements handling of registered functions.
-const mm_names = ([:mm])
-const mmr_names = ([:mmr])
-const hill_names = ([:hill])
-const hillr_names = ([:hillr])
-const hillar_names = ([:hillar])
-
-function make_mm_exp(expr::Expr)
-    :($(expr.args[3]) * $(expr.args[2]) / ($(expr.args[4]) + $(expr.args[2])))
-end
-function make_mmr_exp(expr::Expr)
-    :($(expr.args[3]) * $(expr.args[4]) / ($(expr.args[4]) + $(expr.args[2])))
-end
-function make_hill_exp(expr::Expr)
-    :($(expr.args[3]) * ($(expr.args[2])^$(expr.args[5])) /
-      ($(expr.args[4])^$(expr.args[5]) + $(expr.args[2])^$(expr.args[5])))
-end
-function make_hillr_exp(expr::Expr)
-    :($(expr.args[3]) * ($(expr.args[4])^$(expr.args[5])) /
-      ($(expr.args[4])^$(expr.args[5]) + $(expr.args[2])^$(expr.args[5])))
-end
-function make_hillar_exp(expr::Expr)
-    :($(expr.args[4]) * ($(expr.args[2])^$(expr.args[6])) /
-      ($(expr.args[5])^$(expr.args[6]) + $(expr.args[2])^$(expr.args[6]) +
-       $(expr.args[3])^$(expr.args[6])))
-end
-
 #Recursively traverses an expression and removes things like X^1, 1*X. Will not actually have any effect on the expression when used as a function, but will make it much easier to look at it for debugging, as well as if it is transformed to LaTeX code.
 function recursive_clean!(expr)
     (expr isa Symbol) && (expr == :no___noise___scaling) && (return 1)
@@ -65,11 +38,6 @@ function recursive_clean!(expr)
     end
     if expr.head == :call
         (expr.args[1] == :/) && (expr.args[3] == 1) && (return expr.args[2])
-        in(expr.args[1], mm_names) && return make_mm_exp(expr)
-        in(expr.args[1], mmr_names) && return make_mmr_exp(expr)
-        in(expr.args[1], hill_names) && return make_hill_exp(expr)
-        in(expr.args[1], hillr_names) && return make_hillr_exp(expr)
-        in(expr.args[1], hillar_names) && return make_hillar_exp(expr)
         (expr.args[1] == :binomial) && (expr.args[3] == 1) && return expr.args[2]
         #@isdefined($(expr.args[1])) || error("Function $(expr.args[1]) not defined.")
     end
@@ -206,7 +174,8 @@ function chemical_arrows(rn::ReactionSystem; expand = true,
     return latexstr
 end
 
-@latexrecipe function f(rs::ReactionSystem; form = :reactions)
+@latexrecipe function f(rs::ReactionSystem; form = :reactions, expand_functions=true)
+    expand_functions && (rs = expand_registered_functions(rs))
     if form == :reactions    # Returns chemical reaction network code.
         cdot --> false
         env --> :chem

--- a/test/visualization/latexify.jl
+++ b/test/visualization/latexify.jl
@@ -42,14 +42,35 @@ let
     end
 
     # Latexify.@generate_test latexify(rn)
-    @test_broken latexify(rn) == replace(
+    @test_broken latexify(rn; expand_functions = false) == replace(
     raw"\begin{align*}
-    \varnothing &\xrightarrow{\frac{v1 X4^{n1}}{K1^{n1} + X4^{n1}} \frac{v1 K1^{n1}}{K1^{n1} + X2^{n1}}} \mathrm{X1} \\
-    \varnothing &\xrightarrow{\frac{v2 X5^{n2}}{K2^{n2} + X5^{n2}}} \mathrm{X2} \\
-    \varnothing &\xrightarrow{\frac{v3 X3^{n3}}{K3^{n3} + X3^{n3}}} \mathrm{X3} \\
-    \varnothing &\xrightarrow{\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}} \mathrm{X4} \\
-    \varnothing &\xrightarrow{\frac{v5 X2^{n5}}{K5^{n5} + X2^{n5}}} \mathrm{X5} \\
-    \varnothing &\xrightarrow{\frac{v6 X1^{n6}}{K6^{n6} + X1^{n6} + X6^{n6}}} \mathrm{X6} \\
+    \varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
+    \varnothing &\xrightarrow{\mathrm{hill}\left( X5, v2, K2, n2 \right)} \mathrm{X2} \\
+    \varnothing &\xrightarrow{\mathrm{hill}\left( X3, v3, K3, n3 \right)} \mathrm{X3} \\
+    \varnothing &\xrightarrow{\mathrm{hillr}\left( X1, v4, K4, n4 \right)} \mathrm{X4} \\
+    \varnothing &\xrightarrow{\mathrm{hill}\left( X2, v5, K5, n5 \right)} \mathrm{X5} \\
+    \varnothing &\xrightarrow{\mathrm{hillar}\left( X1, X6, v6, K6, n6 \right)} \mathrm{X6} \\
+    \mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
+    \mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
+    3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
+    \mathrm{X1} &\xrightarrow{d1} \varnothing \\
+    \mathrm{X2} &\xrightarrow{d2} \varnothing \\
+    \mathrm{X3} &\xrightarrow{d3} \varnothing \\
+    \mathrm{X4} &\xrightarrow{d4} \varnothing \\
+    \mathrm{X5} &\xrightarrow{d5} \varnothing \\
+    \mathrm{X6} &\xrightarrow{d6} \varnothing  
+    \end{align*}
+    ", "\r\n"=>"\n")
+
+    #Latexify.@generate_test latexify(rn; expand_functions=false)
+    @test_broken latexify(rn; expand_functions = false) == replace(
+    raw"\begin{align*}
+    \varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
+    \varnothing &\xrightarrow{\mathrm{mm}\left( X5, v2, K2 \right)} \mathrm{X2} \\
+    \varnothing &\xrightarrow{\mathrm{mmr}\left( X3, v3, K3 \right)} \mathrm{X3} \\
+    \varnothing &\xrightarrow{\mathrm{hillr}\left( X1, v4, K4, n4 \right)} \mathrm{X4} \\
+    \varnothing &\xrightarrow{\mathrm{hill}\left( X2, v5, K5, n5 \right)} \mathrm{X5} \\
+    \varnothing &\xrightarrow{\mathrm{hillar}\left( X1, X6, v6, K6, n6 \right)} \mathrm{X6} \\
     \mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
     \mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
     3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
@@ -63,14 +84,14 @@ let
     ", "\r\n"=>"\n")
 
     # Latexify.@generate_test latexify(rn, mathjax=false)
-    @test_broken latexify(rn, mathjax = false) == replace(
+    @test latexify(rn, mathjax = false) == replace(
     raw"\begin{align*}
-    \varnothing &\xrightarrow{\frac{v1 X4^{n1}}{K1^{n1} + X4^{n1}} \frac{v1 K1^{n1}}{K1^{n1} + X2^{n1}}} \mathrm{X1} \\
-    \varnothing &\xrightarrow{\frac{v2 X5^{n2}}{K2^{n2} + X5^{n2}}} \mathrm{X2} \\
-    \varnothing &\xrightarrow{\frac{v3 X3^{n3}}{K3^{n3} + X3^{n3}}} \mathrm{X3} \\
+    \varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
+    \varnothing &\xrightarrow{\frac{X5 v2}{K2 + X5}} \mathrm{X2} \\
+    \varnothing &\xrightarrow{\frac{K3 v3}{K3 + X3}} \mathrm{X3} \\
     \varnothing &\xrightarrow{\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}} \mathrm{X4} \\
-    \varnothing &\xrightarrow{\frac{v5 X2^{n5}}{K5^{n5} + X2^{n5}}} \mathrm{X5} \\
-    \varnothing &\xrightarrow{\frac{v6 X1^{n6}}{K6^{n6} + X1^{n6} + X6^{n6}}} \mathrm{X6} \\
+    \varnothing &\xrightarrow{\frac{v5 X2^{n5}}{X2^{n5} + K5^{n5}}} \mathrm{X5} \\
+    \varnothing &\xrightarrow{\frac{v6 X1^{n6}}{X6^{n6} + K6^{n6} + X1^{n6}}} \mathrm{X6} \\
     \mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
     \mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
     3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
@@ -134,13 +155,46 @@ let
 end
 
 
+# Test using various `env` options.
+let
+    rn = @reaction_network begin
+        (p,d), 0 <--> X
+    end
+    chem_latex = latexify(rn; env = :arrows)
+    @test chem_latex == latexify(rn; env = :chem)
+    @test chem_latex == latexify(rn; env = :chemical)
+    @test chem_latex == latexify(rn; env = :arrow)
+    @test_throws Exception latexify(rn; env = :wrong_env)
+end
+
+# Tests that the `mathrm` option affects the output.
+let
+    rn = @reaction_network begin
+        (k1,k2), 2X <--> X2
+    end
+    @test latexify(rn; mathrm = true) != latexify(rn; mathrm = false)
+end
+
+# Tests for system with parametric stoichiometry.
+let
+    rn = @reaction_network begin
+        p, 0 --> n*X
+    end
+    
+    @test_broken latexify(rn) == replace(
+    raw"\begin{align*}
+    \varnothing &\xrightarrow{p} (m + n)\mathrm{X}  
+     \end{align*}
+    ", "\r\n"=>"\n")
+end
+
 ### Tests  `form` Option ###
 
 # Check for large number of networks.
 let
     for rn in reaction_networks_standard
         @test latexify(rn)==latexify(rn; form=:reactions)
-        #@test_broken latexify(convert(ODESystem,rn)) == latexify(rn; form=:ode) # Slight difference due to some latexify weirdity. Both displays fine though
+        #@test_broken latexify(convert(ODESystem,rn)) == latexify(rn; form=:ode) # Slight difference due to some latexify weirdly. Both displays fine though
     end
 end
 


### PR DESCRIPTION
Makes some improvements to make Latexify automatically use our new `expand_registered_functions` function to expand `mm` and similar. Now this is done by default for reaction, ode, and sde forms. Also, setting the kwarg `expand_functions=false` disables this.
```julia
using Catalyst, Latexify
rn = @reaction_network begin
    (mm(x,v,K),d), 0 <--> X
end
latexify(rn, form=:ode, expand_functions=false)
```