### PR TITLE
[v14 ready] Implement metadata for `Reactions`s

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,7 +22,7 @@ rn = @reaction_network begin
     @parameters η
     k, 2X --> X2, [noise_scaling=η]
 end
-get_metadata(rn, :noise_scaling)
+getnoisescaling(rn)
 ```
 - Changed fields of internal `Reaction` structure. `ReactionSystems`s saved using `serialize` on previous Catalyst versions cannot be loaded using this (or later) versions.
 - Simulation of spatial ODEs now supported. For full details, please see https://github.com/SciML/Catalyst.jl/pull/644 and upcoming documentation. Note that these methods are currently considered alpha, with the interface and approach changing even in non-breaking Catalyst releases.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,15 @@ assess_identifiability(goodwind_oscillator; measured_quantities=[:M])
 to assess (global) structural identifiability for all parameters and variables of the `goodwind_oscillator` model (under the presumption that we can measure `M` only).
 - Automatically handles conservation laws for structural identifiability problems (eliminates these internally to speed up computations).
 - Adds a tutorial to illustrate the use of the extension.
+- Enable adding metadata to individual reactions, e.g:
+```julia
+rn = @reaction_network begin
+    @parameters η
+    k, 2X --> X2, [noise_scaling=η]
+end
+get_metadata(rn, :noise_scaling)
+```
+- Changed fields of internal `Reaction` structure. `ReactionSystems`s saved using `serialize` on previous Catalyst versions cannot be loaded using this (or later) versions.
 - Simulation of spatial ODEs now supported. For full details, please see https://github.com/SciML/Catalyst.jl/pull/644 and upcoming documentation. Note that these methods are currently considered alpha, with the interface and approach changing even in non-breaking Catalyst releases.
 - LatticeReactionSystem structure represents a spatial reaction network:
   ```julia

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -178,7 +178,7 @@ substoichmat
 prodstoichmat
 netstoichmat
 reactionrates
-get_metadata_dict
+get_metadata_vec
 has_metadata
 get_metadata
 ```

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -178,9 +178,6 @@ substoichmat
 prodstoichmat
 netstoichmat
 reactionrates
-get_metadata_dict
-has_metadata
-get_metadata
 ```
 
 ## [Functions to extend or modify a network](@id api_network_extension_and_modification)

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -178,7 +178,7 @@ substoichmat
 prodstoichmat
 netstoichmat
 reactionrates
-get_metadata_vec
+get_metadata_dict
 has_metadata
 get_metadata
 ```

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -178,6 +178,9 @@ substoichmat
 prodstoichmat
 netstoichmat
 reactionrates
+get_metadata_dict
+has_metadata
+get_metadata
 ```
 
 ## [Functions to extend or modify a network](@id api_network_extension_and_modification)

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -67,7 +67,7 @@ export ODEProblem,
        SteadyStateProblem
 
 # reaction_network macro
-const ExprValues = Union{Expr, Symbol, Float64, Int}
+const ExprValues = Union{Expr, Symbol, Float64, Int, Bool}
 include("expression_utils.jl")
 include("reaction_network.jl")
 export @reaction_network, @add_reactions, @reaction, @species
@@ -80,6 +80,7 @@ export mm, mmr, hill, hillr, hillar
 include("networkapi.jl")
 export species, nonspecies, reactionparams, reactions, speciesmap, paramsmap
 export numspecies, numreactions, numreactionparams, setdefaults!, symmap_to_varmap
+export get_metadata_dict, has_metadata, get_metadata
 export make_empty_network, addspecies!, addparam!, addreaction!, reactionparamsmap
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities, conservedequations, conservationlaw_constants

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -80,7 +80,7 @@ export mm, mmr, hill, hillr, hillar
 include("networkapi.jl")
 export species, nonspecies, reactionparams, reactions, speciesmap, paramsmap
 export numspecies, numreactions, numreactionparams, setdefaults!, symmap_to_varmap
-export get_metadata_dict, has_metadata, get_metadata
+export get_metadata_vec, has_metadata, get_metadata
 export make_empty_network, addspecies!, addparam!, addreaction!, reactionparamsmap
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities, conservedequations, conservationlaw_constants

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -80,7 +80,6 @@ export mm, mmr, hill, hillr, hillar
 include("networkapi.jl")
 export species, nonspecies, reactionparams, reactions, speciesmap, paramsmap
 export numspecies, numreactions, numreactionparams, setdefaults!, symmap_to_varmap
-export get_metadata_dict, has_metadata, get_metadata
 export make_empty_network, addspecies!, addparam!, addreaction!, reactionparamsmap
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities, conservedequations, conservationlaw_constants

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -80,7 +80,7 @@ export mm, mmr, hill, hillr, hillar
 include("networkapi.jl")
 export species, nonspecies, reactionparams, reactions, speciesmap, paramsmap
 export numspecies, numreactions, numreactionparams, setdefaults!, symmap_to_varmap
-export get_metadata_vec, has_metadata, get_metadata
+export get_metadata_dict, has_metadata, get_metadata
 export make_empty_network, addspecies!, addparam!, addreaction!, reactionparamsmap
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export conservationlaws, conservedquantities, conservedequations, conservationlaw_constants

--- a/src/expression_utils.jl
+++ b/src/expression_utils.jl
@@ -4,7 +4,8 @@ function tup_leng(ex::ExprValues)
     return 1
 end
 
-#Gets the ith element in a expression tuple, or returns the input itself if it is not an expression tuple (probably a  Symbol/Numerical).
+# Gets the ith element in a expression tuple, or returns the input itself if it is not an expression tuple
+# (probably a  Symbol/Numerical).
 function get_tup_arg(ex::ExprValues, i::Int)
     (tup_leng(ex) == 1) && (return ex)
     return ex.args[i]

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -656,8 +656,7 @@ function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues
         end
 
         # Checks that metadata fields are unqiue.
-        metadata_entries = [arg.args[1] for arg in metadata_i.args]
-        if length(unique(metadata_entries)) < length(metadata_entries)
+        if !allunique(arg.args[1] for arg in metadata_i.args)
             error("Some reaction metadata fields where repeated: $(metadata_entries)")
         end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -567,7 +567,7 @@ function get_rxexprs(rxstruct)
     prod_stoich_init = deepcopy(prod_init)
     reaction_func = :(Reaction($(recursive_expand_functions!(rxstruct.rate)), $subs_init,
                                $prod_init, $subs_stoich_init, $prod_stoich_init, 
-                               metadata = Dict($(rxstruct.metadata)),))
+                               metadata = $(rxstruct.metadata),))
     for sub in rxstruct.substrates
         push!(reaction_func.args[3].args, sub.reactant)
         push!(reaction_func.args[5].args, sub.stoichiometry)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -446,7 +446,7 @@ function make_reaction(ex::Expr)
     pexprs = get_pexpr(parameters, Dict{Symbol, Expr}())
     rxexpr = get_rxexprs(reaction)
     iv = :(@variables $(DEFAULT_IV_SYM))
-
+    
     # Returns the rephrased expression.
     quote
         $pexprs

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -643,7 +643,7 @@ function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues
     # The rates, substrates, products, and metadata may be in a tupple form (e.g. `k, (X,Y) --> 0`).
     # This finds the length of these tuples (or 1 if not in tuple forms). Errors if lengs inconsistent.
     lengs = (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate), tup_leng(metadata))
-    if any(!(leng in [1, maximum(lengs)]) for leng in lengs)
+    if any(!(leng == 1 || leng == maximum(lengs)) for leng in lengs)
         throw("Malformed reaction, rate=$rate, subs=$sub_line, prods=$prod_line, metadata=$metadata.")
     end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -655,6 +655,12 @@ function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues
             push!(metadata_i.args, :(only_use_rate = $(in(arrow, pure_rate_arrows))))
         end
 
+        # Checks that metadata fields are unqiue.
+        metadata_entries = [arg.args[1] for arg in metadata_i.args]
+        if length(unique(metadata_entries)) < length(metadata_entries)
+            error("Some reaction metadata fields where repeated: $(metadata_entries)")
+        end
+
         push!(reactions, ReactionStruct(get_tup_arg(sub_line, i), get_tup_arg(prod_line, i),
                                         get_tup_arg(rate, i), metadata_i))
     end

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -651,7 +651,7 @@ function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues
     for i in 1:maximum(lengs)                       
         # If the `only_use_rate` metadata was not provided, this has to be infered from the arrow used.
         metadata_i = get_tup_arg(metadata, i)
-        if all([arg.args[1] != :only_use_rate for arg in metadata_i.args])
+        if all(arg.args[1] != :only_use_rate for arg in metadata_i.args)
             push!(metadata_i.args, :(only_use_rate = $(in(arrow, pure_rate_arrows))))
         end
 

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -293,16 +293,17 @@ struct ReactionStruct
     substrates::Vector{ReactantStruct}
     products::Vector{ReactantStruct}
     rate::ExprValues
-    only_use_rate::Bool
+    metadata::Expr
 
-    function ReactionStruct(sub_line::ExprValues, prod_line::ExprValues, rate::ExprValues,
-                            only_use_rate::Bool)
+    function ReactionStruct(sub_line::ExprValues, prod_line::ExprValues, rate::ExprValues, 
+                            metadata_line::ExprValues)
         sub = recursive_find_reactants!(sub_line, 1, Vector{ReactantStruct}(undef, 0))
         prod = recursive_find_reactants!(prod_line, 1, Vector{ReactantStruct}(undef, 0))
-        new(sub, prod, rate, only_use_rate)
+        metadata = extract_metadata(metadata_line)
+        new(sub, prod, rate, metadata)
     end
 end
-
+ 
 ### Functions rephrasing the macro input as a ReactionSystem structure. ###
 
 function forbidden_variable_check(v)
@@ -565,8 +566,8 @@ function get_rxexprs(rxstruct)
     prod_init = isempty(rxstruct.products) ? nothing : :([])
     prod_stoich_init = deepcopy(prod_init)
     reaction_func = :(Reaction($(recursive_expand_functions!(rxstruct.rate)), $subs_init,
-                               $prod_init, $subs_stoich_init, $prod_stoich_init,
-                               only_use_rate = $(rxstruct.only_use_rate)))
+                               $prod_init, $subs_stoich_init, $prod_stoich_init, 
+                               metadata = Dict($(rxstruct.metadata)),))
     for sub in rxstruct.substrates
         push!(reaction_func.args[3].args, sub.reactant)
         push!(reaction_func.args[5].args, sub.stoichiometry)
@@ -580,70 +581,82 @@ end
 
 ### Functions for extracting the reactions from a DSL expression, and putting them ReactionStruct vector. ###
 
-# Reads a line and creates the corresponding ReactionStruct.
+# Reads a single line and creates the corresponding ReactionStruct.
 function get_reaction(line)
-    (rate, r_line) = line.args
-    (r_line.head == :-->) && (r_line = Expr(:call, :→, r_line.args[1], r_line.args[2]))
-
-    arrow = r_line.args[1]
-    in(arrow, double_arrows) && error("Double arrows not allowed for single reactions.")
-
-    only_use_rate = in(arrow, pure_rate_arrows)
-    if in(arrow, fwd_arrows)
-        rs = create_ReactionStruct(r_line.args[2], r_line.args[3], rate, only_use_rate)
-    elseif in(arrow, bwd_arrows)
-        rs = create_ReactionStruct(r_line.args[3], r_line.args[2], rate, only_use_rate)
-    else
-        throw("Malformed reaction, invalid arrow type used in: $(MacroTools.striplines(line))")
+    reaction = get_reactions([line])
+    if (length(reaction) != 1)
+        error("Malformed reaction. @reaction macro only creates a single reaction. E.g. double arrows, such as `<-->` are not supported.")
     end
-
-    rs
+    return reaction[1]
 end
+
 # Generates a vector containing a number of reaction structures, each containing the information about one reaction.
 function get_reactions(exprs::Vector{Expr}, reactions = Vector{ReactionStruct}(undef, 0))
     for line in exprs
-        (rate, r_line) = line.args
-        (r_line.head == :-->) && (r_line = Expr(:call, :→, r_line.args[1], r_line.args[2]))
+        # Reads core reaction information.
+        arrow, rate, reaction, metadata = read_reaction_line(line)
 
-        arrow = r_line.args[1]
-        only_use_rate = in(arrow, pure_rate_arrows)
+        # Checks the type of arrow used, and creates the corresponding reaction(s). Returns them in an array.
         if in(arrow, double_arrows)
-            (typeof(rate) == Expr && rate.head == :tuple) ||
+            if typeof(rate) != Expr || rate.head != :tuple
                 error("Error: Must provide a tuple of reaction rates when declaring a bi-directional reaction.")
-            push_reactions!(reactions, r_line.args[2], r_line.args[3], rate.args[1],
-                            only_use_rate)
-            push_reactions!(reactions, r_line.args[3], r_line.args[2], rate.args[2],
-                            only_use_rate)
+            end
+            push_reactions!(reactions, reaction.args[2], reaction.args[3], rate.args[1], metadata.args[1], arrow)
+            push_reactions!(reactions, reaction.args[3], reaction.args[2], rate.args[2], metadata.args[2], arrow)
         elseif in(arrow, fwd_arrows)
-            push_reactions!(reactions, r_line.args[2], r_line.args[3], rate, only_use_rate)
+            push_reactions!(reactions, reaction.args[2], reaction.args[3], rate, metadata, arrow)
         elseif in(arrow, bwd_arrows)
-            push_reactions!(reactions, r_line.args[3], r_line.args[2], rate, only_use_rate)
+            push_reactions!(reactions, reaction.args[3], reaction.args[2], rate, metadata, arrow)
         else
             throw("Malformed reaction, invalid arrow type used in: $(MacroTools.striplines(line))")
         end
     end
-    reactions
+    return reactions
 end
 
-# Creates a ReactionStruct from the information in a single line.
-function create_ReactionStruct(sub_line::ExprValues, prod_line::ExprValues,
-                               rate::ExprValues, only_use_rate::Bool)
-    all(==(1), (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate))) ||
-        error("Malformed reaction, line appears to be defining multiple reactions incorrectly: rate=$rate, subs=$sub_line, prods=$prod_line.")
-    ReactionStruct(get_tup_arg(sub_line, 1), get_tup_arg(prod_line, 1),
-                   get_tup_arg(rate, 1), only_use_rate)
+# Extracts the rate, reaction, and metadata fields (the last one optional) from a reaction line.
+function read_reaction_line(line::Expr)
+    # Handles rate, reaction, and arrow.
+    # Special routine required for  the`-->` case, which creates different expression from all other cases.
+    rate = line.args[1]
+    reaction = line.args[2]
+    (reaction.head == :-->) && (reaction = Expr(:call, :→, reaction.args[1], reaction.args[2]))
+    arrow = reaction.args[1]
+
+    # Handles metadata. If not provided, empty metadata is created.
+    if length(line.args) == 2
+        metadata = in(arrow, double_arrows) ? :(([], [])) : :([])
+    elseif length(line.args) == 3
+        metadata = line.args[3]
+    else
+        error("The following reaction line: \"$line\" was malformed. It should have a form \"rate, reaction\" or a form \"rate, reaction, metadata\". It has neither.")
+    end
+
+    return arrow, rate, reaction, metadata
 end
 
-#Takes a reaction line and creates reactions from it and pushes those to the reaction array. Used to create multiple reactions from, for instance, 1.0, (X,Y) --> 0.
-function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues,
-                         prod_line::ExprValues, rate::ExprValues, only_use_rate::Bool)
-    lengs = (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate))
-    for i in 1:maximum(lengs)
-        (count(lengs .== 1) + count(lengs .== maximum(lengs)) < 3) &&
-            (throw("Malformed reaction, rate=$rate, subs=$sub_line, prods=$prod_line."))
-        push!(reactions,
-              ReactionStruct(get_tup_arg(sub_line, i), get_tup_arg(prod_line, i),
-                             get_tup_arg(rate, i), only_use_rate))
+# Takes a reaction line and creates reaction(s) from it and pushes those to the reaction array.
+# Used to create multiple reactions from, for instance, `k, (X,Y) --> 0`.
+# Handles metadata, e.g. `1.0, Z --> 0, [noisescaling=η]`.
+function push_reactions!(reactions::Vector{ReactionStruct}, sub_line::ExprValues, prod_line::ExprValues, 
+                         rate::ExprValues, metadata::ExprValues, arrow::Symbol)  
+    # The rates, substrates, products, and metadata may be in a tupple form (e.g. `k, (X,Y) --> 0`).
+    # This finds the length of these tuples (or 1 if not in tuple forms). Errors if lengs inconsistent.
+    lengs = (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate), tup_leng(metadata))
+    if any(!(leng in [1, maximum(lengs)]) for leng in lengs)
+        throw("Malformed reaction, rate=$rate, subs=$sub_line, prods=$prod_line, metadata=$metadata.")
+    end
+
+    # Loops through each reaction encoded by the reaction composites. Adds the reaction to the reactions vector.
+    for i in 1:maximum(lengs)                       
+        # If the `only_use_rate` metadata was not provided, this has to be infered from the arrow used.
+        metadata_i = get_tup_arg(metadata, i)
+        if all([arg.args[1] != :only_use_rate for arg in metadata_i.args])
+            push!(metadata_i.args, :(only_use_rate = $(in(arrow, pure_rate_arrows))))
+        end
+
+        push!(reactions, ReactionStruct(get_tup_arg(sub_line, i), get_tup_arg(prod_line, i),
+                                        get_tup_arg(rate, i), metadata_i))
     end
 end
 
@@ -685,6 +698,17 @@ function recursive_find_reactants!(ex::ExprValues, mult::ExprValues,
         throw("Malformed reaction, bad operator: $(ex.args[1]) found in stochiometry expression $ex.")
     end
     reactants
+end
+
+# Finds the metadata from a metadata expresion (`[key=val, ...]`) and returns as a Vector{Pair{Symbol,ExprValues}}.
+function extract_metadata(metadata_line::Expr)
+    metadata = :([])
+    for arg in metadata_line.args
+        (arg.head != :(=)) && error("Malformatted metadata line: $metadata_line. Each entry in the vector should contain a `=`.")
+        (arg.args[1] isa Symbol) || error("Malformatted metadata entry: $arg. Entries left-hand-side should be a single symbol.")
+        push!(metadata.args, :($(QuoteNode(arg.args[1])) => $(arg.args[2])))
+    end
+    return metadata
 end
 
 ### DSL Options Handling ###
@@ -887,4 +911,14 @@ end
 #         push!(defaults.args[2].args, :($(arg.args[1]) => $(arg.args[2])))
 #     end
 #     return defaults
+# end
+
+
+# # Creates a ReactionStruct from the information in a single line.
+# function create_ReactionStruct(sub_line::ExprValues, prod_line::ExprValues,
+#     rate::ExprValues, only_use_rate::Bool)
+#     all(==(1), (tup_leng(sub_line), tup_leng(prod_line), tup_leng(rate))) ||
+#     error("Malformed reaction, line appears to be defining multiple reactions incorrectly: rate=$rate, subs=$sub_line, prods=$prod_line.")
+#     ReactionStruct(get_tup_arg(sub_line, 1), get_tup_arg(prod_line, 1),
+#     get_tup_arg(rate, 1), only_use_rate)
 # end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -187,8 +187,7 @@ function Reaction(rate, subs, prods, substoich, prodstoich;
     end
 
     # Check that all metadata entries are unique. (cannot use `in` since some entries may be symbolics).
-    if any(any(isequal(metadata[i][1], entry[1]) for entry in metadata[i+1:end]) 
-                                                 for i in eachindex(metadata))
+    if !allunique(entry[1] for entry in metadata)
         error("Repeated entries for the same metadata encountered in the following metadata set: $([entry[1] for entry in metadata]).")
     end
 
@@ -205,8 +204,9 @@ end
 
 # Checks if a metadata input has an entry :only_use_rate => true
 function metadata_only_use_rate_check(metadata)
-    any(:only_use_rate == entry[1] for entry in metadata) || (return false)
-    return Bool(metadata[findfirst(:only_use_rate == entry[1] for entry in metadata)][2])
+    only_use_rate_idx = findfirst(:only_use_rate == entry[1] for entry in metadata)
+    isnothing(only_use_rate_idx) && return true
+    return Bool(metadata[only_use_rate_idx][2])
 end
 
 # three argument constructor assumes stoichiometric coefs are one and integers

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -186,8 +186,9 @@ function Reaction(rate, subs, prods, substoich, prodstoich;
         convert.(stoich_type, netstoich) : netstoich
     end
 
-    # Check that all metadata entries are unique.
-    if any(metadata[i] in metadata[i+1:end] for i in eachindex(metadata))
+    # Check that all metadata entries are unique. (cannot use `in` since some entries may be symbolics).
+    if any(any(isequal(metadata[i][1], entry[1]) for entry in metadata[i+1:end]) 
+                                                 for i in eachindex(metadata))
         error("Repeated entries for the same metadata encountered in the following metadata set: $([entry[1] for entry in metadata]).")
     end
 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -193,7 +193,7 @@ function Reaction(rate, subs, prods, substoich, prodstoich;
 
     # Deletes potential `:only_use_rate => ` entries from the metadata.
     if any(:only_use_rate == entry[1] for entry in metadata) 
-        findfirst(:only_use_rate == entry[1] for entry in metadata)
+        deleteat!(metadata, findfirst(:only_use_rate == entry[1] for entry in metadata))
     end
 
     Reaction(value(rate), subs, prods, substoich′, prodstoich′, ns, only_use_rate, metadata)
@@ -202,7 +202,7 @@ end
 # Checks if a metadata input has an entry :only_use_rate => true
 function metadata_only_use_rate_check(metadata)
     any(:only_use_rate == entry[1] for entry in metadata) || (return false)
-    return metadata[findfirst(:only_use_rate == entry[1] for entry in metadata)] 
+    return metadata[findfirst(:only_use_rate == entry[1] for entry in metadata)][2]
 end
 
 # three argument constructor assumes stoichiometric coefs are one and integers

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -202,7 +202,7 @@ end
 # Checks if a metadata input has an entry :only_use_rate => true
 function metadata_only_use_rate_check(metadata)
     any(:only_use_rate == entry[1] for entry in metadata) || (return false)
-    return metadata[findfirst(:only_use_rate == entry[1] for entry in metadata)][2]
+    return Bool(metadata[findfirst(:only_use_rate == entry[1] for entry in metadata)][2])
 end
 
 # three argument constructor assumes stoichiometric coefs are one and integers

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -196,6 +196,9 @@ function Reaction(rate, subs, prods, substoich, prodstoich;
         deleteat!(metadata, findfirst(:only_use_rate == entry[1] for entry in metadata))
     end
 
+    # Ensures metadata have the correct type.
+    metadata = convert(Vector{Pair{Symbol, Any}}, metadata)
+
     Reaction(value(rate), subs, prods, substoich′, prodstoich′, ns, only_use_rate, metadata)
 end
 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -854,7 +854,7 @@ end
 ######################## Other accessors ##############################
 
 """
-    get_metadata_vec(reaction::Reaction)
+    get_metadata_dict(reaction::Reaction)
 
 Retrives the `ImmutableDict` containing all of the metadata associated with a specific reaction.
 
@@ -864,10 +864,10 @@ Arguments:
 Example:
 ```julia
 reaction = @reaction k, 0 --> X, [noise_scaling=0.0]
-get_metadata_vec(reaction)
+get_metadata_dict(reaction)
 ```
 """
-function get_metadata_vec(reaction::Reaction)
+function get_metadata_dict(reaction::Reaction)
     return reaction.metadata
 end
 
@@ -887,7 +887,7 @@ has_metadata(reaction, :noise_scaling)
 ```
 """
 function has_metadata(reaction::Reaction, md_key::Symbol)
-    return any(isequal(md_key, entry[1]) for entry in get_metadata_vec(reaction))
+    return any(isequal(md_key, entry[1]) for entry in get_metadata_dict(reaction))
 end
 
 """
@@ -907,9 +907,9 @@ get_metadata(reaction, :noise_scaling)
 """
 function get_metadata(reaction::Reaction, md_key::Symbol)
     if !has_metadata(reaction, md_key) 
-        error("The reaction does not have a metadata field $md_key. It does have the following metadata fields: $(keys(get_metadata_vec(reaction))).")
+        error("The reaction does not have a metadata field $md_key. It does have the following metadata fields: $(keys(get_metadata_dict(reaction))).")
     end
-    return get_metadata_vec(reaction)[findfirst(isequal(md_key, entry[1]) for entry in get_metadata_vec(reaction))][2]
+    return get_metadata_dict(reaction)[findfirst(isequal(md_key, entry[1]) for entry in get_metadata_dict(reaction))][2]
 end
 
 ######################## Conversion to ODEs/SDEs/jump, etc ##############################

--- a/src/registered_functions.jl
+++ b/src/registered_functions.jl
@@ -134,7 +134,8 @@ function expand_registered_functions(expr)
 end
 # If applied to a Reaction, return a reaction with its rate modified.
 function expand_registered_functions(rx::Reaction)
-    Reaction(expand_registered_functions(rx.rate), rx.substrates, rx.products, rx.substoich, rx.prodstoich, rx.netstoich, rx.only_use_rate)
+    Reaction(expand_registered_functions(rx.rate), rx.substrates, rx.products, rx.substoich, 
+             rx.prodstoich, rx.netstoich, rx.only_use_rate, rx.metadata)
 end
 # If applied to a Equation, returns it with it applied to lhs and rhs
 function expand_registered_functions(eq::Equation)

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -143,14 +143,14 @@ let
     @parameters k η
     @species X(t) X2(t)
 
-    metadata1 = Dict(:noise_scaling => η)
+    metadata1 = [:noise_scaling => η]
     r1 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata1)
 
-    metadata2 = Dict(:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
-                     :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0))
+    metadata2 = [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
+                     :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)]
     r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata2)
 
-    metadata3 = Dict{Symbol,Any}()
+    metadata3 = Pair{Symbol,Any}[]
     r3 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata3)
 
     # Creates reactions using DSL.
@@ -164,9 +164,9 @@ let
     # Checks DSL reactions are correct.
     rxs = reactions(rs)
     @test isequal([r1, r2, r3], rxs)
-    @test isequal(get_metadata_dict(r1), get_metadata_dict(rxs[1]))
-    @test isequal(get_metadata_dict(r2), get_metadata_dict(rxs[2]))
-    @test isequal(get_metadata_dict(r3), get_metadata_dict(rxs[3]))
+    @test isequal(get_metadata_vec(r1), get_metadata_vec(rxs[1]))
+    @test isequal(get_metadata_vec(r2), get_metadata_vec(rxs[2]))
+    @test isequal(get_metadata_vec(r3), get_metadata_vec(rxs[3]))
 
     # Checks that accessor functions works on the DSL.
     @test has_metadata(rxs[1], :noise_scaling)
@@ -185,9 +185,9 @@ let
     rx3 = @reaction k, 2X --> X2
 
     @test isequal([rx1, rx2, rx3], rxs)
-    @test isequal(get_metadata_dict(rx1), get_metadata_dict(rxs[1]))
-    @test isequal(get_metadata_dict(rx2), get_metadata_dict(rxs[2]))
-    @test isequal(get_metadata_dict(rx3), get_metadata_dict(rxs[3]))
+    @test isequal(get_metadata_vec(rx1), get_metadata_vec(rxs[1]))
+    @test isequal(get_metadata_vec(rx2), get_metadata_vec(rxs[2]))
+    @test isequal(get_metadata_vec(rx3), get_metadata_vec(rxs[3]))
 end
 
 # Checks that repeated metadata throws errors.

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -190,6 +190,14 @@ let
     @test isequal(get_metadata_dict(rx3), get_metadata_dict(rxs[3]))
 end
 
+# Checks that repeated metadata throws errors.
+let 
+    @test_throws LoadError @eval @reaction k, 0 --> X, [md1=1.0, md1=2.0] 
+    @test_throws LoadError @eval @reaction_network begin
+        k, 0 --> X, [md1=1.0, md1=1.0] 
+    end 
+end
+
 # Tests for nested metadata.
 let
     rn1 = @reaction_network reactions begin

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -146,8 +146,13 @@ let
     metadata1 = [:noise_scaling => η]
     r1 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata1)
 
-    metadata2 = [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
-                     :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)]
+    metadata2 = Pair{Symbol,Any}[]
+    push!(metadata2, :md_1 => 1.0)
+    push!(metadata2, :md_2 => false)
+    push!(metadata2, :md_3 => "Hello world")
+    push!(metadata2, :md_4 => :sym)
+    push!(metadata2, :md_5 => X + X2^k -1)
+    push!(metadata2, :md_6 => (0.1, 2.0))
     r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata2)
 
     metadata3 = Pair{Symbol,Any}[]

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -169,9 +169,9 @@ let
     # Checks DSL reactions are correct.
     rxs = reactions(rs)
     @test isequal([r1, r2, r3], rxs)
-    @test isequal(get_metadata_vec(r1), get_metadata_vec(rxs[1]))
-    @test isequal(get_metadata_vec(r2), get_metadata_vec(rxs[2]))
-    @test isequal(get_metadata_vec(r3), get_metadata_vec(rxs[3]))
+    @test isequal(get_metadata_dict(r1), get_metadata_dict(rxs[1]))
+    @test isequal(get_metadata_dict(r2), get_metadata_dict(rxs[2]))
+    @test isequal(get_metadata_dict(r3), get_metadata_dict(rxs[3]))
 
     # Checks that accessor functions works on the DSL.
     @test has_metadata(rxs[1], :noise_scaling)
@@ -190,9 +190,9 @@ let
     rx3 = @reaction k, 2X --> X2
 
     @test isequal([rx1, rx2, rx3], rxs)
-    @test isequal(get_metadata_vec(rx1), get_metadata_vec(rxs[1]))
-    @test isequal(get_metadata_vec(rx2), get_metadata_vec(rxs[2]))
-    @test isequal(get_metadata_vec(rx3), get_metadata_vec(rxs[3]))
+    @test isequal(get_metadata_dict(rx1), get_metadata_dict(rxs[1]))
+    @test isequal(get_metadata_dict(rx2), get_metadata_dict(rxs[2]))
+    @test isequal(get_metadata_dict(rx3), get_metadata_dict(rxs[3]))
 end
 
 # Checks that repeated metadata throws errors.

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -169,20 +169,20 @@ let
     # Checks DSL reactions are correct.
     rxs = reactions(rs)
     @test isequal([r1, r2, r3], rxs)
-    @test isequal(get_metadata_dict(r1), get_metadata_dict(rxs[1]))
-    @test isequal(get_metadata_dict(r2), get_metadata_dict(rxs[2]))
-    @test isequal(get_metadata_dict(r3), get_metadata_dict(rxs[3]))
+    @test isequal(Catalyst.get_metadata_dict(r1), Catalyst.get_metadata_dict(rxs[1]))
+    @test isequal(Catalyst.get_metadata_dict(r2), Catalyst.get_metadata_dict(rxs[2]))
+    @test isequal(Catalyst.get_metadata_dict(r3), Catalyst.get_metadata_dict(rxs[3]))
 
     # Checks that accessor functions works on the DSL.
-    @test has_metadata(rxs[1], :noise_scaling)
-    @test !has_metadata(rxs[1], :md_1)
-    @test !has_metadata(rxs[2], :noise_scaling)
-    @test has_metadata(rxs[2], :md_1)
-    @test !has_metadata(rxs[3], :noise_scaling)
-    @test !has_metadata(rxs[3], :md_1)
+    @test Catalyst.has_metadata(rxs[1], :noise_scaling)
+    @test !Catalyst.has_metadata(rxs[1], :md_1)
+    @test !Catalyst.has_metadata(rxs[2], :noise_scaling)
+    @test Catalyst.has_metadata(rxs[2], :md_1)
+    @test !Catalyst.has_metadata(rxs[3], :noise_scaling)
+    @test !Catalyst.has_metadata(rxs[3], :md_1)
     
-    @test isequal(get_metadata(rxs[1], :noise_scaling), η)
-    @test isequal(get_metadata(rxs[2], :md_1), 1.0)
+    @test isequal(Catalyst.get_metadata(rxs[1], :noise_scaling), η)
+    @test isequal(Catalyst.get_metadata(rxs[2], :md_1), 1.0)
 
     # Test that metadata works for @reaction macro.
     rx1 = @reaction k, 2X --> X2, [noise_scaling=$η]
@@ -190,9 +190,9 @@ let
     rx3 = @reaction k, 2X --> X2
 
     @test isequal([rx1, rx2, rx3], rxs)
-    @test isequal(get_metadata_dict(rx1), get_metadata_dict(rxs[1]))
-    @test isequal(get_metadata_dict(rx2), get_metadata_dict(rxs[2]))
-    @test isequal(get_metadata_dict(rx3), get_metadata_dict(rxs[3]))
+    @test isequal(Catalyst.get_metadata_dict(rx1), Catalyst.get_metadata_dict(rxs[1]))
+    @test isequal(Catalyst.get_metadata_dict(rx2), Catalyst.get_metadata_dict(rxs[2]))
+    @test isequal(Catalyst.get_metadata_dict(rx3), Catalyst.get_metadata_dict(rxs[3]))
 end
 
 # Checks that repeated metadata throws errors.

--- a/test/reactionsystem_structure/reactions.jl
+++ b/test/reactionsystem_structure/reactions.jl
@@ -7,18 +7,22 @@ using Catalyst, Test
 
 # Tests creation.
 # Tests basic accessor functions.
+# Tests that repeated metadata entries are not permitted.
 let
     @variables t
     @parameters k
     @species X(t) X2(t)
 
-    metadata = Dict(:noise_scaling => 0.0)
+    metadata = [:noise_scaling => 0.0]
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test get_metadata_dict(r) == Dict(:noise_scaling => 0.0)
+    @test get_metadata_vec(r) == [:noise_scaling => 0.0]
     @test has_metadata(r, :noise_scaling)
     @test !has_metadata(r, :nonexisting_metadata)
     @test get_metadata(r, :noise_scaling) == 0.0
+
+    metadata_repeated = [:noise_scaling => 0.0, :noise_scaling => 1.0, :metadata_entry => "unused"]
+    @test_throws Exception Reaction(k, [X], [X2], [2], [1]; metadata=metadata_repeated)
 end
 
 # Tests accessors for system without metadata.
@@ -27,12 +31,12 @@ let
     @parameters k
     @species X(t) X2(t)
 
-    metadata = Dict{Symbol,Any}()
+    metadata = Pair{Symbol,Any}[]
     r1 = Reaction(k, [X], [X2], [2], [1])
     r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
     @test isequal(r1, r2)
-    @test get_metadata_dict(r1) == Dict()
+    @test get_metadata_vec(r1) == Pair{Symbol,Any}[]
     @test !has_metadata(r1, :md)
 end
 
@@ -44,12 +48,12 @@ let
     @parameters k
     @species X(t) X2(t)
 
-    metadata = Dict(:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
-                                  :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0))
+    metadata = [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
+                                  :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)]
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test isequal(get_metadata_dict(r), Dict(:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", 
-                                                     :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)))
+    @test isequal(get_metadata_vec(r), [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", 
+                                        :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)])
     @test has_metadata(r, :md_1)
     @test has_metadata(r, :md_2)
     @test has_metadata(r, :md_3)

--- a/test/reactionsystem_structure/reactions.jl
+++ b/test/reactionsystem_structure/reactions.jl
@@ -48,10 +48,16 @@ let
     @parameters k
     @species X(t) X2(t)
 
-    metadata = [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)]
+    metadata = Pair{Symbol,Any}[]
+    push!(metadata, :md_1 => 1.0)
+    push!(metadata, :md_2 => false)
+    push!(metadata, :md_3 => "Hello world")
+    push!(metadata, :md_4 => :sym)
+    push!(metadata, :md_5 => X + X2^k -1)
+    push!(metadata, :md_6 => (0.1, 2.0))
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test isequal(get_metadata_vec(r), [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)])
+    @test get_metadata_vec(r) isa Vector{Pair{Symbol,Any}}
     @test has_metadata(r, :md_1)
     @test has_metadata(r, :md_2)
     @test has_metadata(r, :md_3)

--- a/test/reactionsystem_structure/reactions.jl
+++ b/test/reactionsystem_structure/reactions.jl
@@ -16,7 +16,7 @@ let
     metadata = [:noise_scaling => 0.0]
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test get_metadata_vec(r) == [:noise_scaling => 0.0]
+    @test get_metadata_dict(r) == [:noise_scaling => 0.0]
     @test has_metadata(r, :noise_scaling)
     @test !has_metadata(r, :nonexisting_metadata)
     @test get_metadata(r, :noise_scaling) == 0.0
@@ -36,7 +36,7 @@ let
     r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
     @test isequal(r1, r2)
-    @test get_metadata_vec(r1) == Pair{Symbol,Any}[]
+    @test get_metadata_dict(r1) == Pair{Symbol,Any}[]
     @test !has_metadata(r1, :md)
 end
 
@@ -57,7 +57,7 @@ let
     push!(metadata, :md_6 => (0.1, 2.0))
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test get_metadata_vec(r) isa Vector{Pair{Symbol,Any}}
+    @test get_metadata_dict(r) isa Vector{Pair{Symbol,Any}}
     @test has_metadata(r, :md_1)
     @test has_metadata(r, :md_2)
     @test has_metadata(r, :md_3)

--- a/test/reactionsystem_structure/reactions.jl
+++ b/test/reactionsystem_structure/reactions.jl
@@ -16,10 +16,10 @@ let
     metadata = [:noise_scaling => 0.0]
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test get_metadata_dict(r) == [:noise_scaling => 0.0]
-    @test has_metadata(r, :noise_scaling)
-    @test !has_metadata(r, :nonexisting_metadata)
-    @test get_metadata(r, :noise_scaling) == 0.0
+    @test Catalyst.get_metadata_dict(r) == [:noise_scaling => 0.0]
+    @test Catalyst.has_metadata(r, :noise_scaling)
+    @test !Catalyst.has_metadata(r, :nonexisting_metadata)
+    @test Catalyst.get_metadata(r, :noise_scaling) == 0.0
 
     metadata_repeated = [:noise_scaling => 0.0, :noise_scaling => 1.0, :metadata_entry => "unused"]
     @test_throws Exception Reaction(k, [X], [X2], [2], [1]; metadata=metadata_repeated)
@@ -36,8 +36,8 @@ let
     r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
     @test isequal(r1, r2)
-    @test get_metadata_dict(r1) == Pair{Symbol,Any}[]
-    @test !has_metadata(r1, :md)
+    @test Catalyst.get_metadata_dict(r1) == Pair{Symbol,Any}[]
+    @test !Catalyst.has_metadata(r1, :md)
 end
 
 # Tests creation.
@@ -57,19 +57,34 @@ let
     push!(metadata, :md_6 => (0.1, 2.0))
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test get_metadata_dict(r) isa Vector{Pair{Symbol,Any}}
-    @test has_metadata(r, :md_1)
-    @test has_metadata(r, :md_2)
-    @test has_metadata(r, :md_3)
-    @test has_metadata(r, :md_4)
-    @test has_metadata(r, :md_5)
-    @test has_metadata(r, :md_6)
-    @test !has_metadata(r, :md_8)
+    @test Catalyst.get_metadata_dict(r) isa Vector{Pair{Symbol,Any}}
+    @test Catalyst.has_metadata(r, :md_1)
+    @test Catalyst.has_metadata(r, :md_2)
+    @test Catalyst.has_metadata(r, :md_3)
+    @test Catalyst.has_metadata(r, :md_4)
+    @test Catalyst.has_metadata(r, :md_5)
+    @test Catalyst.has_metadata(r, :md_6)
+    @test !Catalyst.has_metadata(r, :md_8)
     
-    @test isequal(get_metadata(r, :md_1), 1.0)
-    @test isequal(get_metadata(r, :md_2), false)
-    @test isequal(get_metadata(r, :md_3), "Hello world")
-    @test isequal(get_metadata(r, :md_4), :sym)
-    @test isequal(get_metadata(r, :md_5), X + X2^k -1)
-    @test isequal(get_metadata(r, :md_6), (0.1, 2.0))
+    @test isequal(Catalyst.get_metadata(r, :md_1), 1.0)
+    @test isequal(Catalyst.get_metadata(r, :md_2), false)
+    @test isequal(Catalyst.get_metadata(r, :md_3), "Hello world")
+    @test isequal(Catalyst.get_metadata(r, :md_4), :sym)
+    @test isequal(Catalyst.get_metadata(r, :md_5), X + X2^k -1)
+    @test isequal(Catalyst.get_metadata(r, :md_6), (0.1, 2.0))
+end
+
+# Noise scaling metadata.
+let
+    @variables t
+    @parameters k η  
+    @species X(t) X2(t)
+
+    metadata = Pair{Symbol,Any}[]
+    push!(metadata, :noise_scaling => η)
+    r1 = Reaction(k, [X], [X2], [2], [1])
+    r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
+
+    @test isequal(Catalyst.getnoisescaling(r1), 1.0)
+    @test isequal(Catalyst.getnoisescaling(r2), η)
 end

--- a/test/reactionsystem_structure/reactions.jl
+++ b/test/reactionsystem_structure/reactions.jl
@@ -1,0 +1,67 @@
+### Preparations ###
+
+# Fetch packages.
+using Catalyst, Test
+
+### Tests Metadata ###
+
+# Tests creation.
+# Tests basic accessor functions.
+let
+    @variables t
+    @parameters k
+    @species X(t) X2(t)
+
+    metadata = Dict(:noise_scaling => 0.0)
+    r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
+
+    @test get_metadata_dict(r) == Dict(:noise_scaling => 0.0)
+    @test has_metadata(r, :noise_scaling)
+    @test !has_metadata(r, :nonexisting_metadata)
+    @test get_metadata(r, :noise_scaling) == 0.0
+end
+
+# Tests accessors for system without metadata.
+let
+    @variables t
+    @parameters k
+    @species X(t) X2(t)
+
+    metadata = Dict{Symbol,Any}()
+    r1 = Reaction(k, [X], [X2], [2], [1])
+    r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
+
+    @test isequal(r1, r2)
+    @test get_metadata_dict(r1) == Dict()
+    @test !has_metadata(r1, :md)
+end
+
+# Tests creation.
+# Tests basic accessor functions.
+# Tests various metadata types.
+let
+    @variables t
+    @parameters k
+    @species X(t) X2(t)
+
+    metadata = Dict(:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
+                                  :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0))
+    r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
+
+    @test isequal(get_metadata_dict(r), Dict(:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", 
+                                                     :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)))
+    @test has_metadata(r, :md_1)
+    @test has_metadata(r, :md_2)
+    @test has_metadata(r, :md_3)
+    @test has_metadata(r, :md_4)
+    @test has_metadata(r, :md_5)
+    @test has_metadata(r, :md_6)
+    @test !has_metadata(r, :md_8)
+    
+    @test isequal(get_metadata(r, :md_1), 1.0)
+    @test isequal(get_metadata(r, :md_2), false)
+    @test isequal(get_metadata(r, :md_3), "Hello world")
+    @test isequal(get_metadata(r, :md_4), :sym)
+    @test isequal(get_metadata(r, :md_5), X + X2^k -1)
+    @test isequal(get_metadata(r, :md_6), (0.1, 2.0))
+end

--- a/test/reactionsystem_structure/reactions.jl
+++ b/test/reactionsystem_structure/reactions.jl
@@ -48,12 +48,10 @@ let
     @parameters k
     @species X(t) X2(t)
 
-    metadata = [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, 
-                                  :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)]
+    metadata = [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)]
     r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
 
-    @test isequal(get_metadata_vec(r), [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", 
-                                        :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)])
+    @test isequal(get_metadata_vec(r), [:md_1 => 1.0, :md_2 => false, :md_3 => "Hello world", :md_4 => :sym, :md_5 => X + X2^k -1, :md_6 => (0.1, 2.0)])
     @test has_metadata(r, :md_1)
     @test has_metadata(r, :md_2)
     @test has_metadata(r, :md_3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using SafeTestsets
 @time begin
 
     ### Tests the properties of ReactionSystems. ###
+    @time @safetestset "Reactions" begin include("reactionsystem_structure/reactions.jl") end
     @time @safetestset "ReactionSystem" begin include("reactionsystem_structure/reactionsystem.jl") end
     @time @safetestset "Higher Order Reactions" begin include("reactionsystem_structure/higher_order_reactions.jl") end
 


### PR DESCRIPTION
The `Reaction` type now have a `.metadata` field:
```julia
    """
    Contain additional data, such whenever the reaction have a specific noise-scaling expression for
    the chemical Langevin equation.
    """
    metadata::Dict{Symbol, R}
```

I would have used `Base.ImmutableDict`s, but there are problems with regards to these: https://discourse.julialang.org/t/create-immutabledict-with-values-of-differenrt-types/107831

The metadata can be accessed via the following functions:
```
get_metadata_dict
has_metadata
get_metadata
```

Metadata can either be added as an optional argument when creating `Reactions`s programmatically:
```julia
using Catalyst

@variables t
@parameters k
@species X(t) X2(t)

metadata = Dict(:noise_scaling => 0.0)
r = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
```
Here, the accessors works like this:
```julia
get_metadata_dict(r)
has_metadata(r, :noise_scaling)
get_metadata(r, :noise_scaling)
```

Metadata can also be provided via the DSLs:
```julia
rs = @reaction_network begin
    @parameters η
    k, 2X --> X2, [noise_scaling=η]
    k, 2X --> X2, [some_metadata=1.0, more_metadata="Hello world"]
end

@parameters η
@reaction k, 2X --> X2, [noise_scaling=$η]
@reaction k, 2X --> X2, [some_metadata=1.0, more_metadata="Hello world"]
```

Finally, instead of using arrows like `=>`, 
```julia
rs = @reaction_network begin
    k, 2X --> X2, [only_use_rate=true]
end
```
can be used to remove the substrate expression from the rate. Internally, `only_use_rate=true` is carried through as a metadata to record this. However, it is removed at the end.

Currently, no additional metadata is actually used. However, `noise_scaling` will be added after this is merged. 

Also:
- I have updated this, adding `Bool`: `const ExprValues = Union{Expr, Symbol, Float64, Int, Bool}`. Here, `Bool`s can potentially be inside expressions (like `Float64`). We missed this before and I realised when working with this. Added it now.
- Since some tests here are specific to the `Reaction` struct, I added another test file for tests related to this struct.
- I made a minor internal remake so that reactions created in `@reaction` and `@reaction_network` are created using the same internal function.

Considerations:
- Should `only_use_rate` remain in the metadata post-creation? This could also be entirely turned into a metadata thing. Alternatively, we keep it as currently implemented, where this can be used as an option, but never actually appear in the metadata.
- Should we maintain a list of permitted metadata? This would prevent the user to add their own, but would give us more control. Alternatively, we can add a warning if another metadata was used. This would be useful if someone e.g. writers `noise_scalling = `, since we could then catch this error.


