### PR TITLE
Add reaction system metadata

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -508,9 +508,7 @@ struct ReactionSystem{V <: NetworkProperties} <:
     """
     discrete_events::Vector{MT.SymbolicDiscreteCallback}
     """
-    Metadata for the system, to be used by downstream packages. Currently have no known usage,
-    however, is present in other ModelingToolkit systems, and hence added here in case it might
-    be needed in the future.
+    Metadata for the system, to be used by downstream packages. 
     """
     metadata::Any
     """

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -508,6 +508,12 @@ struct ReactionSystem{V <: NetworkProperties} <:
     """
     discrete_events::Vector{MT.SymbolicDiscreteCallback}
     """
+    Metadata for the system, to be used by downstream packages. Currently have no known usage,
+    however, is present in other ModelingToolkit systems, and hence added here in case it might
+    be needed in the future.
+    """
+    metadata::Any
+    """
     complete: if a model `sys` is complete, then `sys.x` no longer performs namespacing.
     """
     complete::Bool
@@ -515,7 +521,7 @@ struct ReactionSystem{V <: NetworkProperties} <:
     # inner constructor is considered private and may change between non-breaking releases.
     function ReactionSystem(eqs, rxs, iv, sivs, states, spcs, ps, var_to_name, observed,
                             name, systems, defaults, connection_type, nps, cls, cevs, devs,
-                            complete::Bool = false; checks::Bool = true)
+                            metadata = nothing, complete::Bool = false; checks::Bool = true)
                             
         # unit checks are for ODEs and Reactions only currently
         nonrx_eqs = Equation[eq for eq in eqs if eq isa Equation]
@@ -534,7 +540,7 @@ struct ReactionSystem{V <: NetworkProperties} <:
 
         rs = new{typeof(nps)}(eqs, rxs, iv, sivs, states, spcs, ps, var_to_name, observed,
                               name, systems, defaults, connection_type, nps, cls, cevs,
-                              devs, complete)
+                              devs, metadata, complete)
         checks && validate(rs)
         rs
     end

--- a/test/reactionsystem_structure/reactionsystem.jl
+++ b/test/reactionsystem_structure/reactionsystem.jl
@@ -763,3 +763,9 @@ let
     @test !isspecies(Y)
     @test isspecies(Catalyst.tospecies(Y))
 end
+
+# Tests metadata.
+let
+    @test isnothing(ModelingToolkit.get_metadata(rs))
+end
+


### PR DESCRIPTION
Adds a `metadata::Any` field to `ReactionSystem`s. Currently have no direct use. However, it can be used by downstream packages. Also, it makes `ReactionSystem` conform to the standard of various MTK System types which have this field.