### PR TITLE
Use MTK's default `t` and `D` throughout repository

### DIFF
--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -36,8 +36,8 @@ models, and stochastic chemical kinetics jump process models.
 
 ```@example ex1
 using Catalyst, DifferentialEquations, Plots
+import Catalyst: t_nounits as t
 @parameters β γ
-@variables t
 @species S(t) I(t) R(t)
 
 rxs = [Reaction(β, [S,I], [I], [1,1], [2])

--- a/docs/src/api/catalyst_api.md
+++ b/docs/src/api/catalyst_api.md
@@ -36,7 +36,7 @@ models, and stochastic chemical kinetics jump process models.
 
 ```@example ex1
 using Catalyst, DifferentialEquations, Plots
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters β γ
 @species S(t) I(t) R(t)
 

--- a/docs/src/catalyst_applications/simulation_structure_interfacing.md
+++ b/docs/src/catalyst_applications/simulation_structure_interfacing.md
@@ -104,7 +104,7 @@ Finally, we note that we cannot change the values of solution unknowns or parame
 Catalyst is built on an *intermediary representation* implemented by (ModelingToolkit.jl)[https://github.com/SciML/ModelingToolkit.jl]. ModelingToolkit is a modelling framework where one first declares a set of symbolic variables and parameters using e.g.
 ```@example ex2
 using ModelingToolkit
-import ModelingToolkit: t_nounits as t
+t = default_t()
 @parameters σ ρ β
 @variables x(t) y(t) z(t)
 nothing # hide

--- a/docs/src/catalyst_applications/simulation_structure_interfacing.md
+++ b/docs/src/catalyst_applications/simulation_structure_interfacing.md
@@ -104,8 +104,9 @@ Finally, we note that we cannot change the values of solution unknowns or parame
 Catalyst is built on an *intermediary representation* implemented by (ModelingToolkit.jl)[https://github.com/SciML/ModelingToolkit.jl]. ModelingToolkit is a modelling framework where one first declares a set of symbolic variables and parameters using e.g.
 ```@example ex2
 using ModelingToolkit
+import ModelingToolkit: t_nounits as t
 @parameters σ ρ β
-@variables t x(t) y(t) z(t)
+@variables x(t) y(t) z(t)
 nothing # hide
 ```
 and then uses these to build systems of equations. Here, these symbolic variables (`x`, `y`, and `z`) and parameters (`σ`, `ρ`, and `β`) can be used to interface a `problem`, `integrator`, and `solution` object (like we did previously, but using Symbols, e.g. `:X`). Since Catalyst models are built on ModelingToolkit, these models also contain similar symbolic variables and parameters.

--- a/docs/src/catalyst_functionality/chemistry_related_functionality.md
+++ b/docs/src/catalyst_functionality/chemistry_related_functionality.md
@@ -10,7 +10,7 @@ While Catalyst has primarily been designed around the modelling of biological sy
 We will first show how to create compound species through [programmatic model construction](@ref programmatic_CRN_construction), and then demonstrate using the DSL. To create a compound species, use the `@compound` macro, first designating the compound, followed by its components (and their stoichiometries). In this example, we will create a CO₂ molecule, consisting of one C atom and two O atoms. First, we create species corresponding to the components:
 ```@example chem1
 using Catalyst
-@variables t
+import Catalyst: t_nounits as t
 @species C(t) O(t) 
 ```
 Next, we create the `CO2` compound species:
@@ -97,7 +97,8 @@ In all of these cases, the side to the left of the `~` must be enclosed within `
 ### Compounds with multiple independent variables
 While we generally do not need to specify independent variables for compound, if the components (together) have more than one independent variable, this have to be done:
 ```@example chem1
-@variables t s
+import Catalyst: t_nounits as t
+@variables s
 @species N(s) O(t) 
 @compound NO2(t,s) ~ N + 2O
 ```
@@ -117,7 +118,7 @@ which correctly finds the (rather trivial) solution `C + 2O --> CO2`. Here we no
 Let us consider a more elaborate example, the reaction between ammonia (NH₃) and oxygen (O₂) to form nitrogen monoxide (NO) and water (H₂O). Let us first create the components and the unbalanced reaction:
 ```@example chem2
 using Catalyst # hide
-@variables t
+import Catalyst: t_nounits as t
 @species N(t) H(t) O(t) 
 @compounds begin
     NH3 ~ N + 3H

--- a/docs/src/catalyst_functionality/chemistry_related_functionality.md
+++ b/docs/src/catalyst_functionality/chemistry_related_functionality.md
@@ -10,7 +10,7 @@ While Catalyst has primarily been designed around the modelling of biological sy
 We will first show how to create compound species through [programmatic model construction](@ref programmatic_CRN_construction), and then demonstrate using the DSL. To create a compound species, use the `@compound` macro, first designating the compound, followed by its components (and their stoichiometries). In this example, we will create a CO₂ molecule, consisting of one C atom and two O atoms. First, we create species corresponding to the components:
 ```@example chem1
 using Catalyst
-import Catalyst: t_nounits as t
+t = default_t()
 @species C(t) O(t) 
 ```
 Next, we create the `CO2` compound species:
@@ -97,7 +97,7 @@ In all of these cases, the side to the left of the `~` must be enclosed within `
 ### Compounds with multiple independent variables
 While we generally do not need to specify independent variables for compound, if the components (together) have more than one independent variable, this have to be done:
 ```@example chem1
-import Catalyst: t_nounits as t
+t = default_t()
 @variables s
 @species N(s) O(t) 
 @compound NO2(t,s) ~ N + 2O
@@ -118,7 +118,7 @@ which correctly finds the (rather trivial) solution `C + 2O --> CO2`. Here we no
 Let us consider a more elaborate example, the reaction between ammonia (NH₃) and oxygen (O₂) to form nitrogen monoxide (NO) and water (H₂O). Let us first create the components and the unbalanced reaction:
 ```@example chem2
 using Catalyst # hide
-import Catalyst: t_nounits as t
+t = default_t()
 @species N(t) H(t) O(t) 
 @compounds begin
     NH3 ~ N + 3H

--- a/docs/src/catalyst_functionality/compositional_modeling.md
+++ b/docs/src/catalyst_functionality/compositional_modeling.md
@@ -51,7 +51,7 @@ plot(TreePlot(rn), method=:tree, fontsize=12, nodeshape=:ellipse)
 We could also have directly constructed `rn` using the same reaction as in
 `basern` as
 ```@example ex1
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k
 @species A(t), B(t), C(t)
 rxs = [Reaction(k, [A,B], [C])]
@@ -114,7 +114,7 @@ ability to substitute the value of these variables into the DSL (see
 [Interpolation of Julia Variables](@ref dsl_description_interpolation_of_variables)). To make the repressilator we now make
 three genes, and then compose them together
 ```@example ex1
-import Catalyst: t_nounits as t
+t = default_t()
 @species G3₊P(t)
 @named G1 = repressed_gene(; R=ParentScope(G3₊P))
 @named G2 = repressed_gene(; R=ParentScope(G1.P))

--- a/docs/src/catalyst_functionality/compositional_modeling.md
+++ b/docs/src/catalyst_functionality/compositional_modeling.md
@@ -51,8 +51,8 @@ plot(TreePlot(rn), method=:tree, fontsize=12, nodeshape=:ellipse)
 We could also have directly constructed `rn` using the same reaction as in
 `basern` as
 ```@example ex1
+import Catalyst: t_nounits as t
 @parameters k
-@variables t
 @species A(t), B(t), C(t)
 rxs = [Reaction(k, [A,B], [C])]
 @named rn = ReactionSystem(rxs, t; systems = [newrn, newestrn])
@@ -114,7 +114,7 @@ ability to substitute the value of these variables into the DSL (see
 [Interpolation of Julia Variables](@ref dsl_description_interpolation_of_variables)). To make the repressilator we now make
 three genes, and then compose them together
 ```@example ex1
-@variables t
+import Catalyst: t_nounits as t
 @species G3₊P(t)
 @named G1 = repressed_gene(; R=ParentScope(G3₊P))
 @named G2 = repressed_gene(; R=ParentScope(G1.P))
@@ -130,7 +130,7 @@ plot(TreePlot(repressilator), method=:tree, fontsize=12, nodeshape=:ellipse)
 In building the repressilator we needed to use two new features. First, we
 needed to create a symbolic variable that corresponds to the protein produced by
 the third gene before we created the corresponding system. We did this via
-`@variables t, G3₊P(t)`. We also needed to set the scope where each repressor
+`@variables G3₊P(t)`. We also needed to set the scope where each repressor
 lived. Here `ParentScope(G3₊P)`, `ParentScope(G1.P)`, and `ParentScope(G2.P)`
 signal Catalyst that these variables will come from parallel systems in the tree
 that have the same parent as the system being constructed (in this case the

--- a/docs/src/catalyst_functionality/constraint_equations.md
+++ b/docs/src/catalyst_functionality/constraint_equations.md
@@ -25,11 +25,12 @@ separate `ReactionSystem`s and `ODESystem`s with their respective components,
 and then extend the `ReactionSystem` with the `ODESystem`. Let's begin by
 creating these two systems. 
 
-Here, to create differentials with respect to time (for our differential equations), we must import the time differential operator from Catalyst. We do this through `import Catalyst: D_nounits as D` (calling it `D`). Here, `D(V)` denotes the differential of the variable `V` with respect to time.
+Here, to create differentials with respect to time (for our differential equations), we must import the time differential operator from Catalyst. We do this through `D = default_time_deriv()`. Here, `D(V)` denotes the differential of the variable `V` with respect to time.
 
 ```@example ceq1
 using Catalyst, DifferentialEquations, Plots
-t = default_t(), D_nounits as D
+t = default_t()
+D = default_time_deriv()
 
 # set the growth rate to 1.0
 @parameters λ = 1.0
@@ -72,7 +73,8 @@ As an alternative to the previous approach, we could have constructed our
 `ReactionSystem` all at once by directly using the symbolic interface:
 ```@example ceq2
 using Catalyst, DifferentialEquations, Plots
-t = default_t(), D_nounits as D
+t = default_t()
+D = default_time_deriv()
 
 @parameters λ = 1.0
 @variables V(t) = 1.0
@@ -104,7 +106,8 @@ advanced_simulations) tutorial.
 Let's first create our equations and unknowns/species again
 ```@example ceq3
 using Catalyst, DifferentialEquations, Plots
-t = default_t(), D_nounits as D
+t = default_t()
+D = default_time_deriv()
 
 @parameters λ = 1.0
 @variables V(t) = 1.0

--- a/docs/src/catalyst_functionality/constraint_equations.md
+++ b/docs/src/catalyst_functionality/constraint_equations.md
@@ -23,19 +23,21 @@ There are several ways we can create our Catalyst model with the two reactions
 and ODE for $V(t)$. One approach is to use compositional modeling, create
 separate `ReactionSystem`s and `ODESystem`s with their respective components,
 and then extend the `ReactionSystem` with the `ODESystem`. Let's begin by
-creating these two systems:
+creating these two systems. 
+
+Here, to create differentials with respect to time (for our differential equations), we must import the time differential operator from Catalyst. We do this through `import Catalyst: D_nounits as D` (calling it `D`). Here, `D(V)` denotes the differential of the variable `V` with respect to time.
 
 ```@example ceq1
 using Catalyst, DifferentialEquations, Plots
+import Catalyst: t_nounits as t, D_nounits as D
 
 # set the growth rate to 1.0
 @parameters λ = 1.0
 
 # set the initial volume to 1.0
-@variables t V(t) = 1.0
+@variables V(t) = 1.0
 
 # build the ODESystem for dV/dt
-D = Differential(t)
 eq = [D(V) ~ λ * V]
 @named osys = ODESystem(eq, t)
 
@@ -70,10 +72,10 @@ As an alternative to the previous approach, we could have constructed our
 `ReactionSystem` all at once by directly using the symbolic interface:
 ```@example ceq2
 using Catalyst, DifferentialEquations, Plots
+import Catalyst: t_nounits as t, D_nounits as D
 
 @parameters λ = 1.0
-@variables t V(t) = 1.0
-D = Differential(t)
+@variables V(t) = 1.0
 eq = D(V) ~ λ * V
 rx1 = @reaction $V, 0 --> P
 rx2 = @reaction 1.0, P --> 0
@@ -102,11 +104,11 @@ advanced_simulations) tutorial.
 Let's first create our equations and unknowns/species again
 ```@example ceq3
 using Catalyst, DifferentialEquations, Plots
+import Catalyst: t_nounits as t, D_nounits as D
 
 @parameters λ = 1.0
-@variables t V(t) = 1.0
+@variables V(t) = 1.0
 @species P(t) = 0.0
-D = Differential(t)
 eq = D(V) ~ λ * V
 rx1 = @reaction $V, 0 --> $P
 rx2 = @reaction 1.0, $P --> 0
@@ -126,8 +128,8 @@ plot(sol; plotdensity = 1000)
 ```
 We can also model discrete events. Similar to our example with continuous events, we start by creating reaction equations, parameters, variables, and unknowns. 
 ```@example ceq3
+import Catalyst: t_nounits as t
 @parameters k_on switch_time k_off
-@variables t
 @species A(t) B(t)
 
 rxs = [(@reaction k_on, A --> B), (@reaction k_off, B --> A)]

--- a/docs/src/catalyst_functionality/constraint_equations.md
+++ b/docs/src/catalyst_functionality/constraint_equations.md
@@ -29,7 +29,7 @@ Here, to create differentials with respect to time (for our differential equatio
 
 ```@example ceq1
 using Catalyst, DifferentialEquations, Plots
-import Catalyst: t_nounits as t, D_nounits as D
+t = default_t(), D_nounits as D
 
 # set the growth rate to 1.0
 @parameters λ = 1.0
@@ -72,7 +72,7 @@ As an alternative to the previous approach, we could have constructed our
 `ReactionSystem` all at once by directly using the symbolic interface:
 ```@example ceq2
 using Catalyst, DifferentialEquations, Plots
-import Catalyst: t_nounits as t, D_nounits as D
+t = default_t(), D_nounits as D
 
 @parameters λ = 1.0
 @variables V(t) = 1.0
@@ -104,7 +104,7 @@ advanced_simulations) tutorial.
 Let's first create our equations and unknowns/species again
 ```@example ceq3
 using Catalyst, DifferentialEquations, Plots
-import Catalyst: t_nounits as t, D_nounits as D
+t = default_t(), D_nounits as D
 
 @parameters λ = 1.0
 @variables V(t) = 1.0
@@ -128,7 +128,7 @@ plot(sol; plotdensity = 1000)
 ```
 We can also model discrete events. Similar to our example with continuous events, we start by creating reaction equations, parameters, variables, and unknowns. 
 ```@example ceq3
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k_on switch_time k_off
 @species A(t) B(t)
 

--- a/docs/src/catalyst_functionality/dsl_description.md
+++ b/docs/src/catalyst_functionality/dsl_description.md
@@ -54,7 +54,7 @@ the model. We do this by creating a mapping from each symbolic variable
 representing a chemical species to its initial value
 ```@example tut2
 # define the symbolic variables
-import Catalyst: t_nounits as t
+t = default_t()
 @species X(t) Y(t) Z(t) XY(t) Z1(t) Z2(t)
 
 # create the mapping
@@ -610,7 +610,7 @@ parameters outside of the macro, which can then be used within expressions in
 the DSL (see the [Programmatic Construction of Symbolic Reaction Systems](@ref programmatic_CRN_construction)
 tutorial for details on the lower-level symbolic interface). For example,
 ```@example tut2
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k α
 @species A(t)
 spec = A

--- a/docs/src/catalyst_functionality/dsl_description.md
+++ b/docs/src/catalyst_functionality/dsl_description.md
@@ -54,7 +54,7 @@ the model. We do this by creating a mapping from each symbolic variable
 representing a chemical species to its initial value
 ```@example tut2
 # define the symbolic variables
-@variables t
+import Catalyst: t_nounits as t
 @species X(t) Y(t) Z(t) XY(t) Z1(t) Z2(t)
 
 # create the mapping
@@ -610,8 +610,8 @@ parameters outside of the macro, which can then be used within expressions in
 the DSL (see the [Programmatic Construction of Symbolic Reaction Systems](@ref programmatic_CRN_construction)
 tutorial for details on the lower-level symbolic interface). For example,
 ```@example tut2
+import Catalyst: t_nounits as t
 @parameters k α
-@variables t
 @species A(t)
 spec = A
 par = α

--- a/docs/src/catalyst_functionality/example_networks/hodgkin_huxley_equation.md
+++ b/docs/src/catalyst_functionality/example_networks/hodgkin_huxley_equation.md
@@ -15,7 +15,8 @@ We begin by importing some necessary packages.
 using ModelingToolkit, Catalyst, NonlinearSolve
 using DifferentialEquations, Symbolics
 using Plots
-t = default_t(), D_nounits as D
+t = default_t()
+D = default_time_deriv()
 ```
 
 We'll build a simple Hodgkin-Huxley model for a single neuron, with the voltage,

--- a/docs/src/catalyst_functionality/example_networks/hodgkin_huxley_equation.md
+++ b/docs/src/catalyst_functionality/example_networks/hodgkin_huxley_equation.md
@@ -15,6 +15,7 @@ We begin by importing some necessary packages.
 using ModelingToolkit, Catalyst, NonlinearSolve
 using DifferentialEquations, Symbolics
 using Plots
+import Catalyst: t_nounits as t, D_nounits as D
 ```
 
 We'll build a simple Hodgkin-Huxley model for a single neuron, with the voltage,
@@ -51,7 +52,7 @@ We now declare the symbolic variable, `V(t)`, that will represent the
 transmembrane potential
 
 ```@example hh1
-@variables t V(t)
+@variables V(t)
 nothing # hide
 ```
 
@@ -75,7 +76,6 @@ I = I₀ * sin(2*pi*t/30)^2
 # get the gating variables to use in the equation for dV/dt
 @unpack m,n,h = hhrn
 
-Dₜ = Differential(t)
 eqs = [Dₜ(V) ~ -1/C * (ḡK*n^4*(V-EK) + ḡNa*m^3*h*(V-ENa) + ḡL*(V-EL)) + I/C]
 @named voltageode = ODESystem(eqs, t)
 nothing # hide

--- a/docs/src/catalyst_functionality/example_networks/hodgkin_huxley_equation.md
+++ b/docs/src/catalyst_functionality/example_networks/hodgkin_huxley_equation.md
@@ -15,7 +15,7 @@ We begin by importing some necessary packages.
 using ModelingToolkit, Catalyst, NonlinearSolve
 using DifferentialEquations, Symbolics
 using Plots
-import Catalyst: t_nounits as t, D_nounits as D
+t = default_t(), D_nounits as D
 ```
 
 We'll build a simple Hodgkin-Huxley model for a single neuron, with the voltage,

--- a/docs/src/catalyst_functionality/example_networks/smoluchowski_coagulation_equation.md
+++ b/docs/src/catalyst_functionality/example_networks/smoluchowski_coagulation_equation.md
@@ -52,7 +52,7 @@ end
 We'll store the reaction rates in `pars` as `Pair`s, and set the initial condition that only monomers are present at ``t=0`` in `u₀map`.
 ```julia
 # unknown variables are X, pars stores rate parameters for each rx
-import Catalyst: t_nounits as t
+t = default_t()
 @species k[1:nr] (X(t))[1:N]
 pars = Pair.(collect(k), kv)
 

--- a/docs/src/catalyst_functionality/example_networks/smoluchowski_coagulation_equation.md
+++ b/docs/src/catalyst_functionality/example_networks/smoluchowski_coagulation_equation.md
@@ -52,7 +52,7 @@ end
 We'll store the reaction rates in `pars` as `Pair`s, and set the initial condition that only monomers are present at ``t=0`` in `u₀map`.
 ```julia
 # unknown variables are X, pars stores rate parameters for each rx
-@variables t
+import Catalyst: t_nounits as t
 @species k[1:nr] (X(t))[1:N]
 pars = Pair.(collect(k), kv)
 

--- a/docs/src/catalyst_functionality/network_analysis.md
+++ b/docs/src/catalyst_functionality/network_analysis.md
@@ -52,7 +52,7 @@ the reaction rate equation ODE model for the repressilator is
 ## Matrix-vector reaction rate equation representation
 In general, reaction rate equation (RRE) ODE models for chemical reaction networks can
 be represented as a first-order system of ODEs in a compact matrix-vector notation. Suppose
-we have a reaction network with ``K`` reactions and ``M`` species, labelled by the unknown vector
+we have a reaction network with ``K`` reactions and ``M`` species, labelled by the state vector
 ```math
 \mathbf{x}(t) = \begin{pmatrix} x_1(t) \\ \vdots \\ x_M(t)) \end{pmatrix}.
 ```
@@ -384,7 +384,7 @@ Recall that in the matrix-vector representation for the RRE ODEs, the entries,
 ``N_{m k}``, of the stoichiometry matrix, ``N``, give the net change in species
 ``m`` due to reaction ``k``. If we let ``\mathbf{N}_k`` denote the ``k``th
 column of this matrix, this vector corresponds to the change in the species
-unknown vector, ``\mathbf{x}(t)``, due to reaction ``k``, i.e. when reaction ``k``
+state vector, ``\mathbf{x}(t)``, due to reaction ``k``, i.e. when reaction ``k``
 occurs ``\mathbf{x}(t) \to \mathbf{x}(t) + \mathbf{N}_k``. Moreover, by
 integrating the ODE
 ```math

--- a/docs/src/catalyst_functionality/network_analysis.md
+++ b/docs/src/catalyst_functionality/network_analysis.md
@@ -52,7 +52,7 @@ the reaction rate equation ODE model for the repressilator is
 ## Matrix-vector reaction rate equation representation
 In general, reaction rate equation (RRE) ODE models for chemical reaction networks can
 be represented as a first-order system of ODEs in a compact matrix-vector notation. Suppose
-we have a reaction network with ``K`` reactions and ``M`` species, labelled by the state vector
+we have a reaction network with ``K`` reactions and ``M`` species, labelled by the unknown vector
 ```math
 \mathbf{x}(t) = \begin{pmatrix} x_1(t) \\ \vdots \\ x_M(t)) \end{pmatrix}.
 ```
@@ -384,7 +384,7 @@ Recall that in the matrix-vector representation for the RRE ODEs, the entries,
 ``N_{m k}``, of the stoichiometry matrix, ``N``, give the net change in species
 ``m`` due to reaction ``k``. If we let ``\mathbf{N}_k`` denote the ``k``th
 column of this matrix, this vector corresponds to the change in the species
-state vector, ``\mathbf{x}(t)``, due to reaction ``k``, i.e. when reaction ``k``
+unknown vector, ``\mathbf{x}(t)``, due to reaction ``k``, i.e. when reaction ``k``
 occurs ``\mathbf{x}(t) \to \mathbf{x}(t) + \mathbf{N}_k``. Moreover, by
 integrating the ODE
 ```math

--- a/docs/src/catalyst_functionality/parametric_stoichiometry.md
+++ b/docs/src/catalyst_functionality/parametric_stoichiometry.md
@@ -35,7 +35,7 @@ rx.substrates[1],rx.substoich[1]
 We could have equivalently specified our systems directly via the Catalyst
 API. For example, for `revsys` we would could use
 ```@example s1
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k₊, k₋, m, n
 @species A(t), B(t)
 rxs = [Reaction(k₊, [A], [B], [m], [m*n]),
@@ -177,7 +177,7 @@ calculate and plot the average amount of protein (which is also plotted in the
 MomentClosure.jl
 [tutorial](https://augustinas1.github.io/MomentClosure.jl/dev/tutorials/geometric_reactions+conditional_closures/)).
 ```@example s1
-import Catalyst: t_nounits as t
+t = default_t()
 function getmean(jprob, Nsims, tv)
     Pmean = zeros(length(tv))
     @variables P(t)

--- a/docs/src/catalyst_functionality/parametric_stoichiometry.md
+++ b/docs/src/catalyst_functionality/parametric_stoichiometry.md
@@ -35,8 +35,8 @@ rx.substrates[1],rx.substoich[1]
 We could have equivalently specified our systems directly via the Catalyst
 API. For example, for `revsys` we would could use
 ```@example s1
+import Catalyst: t_nounits as t
 @parameters k₊, k₋, m, n
-@variables t
 @species A(t), B(t)
 rxs = [Reaction(k₊, [A], [B], [m], [m*n]),
        Reaction(k₋, [B], [A])]
@@ -177,9 +177,10 @@ calculate and plot the average amount of protein (which is also plotted in the
 MomentClosure.jl
 [tutorial](https://augustinas1.github.io/MomentClosure.jl/dev/tutorials/geometric_reactions+conditional_closures/)).
 ```@example s1
+import Catalyst: t_nounits as t
 function getmean(jprob, Nsims, tv)
     Pmean = zeros(length(tv))
-    @variables t, P(t)
+    @variables P(t)
     for n in 1:Nsims
         sol = solve(jprob, SSAStepper())
         Pmean .+= sol(tv, idxs=P)

--- a/docs/src/catalyst_functionality/programmatic_CRN_construction.md
+++ b/docs/src/catalyst_functionality/programmatic_CRN_construction.md
@@ -15,12 +15,12 @@ and then define symbolic variables for each parameter and species in the system
 (the latter corresponding to a `variable` or `unknown` in ModelingToolkit
 terminology)
 ```@example ex
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters α K n δ γ β μ
 @species m₁(t) m₂(t) m₃(t) P₁(t) P₂(t) P₃(t)
 nothing    # hide
 ```
-Note: Each species is declared as a function of time. Here, we first import the *time independent variable using `import Catalyst: t_nounits as t`, and then use it to declare out species.
+Note: Each species is declared as a function of time. Here, we first import the *time independent variable using `t = default_t()`, and then use it to declare out species.
 
 !!! note
        For users familiar with ModelingToolkit, chemical species must be declared
@@ -117,7 +117,7 @@ Reaction(rate, nothing, [P₁,...,Pₙ], nothing, [β₁,...,βₙ])
 Finally, we note that the rate constant, `rate` above, does not need to be a
 constant or fixed function, but can be a general symbolic expression:
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters α, β
 @species A(t), B(t)
 rx = Reaction(α + β*t*A, [A], [B])
@@ -133,7 +133,7 @@ reactions using the [`@reaction`](@ref) macro.
 
 For example, the repressilator reactions could also have been constructed like
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @species P₁(t) P₂(t) P₃(t)
 rxs = [(@reaction hillr($P₃,α,K,n), ∅ --> m₁),
        (@reaction hillr($P₁,α,K,n), ∅ --> m₂),
@@ -162,7 +162,7 @@ rx = @reaction hillr(P,α,K,n), A --> B
 ```
 is equivalent to
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters P α K n
 @variables A(t) B(t)
 rx = Reaction(hillr(P,α,K,n), [A], [B])

--- a/docs/src/catalyst_functionality/programmatic_CRN_construction.md
+++ b/docs/src/catalyst_functionality/programmatic_CRN_construction.md
@@ -20,7 +20,7 @@ t = default_t()
 @species m₁(t) m₂(t) m₃(t) P₁(t) P₂(t) P₃(t)
 nothing    # hide
 ```
-Note: Each species is declared as a function of time. Here, we first import the *time independent variable using `t = default_t()`, and then use it to declare out species.
+Note: Each species is declared as a function of time. Here, we first import the *time independent variable*, and stores it in `t`, using `t = default_t()`, and then use it to declare out species.
 
 !!! note
        For users familiar with ModelingToolkit, chemical species must be declared

--- a/docs/src/catalyst_functionality/programmatic_CRN_construction.md
+++ b/docs/src/catalyst_functionality/programmatic_CRN_construction.md
@@ -20,7 +20,7 @@ t = default_t()
 @species m₁(t) m₂(t) m₃(t) P₁(t) P₂(t) P₃(t)
 nothing    # hide
 ```
-Note: Each species is declared as a function of time. Here, we first import the *time independent variable*, and stores it in `t`, using `t = default_t()`, and then use it to declare out species.
+Note: each species is declared as a function of time. Here, we first import the *time independent variable*, and stores it in `t`, using `t = default_t()`, and then use it to declare out species.
 
 !!! note
        For users familiar with ModelingToolkit, chemical species must be declared

--- a/docs/src/catalyst_functionality/programmatic_CRN_construction.md
+++ b/docs/src/catalyst_functionality/programmatic_CRN_construction.md
@@ -15,12 +15,12 @@ and then define symbolic variables for each parameter and species in the system
 (the latter corresponding to a `variable` or `unknown` in ModelingToolkit
 terminology)
 ```@example ex
+import Catalyst: t_nounits as t
 @parameters α K n δ γ β μ
-@variables t
 @species m₁(t) m₂(t) m₃(t) P₁(t) P₂(t) P₃(t)
 nothing    # hide
 ```
-*Note, each species is declared as a function of time!*
+Note: Each species is declared as a function of time. Here, we first import the *time independent variable using `import Catalyst: t_nounits as t`, and then use it to declare out species.
 
 !!! note
        For users familiar with ModelingToolkit, chemical species must be declared
@@ -117,8 +117,8 @@ Reaction(rate, nothing, [P₁,...,Pₙ], nothing, [β₁,...,βₙ])
 Finally, we note that the rate constant, `rate` above, does not need to be a
 constant or fixed function, but can be a general symbolic expression:
 ```julia
+import Catalyst: t_nounits as t
 @parameters α, β
-@variables t
 @species A(t), B(t)
 rx = Reaction(α + β*t*A, [A], [B])
 ```
@@ -133,7 +133,7 @@ reactions using the [`@reaction`](@ref) macro.
 
 For example, the repressilator reactions could also have been constructed like
 ```julia
-@variables t
+import Catalyst: t_nounits as t
 @species P₁(t) P₂(t) P₃(t)
 rxs = [(@reaction hillr($P₃,α,K,n), ∅ --> m₁),
        (@reaction hillr($P₁,α,K,n), ∅ --> m₂),
@@ -162,8 +162,9 @@ rx = @reaction hillr(P,α,K,n), A --> B
 ```
 is equivalent to
 ```julia
+import Catalyst: t_nounits as t
 @parameters P α K n
-@variables t A(t) B(t)
+@variables A(t) B(t)
 rx = Reaction(hillr(P,α,K,n), [A], [B])
 ```
 Here `(P,α,K,n)` are parameters and `(A,B)` are species.

--- a/docs/src/faqs.md
+++ b/docs/src/faqs.md
@@ -80,8 +80,8 @@ end
 ```
 or directly via
 ```@example faq2
+import Catalyst: t_nounits as t
 @parameters k b
-@variables t
 @species A(t) B(t) C(t) D(t)
 rx1 = Reaction(k,[B,C],[B,D], [2.5,1],[3.5, 2.5])
 rx2 = Reaction(2*k, [B], [D], [1], [2.5])
@@ -121,8 +121,8 @@ have the desired default values, and this will automatically be propagated
 through to the equation solvers:
 ```@example faq3
 using Catalyst, Plots, OrdinaryDiffEq
+import Catalyst: t_nounits as t
 @parameters β=1e-4 ν=.01
-@variables t
 @species S(t)=999.0 I(t)=1.0 R(t)=0.0
 rx1 = Reaction(β, [S, I], [I], [1,1], [2])
 rx2 = Reaction(ν, [I], [R])
@@ -137,7 +137,6 @@ condition and pass these to the `ReactionSystem` via the `defaults` keyword
 argument:
 ```@example faq3
 @parameters β ν
-@variables t
 @species S(t) I(t) R(t)
 rx1 = Reaction(β, [S,I], [I], [1,1], [2])
 rx2 = Reaction(ν, [I], [R])
@@ -175,8 +174,8 @@ nothing  # hide
 ```
 while using ModelingToolkit symbolic variables we have
 ```@example faq4
+import Catalyst: t_nounits as t
 @parameters α β
-@variables t
 @species S(t) I(t) R(t)
 u0 = [S => 999.0, I => 1.0, R => 0.0]
 p  = (α => 1e-4, β => .01)
@@ -216,7 +215,8 @@ equation. I.e., to add a force of `(1 + sin(t))` to ``dA/dt`` in a system with
 the reaction `k, A --> 0`, we can do
 ```@example faq5
 using Catalyst
-@variables t f(t)
+import Catalyst: t_nounits as t
+@variables f(t)
 rx1 = @reaction k, A --> 0
 rx2 = @reaction $f, 0 --> A
 eq = f ~ (1 + sin(t))

--- a/docs/src/faqs.md
+++ b/docs/src/faqs.md
@@ -80,7 +80,7 @@ end
 ```
 or directly via
 ```@example faq2
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k b
 @species A(t) B(t) C(t) D(t)
 rx1 = Reaction(k,[B,C],[B,D], [2.5,1],[3.5, 2.5])
@@ -121,7 +121,7 @@ have the desired default values, and this will automatically be propagated
 through to the equation solvers:
 ```@example faq3
 using Catalyst, Plots, OrdinaryDiffEq
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters β=1e-4 ν=.01
 @species S(t)=999.0 I(t)=1.0 R(t)=0.0
 rx1 = Reaction(β, [S, I], [I], [1,1], [2])
@@ -174,7 +174,7 @@ nothing  # hide
 ```
 while using ModelingToolkit symbolic variables we have
 ```@example faq4
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters α β
 @species S(t) I(t) R(t)
 u0 = [S => 999.0, I => 1.0, R => 0.0]
@@ -215,7 +215,7 @@ equation. I.e., to add a force of `(1 + sin(t))` to ``dA/dt`` in a system with
 the reaction `k, A --> 0`, we can do
 ```@example faq5
 using Catalyst
-import Catalyst: t_nounits as t
+t = default_t()
 @variables f(t)
 rx1 = @reaction k, A --> 0
 rx2 = @reaction $f, 0 --> A

--- a/docs/src/introduction_to_catalyst/introduction_to_catalyst.md
+++ b/docs/src/introduction_to_catalyst/introduction_to_catalyst.md
@@ -116,8 +116,8 @@ nothing   # hide
 Alternatively, we can use ModelingToolkit-based symbolic species variables to
 specify these mappings like
 ```@example tut1
+import Catalyst: t_nounits as t
 @parameters  α K n δ γ β μ
-@variables t
 @species m₁(t) m₂(t) m₃(t) P₁(t) P₂(t) P₃(t)
 psymmap  = (α => .5, K => 40, n => 2, δ => log(2)/120,
          γ => 5e-3, β => 20*log(2)/120, μ => log(2)/60)

--- a/docs/src/introduction_to_catalyst/introduction_to_catalyst.md
+++ b/docs/src/introduction_to_catalyst/introduction_to_catalyst.md
@@ -116,7 +116,7 @@ nothing   # hide
 Alternatively, we can use ModelingToolkit-based symbolic species variables to
 specify these mappings like
 ```@example tut1
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters  α K n δ γ β μ
 @species m₁(t) m₂(t) m₃(t) P₁(t) P₂(t) P₃(t)
 psymmap  = (α => .5, K => 40, n => 2, δ => log(2)/120,

--- a/docs/unpublished/pdes.md
+++ b/docs/unpublished/pdes.md
@@ -42,7 +42,8 @@ end
 
 We now define the reaction model
 ```julia
-@variables t x y
+import Catalyst: t_nounits as t
+@variables x y
 @species U(x,y,t) V(x,y,t) W(x,y,t)
 rxs = [Reaction(k[1], [U, W], [V, W]),
        Reaction(k[2], [V], [W], [2], [1]),

--- a/docs/unpublished/pdes.md
+++ b/docs/unpublished/pdes.md
@@ -42,7 +42,7 @@ end
 
 We now define the reaction model
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @variables x y
 @species U(x,y,t) V(x,y,t) W(x,y,t)
 rxs = [Reaction(k[1], [U, W], [V, W]),

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -43,12 +43,15 @@ import DataStructures: OrderedDict, OrderedSet
 import Parameters: @with_kw_noshow
 
 # globals for the modulate
+function default_time_deriv()
+    return ModelingToolkit.D_nounits
+end
 function default_t()
     return ModelingToolkit.t_nounits
 end
 const DEFAULT_t = default_t()
 const DEFAULT_IV_SYM = Symbol(DEFAULT_t)
-export default_t
+export default_t, default_time_deriv
 
 # as used in Catlab
 const USE_GV_JLL = Ref(false)

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -43,11 +43,11 @@ import DataStructures: OrderedDict, OrderedSet
 import Parameters: @with_kw_noshow
 
 # globals for the modulate
-const DEFAULT_t = ModelingToolkit.t_nounits
-const DEFAULT_IV_SYM = Symbol(ModelingToolkit.t_nounits)
 function default_t()
-    return DEFAULT_t
+    return ModelingToolkit.t_nounits
 end
+const DEFAULT_t = default_t()
+const DEFAULT_IV_SYM = Symbol(DEFAULT_t)
 export default_t
 
 # as used in Catlab

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -34,7 +34,7 @@ import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_v
 import ModelingToolkit: check_variables,
                         check_parameters, _iszero, _merge, check_units,
                         get_unit, check_equations
-import ModelingToolkit: t_nounits, D_nounits
+import ModelingToolkit: D_nounits
 
 import Base: (==), hash, size, getindex, setindex, isless, Sort.defalg, length, show
 import MacroTools, Graphs
@@ -43,8 +43,10 @@ import DataStructures: OrderedDict, OrderedSet
 import Parameters: @with_kw_noshow
 
 # globals for the modulate
-const DEFAULT_IV_SYM = :t
-const DEFAULT_IV = (@variables $(DEFAULT_IV_SYM))[1]
+const DEFAULT_t = ModelingToolkit.t_nounits
+function default_t()
+    return DEFAULT_t
+end
 
 # as used in Catlab
 const USE_GV_JLL = Ref(false)

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -47,6 +47,7 @@ const DEFAULT_t = ModelingToolkit.t_nounits
 function default_t()
     return DEFAULT_t
 end
+export default_t
 
 # as used in Catlab
 const USE_GV_JLL = Ref(false)

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -34,7 +34,6 @@ import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_v
 import ModelingToolkit: check_variables,
                         check_parameters, _iszero, _merge, check_units,
                         get_unit, check_equations
-import ModelingToolkit: D_nounits
 
 import Base: (==), hash, size, getindex, setindex, isless, Sort.defalg, length, show
 import MacroTools, Graphs

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -44,6 +44,7 @@ import Parameters: @with_kw_noshow
 
 # globals for the modulate
 const DEFAULT_t = ModelingToolkit.t_nounits
+const DEFAULT_IV_SYM = Symbol(ModelingToolkit.t_nounits)
 function default_t()
     return DEFAULT_t
 end

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -34,6 +34,7 @@ import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_v
 import ModelingToolkit: check_variables,
                         check_parameters, _iszero, _merge, check_units,
                         get_unit, check_equations
+import ModelingToolkit: t_nounits, D_nounits
 
 import Base: (==), hash, size, getindex, setindex, isless, Sort.defalg, length, show
 import MacroTools, Graphs

--- a/src/chemistry_functionality.jl
+++ b/src/chemistry_functionality.jl
@@ -16,7 +16,7 @@ Macro that creates a compound species, which is composed of smaller component sp
 
 Example:
 ```julia
-@variables t
+import Catalyst: t_nounits as t
 @species C(t) O(t)
 @compound CO2(t) ~ C + 2O
 ```
@@ -101,7 +101,7 @@ Macro that creates several compound species, which each is composed of smaller c
 
 Example:
 ```julia
-@variables t
+import Catalyst: t_nounits as t
 @species C(t) H(t) O(t) 
 @compounds
     CH4(t) = C + 4H
@@ -282,7 +282,7 @@ Returns a vector of all possible stoichiometrically balanced `Reaction` objects 
 
 Example:
 ```julia
-@variables t
+import Catalyst: t_nounits as t
 @species Si(t) Cl(t) H(t) O(t)
 @compound SiCl4 ~ Si + 4Cl
 @compound H2O ~ 2H + O
@@ -293,7 +293,7 @@ balance_reaction(rx) # Exactly one solution.
 ```
 
 ```julia
-@variables t
+import Catalyst: t_nounits as t
 @species C(t) H(t) O(t)
 @compound CO ~ C + O
 @compound CO2 ~ C + 2O
@@ -305,7 +305,7 @@ balance_reaction(rx) # Multiple solutions.
 ```
 
 ```julia
-@variables t
+import Catalyst: t_nounits as t
 @species Fe(t) S(t) O(t) H(t) N(t)
 @compound FeS2 ~ Fe + 2S
 @compound HNO3 ~ H + N + 3O

--- a/src/chemistry_functionality.jl
+++ b/src/chemistry_functionality.jl
@@ -16,7 +16,7 @@ Macro that creates a compound species, which is composed of smaller component sp
 
 Example:
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @species C(t) O(t)
 @compound CO2(t) ~ C + 2O
 ```
@@ -101,7 +101,7 @@ Macro that creates several compound species, which each is composed of smaller c
 
 Example:
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @species C(t) H(t) O(t) 
 @compounds
     CH4(t) = C + 4H
@@ -282,7 +282,7 @@ Returns a vector of all possible stoichiometrically balanced `Reaction` objects 
 
 Example:
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @species Si(t) Cl(t) H(t) O(t)
 @compound SiCl4 ~ Si + 4Cl
 @compound H2O ~ 2H + O
@@ -293,7 +293,7 @@ balance_reaction(rx) # Exactly one solution.
 ```
 
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @species C(t) H(t) O(t)
 @compound CO ~ C + O
 @compound CO2 ~ C + 2O
@@ -305,7 +305,7 @@ balance_reaction(rx) # Multiple solutions.
 ```
 
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @species Fe(t) S(t) O(t) H(t) N(t)
 @compound FeS2 ~ Fe + 2S
 @compound HNO3 ~ H + N + 3O

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -193,8 +193,9 @@ Notes:
 - If the rate expression depends on a non-species unknown variable that will be included in
   the dependents, i.e. in
   ```julia
+  import Catalyst: t_nounits as t
   @parameters k
-  @variables t V(t)
+  @variables V(t)
   @species A(t) B(t) C(t)
   rx = Reaction(k*V, [A, B], [C])
   @named rs = ReactionSystem([rx], t)
@@ -437,8 +438,8 @@ end
 setdefaults!(sir, [:S => 999.0, :I => 1.0, :R => 1.0, :β => 1e-4, :ν => .01])
 
 # or
+import Catalyst: t_nounits as t
 @parameter β ν
-@variables t
 @species S(t) I(t) R(t)
 setdefaults!(sir, [S => 999.0, I => 1.0, R => 0.0, β => 1e-4, ν => .01])
 ```

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -193,7 +193,7 @@ Notes:
 - If the rate expression depends on a non-species unknown variable that will be included in
   the dependents, i.e. in
   ```julia
-  import Catalyst: t_nounits as t
+  t = default_t()
   @parameters k
   @variables V(t)
   @species A(t) B(t) C(t)
@@ -438,7 +438,7 @@ end
 setdefaults!(sir, [:S => 999.0, :I => 1.0, :R => 1.0, :β => 1e-4, :ν => .01])
 
 # or
-import Catalyst: t_nounits as t
+t = default_t()
 @parameter β ν
 @species S(t) I(t) R(t)
 setdefaults!(sir, [S => 999.0, I => 1.0, R => 0.0, β => 1e-4, ν => .01])

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -1403,7 +1403,7 @@ Notes:
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined unknown.
+  variable, as this will potentially leave the system in an undefined state.
 """
 function addspecies!(network::ReactionSystem, s::Symbolic; disablechecks = false)
     reset_networkproperties!(network)
@@ -1435,7 +1435,7 @@ integer id of the species within the system.
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined unknown.
+  variable, as this will potentially leave the system in an undefined state.
 """
 function addspecies!(network::ReactionSystem, s::Num; disablechecks = false)
     addspecies!(network, value(s), disablechecks = disablechecks)
@@ -1451,7 +1451,7 @@ id of the parameter within the system.
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined unknown.
+  variable, as this will potentially leave the system in an undefined state.
 """
 function addparam!(network::ReactionSystem, p::Symbolic; disablechecks = false)
     reset_networkproperties!(network)
@@ -1480,7 +1480,7 @@ integer id of the parameter within the system.
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined unknown.
+  variable, as this will potentially leave the system in an undefined state.
 """
 function addparam!(network::ReactionSystem, p::Num; disablechecks = false)
     addparam!(network, value(p); disablechecks = disablechecks)

--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -1402,7 +1402,7 @@ Notes:
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined state.
+  variable, as this will potentially leave the system in an undefined unknown.
 """
 function addspecies!(network::ReactionSystem, s::Symbolic; disablechecks = false)
     reset_networkproperties!(network)
@@ -1434,7 +1434,7 @@ integer id of the species within the system.
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined state.
+  variable, as this will potentially leave the system in an undefined unknown.
 """
 function addspecies!(network::ReactionSystem, s::Num; disablechecks = false)
     addspecies!(network, value(s), disablechecks = disablechecks)
@@ -1450,7 +1450,7 @@ id of the parameter within the system.
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined state.
+  variable, as this will potentially leave the system in an undefined unknown.
 """
 function addparam!(network::ReactionSystem, p::Symbolic; disablechecks = false)
     reset_networkproperties!(network)
@@ -1479,7 +1479,7 @@ integer id of the parameter within the system.
 - `disablechecks` will disable checking for whether the passed in variable is
   already defined, which is useful when adding many new variables to the system.
   *Do not disable checks* unless you are sure the passed in variable is a new
-  variable, as this will potentially leave the system in an undefined state.
+  variable, as this will potentially leave the system in an undefined unknown.
 """
 function addparam!(network::ReactionSystem, p::Num; disablechecks = false)
     addparam!(network, value(p); disablechecks = disablechecks)

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -227,16 +227,16 @@ Examples:
 rx = @reaction k*v, A + B --> C + D
 
 # is equivalent to
+import Catalyst: t_nounits as t
 @parameters k v
-@variables t
 @species A(t) B(t) C(t) D(t)
 rx == Reaction(k*v, [A,B], [C,D])
 ```
 Here `k` and `v` will be parameters and `A`, `B`, `C` and `D` will be variables.
 Interpolation of existing parameters/variables also works
 ```julia
+import Catalyst: t_nounits as t
 @parameters k b
-@variables t
 @species A(t)
 ex = k*A^2 + t
 rx = @reaction b*$ex*$A, $A --> C

--- a/src/reaction_network.jl
+++ b/src/reaction_network.jl
@@ -227,7 +227,7 @@ Examples:
 rx = @reaction k*v, A + B --> C + D
 
 # is equivalent to
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k v
 @species A(t) B(t) C(t) D(t)
 rx == Reaction(k*v, [A,B], [C,D])
@@ -235,7 +235,7 @@ rx == Reaction(k*v, [A,B], [C,D])
 Here `k` and `v` will be parameters and `A`, `B`, `C` and `D` will be variables.
 Interpolation of existing parameters/variables also works
 ```julia
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k b
 @species A(t)
 ex = k*A^2 + t

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -66,8 +66,8 @@ $(FIELDS)
 
 ```julia
 using Catalyst
+import Catalyst: t_nounits as t
 @parameters k[1:20]
-@variables t
 @species A(t) B(t) C(t) D(t)
 rxs = [Reaction(k[1], nothing, [A]),            # 0 -> A
        Reaction(k[2], [B], nothing),            # B -> 0

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -66,7 +66,7 @@ $(FIELDS)
 
 ```julia
 using Catalyst
-import Catalyst: t_nounits as t
+t = default_t()
 @parameters k[1:20]
 @species A(t) B(t) C(t) D(t)
 rxs = [Reaction(k[1], nothing, [A]),            # 0 -> A

--- a/test/dsl/custom_functions.jl
+++ b/test/dsl/custom_functions.jl
@@ -2,6 +2,7 @@
 ### Fetch Packages and Set Global Variables ###
 using DiffEqBase, Catalyst, Random, Symbolics, Test
 using ModelingToolkit: get_unknowns, get_ps
+import Catalyst: t_nounits as t
 
 using StableRNGs
 rng = StableRNG(12345)
@@ -209,7 +210,6 @@ end
 
 # Tests `ReactionSystem`s.
 let
-    @variables t 
     @species x(t) y(t)
     @parameters k v n 
     rs1 = @reaction_network rs begin
@@ -232,7 +232,6 @@ end
 
 # Tests `Reaction`s.
 let
-    @variables t 
     @species x(t) y(t)
     @parameters k v n 
     

--- a/test/dsl/custom_functions.jl
+++ b/test/dsl/custom_functions.jl
@@ -2,7 +2,7 @@
 ### Fetch Packages and Set Global Variables ###
 using DiffEqBase, Catalyst, Random, Symbolics, Test
 using ModelingToolkit: get_unknowns, get_ps
-import Catalyst: t_nounits as t
+t = default_t()
 
 using StableRNGs
 rng = StableRNG(12345)

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -299,7 +299,7 @@ let
         k, A + 2*B --> 2*B
     end
     @unpack A,B = rn2
-    D = Catalyst.D_nounits
+    D = default_time_deriv()
     eq = D(B) ~ -B
     @named osys = ODESystem([eq], t)
     @named rn2 = extend(osys, rn2)

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -3,7 +3,7 @@
 ### Fetch Packages and Set Global Variables ###
 
 using Catalyst, ModelingToolkit
-import Catalyst: t_nounits as t
+t = default_t()
 
 ### Naming Tests ###
 

--- a/test/dsl/dsl_basics.jl
+++ b/test/dsl/dsl_basics.jl
@@ -3,7 +3,7 @@
 ### Fetch Packages and Set Global Variables ###
 
 using Catalyst, ModelingToolkit
-@variables t
+import Catalyst: t_nounits as t
 
 ### Naming Tests ###
 
@@ -281,7 +281,6 @@ let
         π*k*D*hill(B,k2,B*D*H,n), 3*A  --> 2*C
     end
     @parameters k k2 n
-    @variables t
     @species A(t) B(t) C(t) D(t) H(t)
     @test issetequal([A,B,C,D,H], species(rn))
     @test issetequal([k,k2,n], parameters(rn))
@@ -299,9 +298,8 @@ let
         @species A(t) = 1 B(t) = 2 [isbcspecies = true]
         k, A + 2*B --> 2*B
     end
-    @variables t
     @unpack A,B = rn2
-    D = Differential(t)
+    D = Catalyst.D_nounits
     eq = D(B) ~ -B
     @named osys = ODESystem([eq], t)
     @named rn2 = extend(osys, rn2)
@@ -324,7 +322,7 @@ let
     end
 
     @parameters k1 k2
-    @variables t V1(t) V2(t) V3(t)
+    @variables V1(t) V2(t) V3(t)
     @species A(t) B1(t) B2(t) C(t)
     rx = Reaction(k1*k2 + V3, [A, B1], [C, B2], [V1, 2], [V2, 1])
     @named tester = ReactionSystem([rx], t)
@@ -374,7 +372,7 @@ let
     end
 
     @parameters k[1:3] a B
-    @variables t (V(t))[1:2] W(t)
+    @variables (V(t))[1:2] W(t)
     @species (X(t))[1:2] Y(t) C(t)
     rx = Reaction(k[1]*a+k[2], [X[1], X[2]], [Y, C], [1, V[1]], [V[2] * W, B])
     @named arrtest = ReactionSystem([rx], t)

--- a/test/dsl/dsl_model_construction.jl
+++ b/test/dsl/dsl_model_construction.jl
@@ -4,6 +4,7 @@
 using DiffEqBase, Catalyst, Random, Test
 using ModelingToolkit: operation, istree, get_unknowns, get_ps, get_eqs, get_systems,
                        get_iv, nameof
+import Catalyst: t_nounits as t
 
 # Sets rnd number.
 using StableRNGs
@@ -370,7 +371,6 @@ let
         k1, S + I --> 2I
         k2, I --> R
     end
-    @variables t
     @species I(t)
     @test any(isequal(I), species(rn))
     @test any(isequal(I), unknowns(rn))

--- a/test/dsl/dsl_model_construction.jl
+++ b/test/dsl/dsl_model_construction.jl
@@ -4,7 +4,7 @@
 using DiffEqBase, Catalyst, Random, Test
 using ModelingToolkit: operation, istree, get_unknowns, get_ps, get_eqs, get_systems,
                        get_iv, nameof
-import Catalyst: t_nounits as t
+t = default_t()
 
 # Sets rnd number.
 using StableRNGs

--- a/test/dsl/dsl_options.jl
+++ b/test/dsl/dsl_options.jl
@@ -2,7 +2,7 @@
 
 ### Fetch Packages and Set Global Variables ###
 using Catalyst, ModelingToolkit, OrdinaryDiffEq, Plots
-@variables t
+import Catalyst: t_nounits as t
 
 ### Run Tests ###
 
@@ -400,7 +400,7 @@ let
         d, (x,y,x2y) --> 0
     end
 
-    @variables t X(t) Y(t)
+    @variables X(t) Y(t)
     @species x(t), y(t), x2y(t)
     @parameters k kB kD d
     r1 = Reaction(k, nothing, [x], nothing, [1])
@@ -525,7 +525,6 @@ let
 
     # Interpolation into rhs.
     @parameters n [description="A parameter"]
-    @variables t
     @species S(t)
     rn2 = @reaction_network begin
         @observables Stot ~ $S + $n*Sn
@@ -624,7 +623,7 @@ let
     end
 
     # Interpolation and explicit declaration of an observable.
-    @variables t X(t)
+    @variables X(t)
     @test_throws Exception @eval @reaction_network begin
         @variables X(t)
         @observables $X ~ X1 + X2

--- a/test/dsl/dsl_options.jl
+++ b/test/dsl/dsl_options.jl
@@ -2,7 +2,7 @@
 
 ### Fetch Packages and Set Global Variables ###
 using Catalyst, ModelingToolkit, OrdinaryDiffEq, Plots
-import Catalyst: t_nounits as t
+t = default_t()
 
 ### Run Tests ###
 

--- a/test/miscellaneous_tests/api.jl
+++ b/test/miscellaneous_tests/api.jl
@@ -6,6 +6,7 @@ using StochasticDiffEq
 using LinearAlgebra: norm
 using SparseArrays
 using ModelingToolkit: value
+import Catalyst: t_nounits as t
 
 include("../test_networks.jl")
 
@@ -13,7 +14,6 @@ include("../test_networks.jl")
 
 let
     @parameters k1 k2
-    @variables t
     @species S(t) I(t) R(t)
     rxs = [Reaction(k1, [S, I], [I], [1, 1], [2]),
         Reaction(k2, [I], [R])]
@@ -465,7 +465,6 @@ let
         β, I --> R
     end
     @parameters α β
-    @variables t
     @species S(t) I(t) R(t)
     setdefaults!(rn, [S => 999.0, I => 1.0, R => 0.0, α => 1e-4, β => 0.01])
     op = ODEProblem(rn, [], tspan, [])

--- a/test/miscellaneous_tests/api.jl
+++ b/test/miscellaneous_tests/api.jl
@@ -6,7 +6,7 @@ using StochasticDiffEq
 using LinearAlgebra: norm
 using SparseArrays
 using ModelingToolkit: value
-import Catalyst: t_nounits as t
+t = default_t()
 
 include("../test_networks.jl")
 

--- a/test/miscellaneous_tests/compound_macro.jl
+++ b/test/miscellaneous_tests/compound_macro.jl
@@ -1,5 +1,5 @@
 using Catalyst, Test
-import Catalyst: t_nounits as t
+t = default_t()
 
 ### Tests Main Macro Creation Forms ### 
 let

--- a/test/miscellaneous_tests/compound_macro.jl
+++ b/test/miscellaneous_tests/compound_macro.jl
@@ -1,8 +1,8 @@
 using Catalyst, Test
+import Catalyst: t_nounits as t
 
 ### Tests Main Macro Creation Forms ### 
 let
-    @variables t
     @species C(t) H(t) O(t) 
     @parameters p1 p2
 
@@ -62,7 +62,7 @@ end
 
 ### Test Various Independent Variables ###
 let
-    @variables t x y z
+    @variables x y z
     @species C(t) H(x) N(x) O(t) P(t,x) S(x,y)
 
     # Checks that wrong (or absent) independent variable produces errors.
@@ -91,7 +91,6 @@ end
 
 # Test base functionality in two cases.
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound C6H12O2 ~ 6C + 12H + 2O
 
@@ -108,7 +107,6 @@ let
 end
 
 let
-    @variables t
     @species O(t)
     @compound O2 ~ 2O
 
@@ -124,18 +122,15 @@ end
 
 # Checks that compounds cannot be created from non-existing species.
 let
-    @variables t
     @species C(t) H(t)
     @test_throws Exception @compound C6H12O2 ~ 6C + 12H + 2O    
 end
 let
-    @variables t
     @test_throws Exception @compound O2 ~ 2O    
 end
 
 # Checks that nested components works as expected.
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound OH ~ 1O + 1H
     @compound C3H5OH3 ~ 3C + 5H + 3OH
@@ -157,7 +152,6 @@ end
 
 # Checks that interpolation works.
 let
-    @variables t
     @species C(t) H(t) O(t)
     s = C
     @compound C6H12O2_1 ~ 6s + 12H + 2O
@@ -172,7 +166,6 @@ let
 end
 
 let
-    @variables t
     @species C(t) H(t)
     @compound Cyclopentadiene ~ 5C + 6H
     C5H6 = Cyclopentadiene
@@ -187,7 +180,6 @@ let
 end
 
 let
-    @variables t
     @species H(t)
 
     alpha = 2
@@ -211,7 +203,6 @@ let
 end
 
 let
-    @variables t
     @parameters alpha = 2
     @species H(t)
 
@@ -226,7 +217,6 @@ let
 end
 
 let 
-    @variables t
     @species A(t)
     B = A
     @compound A2 ~ 2A
@@ -244,7 +234,6 @@ end
 
 # Basic syntax.
 let 
-    @variables t
     @species C(t) H(t) O(t)
     @compound OH ~ 1O + 1H
     @compound C3H5OH3 ~ 3C + 5H + 3OH
@@ -267,7 +256,6 @@ end
 
 # Interpolation
 let 
-    @variables t
     @species s1(t) s2(t) s3(t)
     s2_alt = s2
     s3_alt = s3

--- a/test/miscellaneous_tests/events.jl
+++ b/test/miscellaneous_tests/events.jl
@@ -1,5 +1,5 @@
 using Test, Catalyst, ModelingToolkit, OrdinaryDiffEq
-import Catalyst: t_nounits as t, D_nounits as D
+t = default_t(), D_nounits as D
 
 # Test discrete event is propagated to ODE solver correctly.
 let

--- a/test/miscellaneous_tests/events.jl
+++ b/test/miscellaneous_tests/events.jl
@@ -1,5 +1,6 @@
 using Test, Catalyst, ModelingToolkit, OrdinaryDiffEq
-t = default_t(), D_nounits as D
+t = default_t()
+D = default_time_deriv()
 
 # Test discrete event is propagated to ODE solver correctly.
 let

--- a/test/miscellaneous_tests/events.jl
+++ b/test/miscellaneous_tests/events.jl
@@ -1,9 +1,9 @@
 using Test, Catalyst, ModelingToolkit, OrdinaryDiffEq
+import Catalyst: t_nounits as t, D_nounits as D
 
 # Test discrete event is propagated to ODE solver correctly.
 let
-    @variables t V(t)=1.0
-    D = Differential(t)
+    @variables V(t)=1.0
     eqs = [D(V) ~ V]
     discrete_events = [1.0 => [V ~ 1.0]]
     rxs = [(@reaction $V, 0 --> A), (@reaction 1.0, A --> 0)]
@@ -21,7 +21,6 @@ end
 # Test continuous event is propagated to the ODE solver.
 let
     @parameters α=5.0 β=1.0
-    @variables t
     @species V(t) = 0.0
     rxs = [Reaction(α, nothing, [V]), Reaction(β, [V], nothing)]
     continuous_events = [V ~ 2.5] => [α ~ 0, β ~ 0]

--- a/test/miscellaneous_tests/reaction_balancing.jl
+++ b/test/miscellaneous_tests/reaction_balancing.jl
@@ -1,8 +1,8 @@
 using Catalyst, Test
+import Catalyst: t_nounits as t
 
 #Check that balancing works.
 let
-    @variables t
     @parameters k
     @species H(t) O(t)
     @compounds begin
@@ -27,7 +27,6 @@ let
 end
 
 let
-    @variables t
     @parameters k
     @species C(t) H(t) O(t)
     @compound O2 ~ 2O
@@ -52,7 +51,6 @@ end
 
 # @reaction k, H2O --> H2O
 let
-    @variables t
     @species H(t) O(t)
     @compound H2O ~ 2H + O
 
@@ -66,7 +64,6 @@ end
 
 # @reaction k, 2H + 1O --> H2O
 let
-    @variables t
     @species H(t) O(t)
     @compound H2O ~ 2H + O
 
@@ -80,7 +77,6 @@ end
 
 # @reaction k, 1CH4 + 2O2 --> 1CO2 + 2H2O
 let
-    @variables t
     @species H(t) O(t) C(t)
     @compounds begin
         CH4 ~ C + 4H
@@ -99,7 +95,6 @@ end
 
 # @reaction k, N2 + 3H2 --> 2NH3
 let
-    @variables t
     @species H(t) N(t)
     @compound N2 ~ 2N
     @compound H2 ~ 2H
@@ -115,7 +110,6 @@ end
 
 # @reaction k, C2H5OH + CH3COOH --> C4H8O2 + H2O
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound C2H5OH ~ 2C + 6H + O
     @compound CH3COOH ~ 2C + 4H + 2O
@@ -132,7 +126,6 @@ end
 
 # @reaction k, 2Ca3PO42 --> 6CaO + 1P4O10
 let
-    @variables t
     @species Ca(t) P(t) O(t)
     @compound Ca3PO42 ~ 3Ca + 2P + 8O
     @compound CaO ~ Ca + O
@@ -148,7 +141,6 @@ end
 
 # @reaction k, 4Fe + 3O2 + 6H2O --> 4FeOH3
 let
-    @variables t
     @species Fe(t) O(t) H(t)
     @compound O2 ~ 2O
     @compound H2O ~ 2H + O
@@ -164,7 +156,6 @@ end
 
 # @reaction k, 2NaOH + H2SO4 --> Na2SO4 + 2H2O
 let
-    @variables t
     @species Na(t) O(t) H(t) S(t)
     @compound SO4 ~ S + 4O
     @compound NaOH ~ Na + O + H
@@ -182,7 +173,6 @@ end
 
 # @reaction k, 2NO2 --> 1N2O4
 let
-    @variables t
     @species N(t) O(t)
     @compound NO2 ~ N + 2O
     @compound N2O4 ~ 2N + 4O
@@ -197,7 +187,6 @@ end
 
 # @reaction k, 1CaCO3 + 2HCl --> CaCl2  + H2O + CO2
 let
-    @variables t
     @species C(t) H(t) O(t) Ca(t) Cl(t)
     @compound H2O ~ 2H + 1O
     @compound CO2 ~ 1C + 2O
@@ -214,7 +203,6 @@ end
 
 # @reaction k, SiCl4 + 4H2O → H4SiO4 + 4HCl
 let
-    @variables t
     @species Si(t) Cl(t) H(t) O(t)
     @compound SiCl4 ~ 1Si + 4Cl
     @compound H2O ~ 2H + O
@@ -230,7 +218,6 @@ end
 
 # @reaction k, 2Al + 6HCl → 2AlCl3 + 3H2
 let
-    @variables t
     @species Al(t) Cl(t) H(t)
     @compound HCl ~ H + Cl
     @compound AlCl3 ~ Al + 3Cl
@@ -245,7 +232,6 @@ end
 
 # @reaction k, Na2CO3 + 2HCl → 2NaCl + H2O + CO2
 let
-    @variables t
     @species Na(t) C(t) O(t) H(t) Cl(t)
     @compound Na2CO3 ~ 2Na + C + 3O
     @compound HCl ~ H + Cl
@@ -262,7 +248,6 @@ end
 
 # @reaction k, 2C7H6O2 + 15O2 → 14CO2 + 6H2O
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound C7H6O2 ~ 7C + 6H + 2O
     @compound O2 ~ 2O
@@ -278,7 +263,6 @@ end
 
 # @reaction k,Fe2(SO4)3 + 6KOH → 3K2SO4 + 2Fe(OH)3
 let
-    @variables t
     @species Fe(t) S(t) O(t) H(t) K(t)
     @compound Fe2S3O12 ~ 2Fe + 3S + 12O
     @compound KOH ~ K + O + H
@@ -294,7 +278,6 @@ end
 
 # @reaction k, 2Ca3(PO4)2 + 6SiO2 → P4O10 + 6CaSiO3
 let
-    @variables t
     @species Ca(t) P(t) O(t) Si(t)
     @compound Ca3P2O8 ~ 3Ca + 2P + 8O
     @compound SiO2 ~ Si + 2O
@@ -310,7 +293,6 @@ end
 
 # @reaction k, 4KClO3 → 3KClO4 + KCl
 let
-    @variables t
     @species K(t) Cl(t) O(t)
     @compound KClO3 ~ K + Cl + 3O
     @compound KClO4 ~ K + Cl + 4O
@@ -325,7 +307,6 @@ end
 
 # @reaction k, Al2(SO4)3 + 3Ca(OH)2 → 2Al(OH)3 + 3CaSO4
 let
-    @variables t
     @species Al(t) S(t) O(t) Ca(t) O(t) H(t)
     @compound Al2S3O12 ~ 2Al + 3S + 12O
     @compound CaO2H2 ~ Ca + 2O + 2H
@@ -341,7 +322,6 @@ end
 
 # @reaction k, H2SO4 + 8HI → H2S + 4I2 + 4H2O
 let
-    @variables t
     @species H(t) S(t) O(t) I(t)
     @compound H2SO4 ~ 2H + S + 4O
     @compound HI ~ H + I
@@ -358,7 +338,6 @@ end
 
 # @reaction k, C2H4 + 3O2 ↔ 2CO2 + 2H2O
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound C2H4 ~ 2C + 4H
     @compound O2 ~ 2O
@@ -374,7 +353,6 @@ end
 
 # Infinite solutions
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound CO ~ C + O
     @compound CO2 ~ C + 2O
@@ -390,7 +368,6 @@ end
 
 # No way to balance
 let
-    @variables t
     @species Fe(t) S(t) O(t) H(t) N(t)
 
     @compound FeS2 ~ Fe + 2S
@@ -407,7 +384,6 @@ end
 
 # test errors on compounds of compounds
 let
-    @variables t
     @species C(t) H(t) O(t)
     @compound CO ~ C + O
     @compound H2 ~ 2H

--- a/test/miscellaneous_tests/reaction_balancing.jl
+++ b/test/miscellaneous_tests/reaction_balancing.jl
@@ -1,5 +1,5 @@
 using Catalyst, Test
-import Catalyst: t_nounits as t
+t = default_t()
 
 #Check that balancing works.
 let

--- a/test/miscellaneous_tests/symbolic_stoichiometry.jl
+++ b/test/miscellaneous_tests/symbolic_stoichiometry.jl
@@ -1,5 +1,5 @@
 using Catalyst, OrdinaryDiffEq, Test, LinearAlgebra, JumpProcesses
-import Catalyst: t_nounits as t
+t = default_t()
 
 ### Base Tests ###
 

--- a/test/miscellaneous_tests/symbolic_stoichiometry.jl
+++ b/test/miscellaneous_tests/symbolic_stoichiometry.jl
@@ -1,10 +1,10 @@
 using Catalyst, OrdinaryDiffEq, Test, LinearAlgebra, JumpProcesses
+import Catalyst: t_nounits as t
 
 ### Base Tests ###
 
 let
     @parameters k α
-    @variables t
     @species A(t), B(t), C(t), D(t)
     rxs = [Reaction(t * k, [A], [B], [2 * α^2], [k + α * C])
            Reaction(1.0, [A, B], [C, D], [α, 2], [k, α])]
@@ -190,7 +190,6 @@ end
 
 let
     @parameters α β γ k
-    @variables t
     @species S(t), I(t), R(t)
     rxs = [Reaction(α, [S, I], [I], [1, 1], [2]),
         Reaction(β, [I], [R], [1], [1])]

--- a/test/model_simulation/u0_n_parameter_inputs.jl
+++ b/test/model_simulation/u0_n_parameter_inputs.jl
@@ -5,6 +5,7 @@
 # Fetch packages.
 using Catalyst, OrdinaryDiffEq, Random, Test
 using ModelingToolkit: get_unknowns, get_ps
+import Catalyst: t_nounits as t
 
 # Sets rnd number.
 using StableRNGs
@@ -20,7 +21,6 @@ let
     test_network = reaction_networks_standard[7]
     test_osys = convert(ODESystem, test_network)
     @parameters p1 p2 p3 k1 k2 k3 v1 K1 d1 d2 d3 d4 d5
-    @variables t
     @species X1(t) X2(t) X3(t) X4(t) X5(t) X6(t) X(t)
 
     for factor = [1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3]

--- a/test/model_simulation/u0_n_parameter_inputs.jl
+++ b/test/model_simulation/u0_n_parameter_inputs.jl
@@ -5,7 +5,7 @@
 # Fetch packages.
 using Catalyst, OrdinaryDiffEq, Random, Test
 using ModelingToolkit: get_unknowns, get_ps
-import Catalyst: t_nounits as t
+t = default_t()
 
 # Sets rnd number.
 using StableRNGs

--- a/test/programmatic_model_creation/component_based_model_creation.jl
+++ b/test/programmatic_model_creation/component_based_model_creation.jl
@@ -340,7 +340,7 @@ let
     @parameters a, b
     @unpack A = rn
     @variables C(t)
-    D = Catalyst.D_nounits
+    D = default_time_deriv()
     eqs = [D(C) ~ -b * C + a * A]
     @named osys = ODESystem(eqs, t, [A, C], [a, b])
     rn2 = extend(osys, rn)
@@ -387,7 +387,7 @@ let
         @parameters k
         k/$V, A + B --> C
     end
-    Dt = Catalyst.D_nounits
+    Dt = default_time_deriv()
     @named csys = ODESystem([Dt(V) ~ -b * V], t)
     @named fullrn = extend(csys, rn)
     setdefaults!(fullrn, [:b => 2.0])
@@ -424,7 +424,7 @@ let
     @parameters k1 k2 k3
     @variables V1(t) V2(t) V3(t)
     @species A1(t) A2(t) A3(t) B1(t) B2(t) B3(t)
-    D = Catalyst.D_nounits
+    D = default_time_deriv()
     rx1 = Reaction(k1*V1, [A1], [B1])
     eq1 = D(V1) ~ -V1
     @named rs1 = ReactionSystem([rx1, eq1], t)

--- a/test/programmatic_model_creation/component_based_model_creation.jl
+++ b/test/programmatic_model_creation/component_based_model_creation.jl
@@ -2,7 +2,7 @@
 using ModelingToolkit, Catalyst, LinearAlgebra, OrdinaryDiffEq, Test
 using SciMLNLSolve
 using ModelingToolkit: nameof
-import Catalyst: t_nounits as t
+t = default_t()
 
 ### Run Tests ###
 

--- a/test/programmatic_model_creation/programmatic_model_expansion.jl
+++ b/test/programmatic_model_creation/programmatic_model_expansion.jl
@@ -5,6 +5,7 @@
 # Fetch packages.
 using Catalyst, Test
 using ModelingToolkit: get_ps, get_unknowns, get_eqs, get_systems, get_iv, getname, nameof
+import Catalyst: t_nounits as t
 
 # Sets rnd number.
 using StableRNGs
@@ -49,7 +50,6 @@ end
 let
     empty_network_3 = @reaction_network
     @parameters p
-    @variables t
     @species x(t)
     addspecies!(empty_network_3, x)
     addparam!(empty_network_3, p)

--- a/test/programmatic_model_creation/programmatic_model_expansion.jl
+++ b/test/programmatic_model_creation/programmatic_model_expansion.jl
@@ -5,7 +5,7 @@
 # Fetch packages.
 using Catalyst, Test
 using ModelingToolkit: get_ps, get_unknowns, get_eqs, get_systems, get_iv, getname, nameof
-import Catalyst: t_nounits as t
+t = default_t()
 
 # Sets rnd number.
 using StableRNGs

--- a/test/reactionsystem_structure/reactionsystem.jl
+++ b/test/reactionsystem_structure/reactionsystem.jl
@@ -456,7 +456,7 @@ end
 let
     @parameters k1 k2 A [isconstantspecies = true]
     @species B(t) C(t) [isbcspecies = true] D(t) E(t)
-    Dt = Catalyst.D_nounits
+    Dt = default_time_deriv()
     eqs = [(@reaction k1, $A --> B),
         (@reaction k2, B --> $A),
         (@reaction k1, $C + D --> E + $C),
@@ -567,7 +567,7 @@ let
     @parameters k1 k2 S2 [isconstantspecies = true]
     @species S1(t) S3(t)
     rx = Reaction(k2, [S1], nothing)
-    ∂ₜ = Catalyst.D_nounits
+    ∂ₜ = default_time_deriv()
     eq = ∂ₜ(S3) ~ k1 * S2
     @named osys = ODESystem([eq], t)
     @named rs = ReactionSystem([rx, eq], t)
@@ -581,7 +581,7 @@ let
     @parameters k1 k2 S2 [isconstantspecies = true]
     @species S1(t) S3(t) [isbcspecies = true]
     rx = Reaction(k2, [S1], nothing)
-    ∂ₜ = Catalyst.D_nounits
+    ∂ₜ = default_time_deriv()
     eq = S3 ~ k1 * S2
     @named rs = ReactionSystem([rx, eq], t)
     @test issetequal(unknowns(rs), [S1, S3])
@@ -599,7 +599,7 @@ let
     @variables S3(t)
     @species S1(t)
     rx = Reaction(k2, [S1], nothing)
-    ∂ₜ = Catalyst.D_nounits
+    ∂ₜ = default_time_deriv()
     eq = S3 ~ k1 * S2
     @named rs = ReactionSystem([rx, eq], t)
     @test issetequal(unknowns(rs), [S1, S3])
@@ -694,7 +694,7 @@ let
     @variables V(t)
     @species A(t) B(t)
     rx = Reaction(k1, [A], [B], [k2], [2])
-    D = Catalyst.D_nounits
+    D = default_time_deriv()
     eq = D(V) ~ -k1 * k2 * V + A
     @named rs = ReactionSystem([eq, rx], t)
     @test length(unknowns(rs)) == 3

--- a/test/reactionsystem_structure/reactionsystem.jl
+++ b/test/reactionsystem_structure/reactionsystem.jl
@@ -2,7 +2,7 @@
 
 # Fetch pakcages.
 using Catalyst, LinearAlgebra, JumpProcesses, Test, OrdinaryDiffEq, StochasticDiffEq
-import Catalyst: t_nounits as t
+t = default_t()
 const MT = ModelingToolkit
 
 # Sets rnd number.

--- a/test/spatial_reaction_systems/lattice_reaction_systems.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems.jl
@@ -2,7 +2,7 @@
 
 # Fetch packages.
 using Catalyst, Graphs, Test
-import Catalyst: t_nounits as t
+t = default_t()
 
 # Pre declares a grid.
 grid = Graphs.grid([2, 2])

--- a/test/spatial_reaction_systems/lattice_reaction_systems.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems.jl
@@ -2,6 +2,7 @@
 
 # Fetch packages.
 using Catalyst, Graphs, Test
+import Catalyst: t_nounits as t
 
 # Pre declares a grid.
 grid = Graphs.grid([2, 2])
@@ -84,7 +85,6 @@ let
     end
     @unpack dX, X, V = rs
     @parameters dV dW
-    @variables t
     @species W(t)
     tr_1 = TransportReaction(dX, X)  
     tr_2 = @transport_reaction dY Y    
@@ -177,7 +177,6 @@ end
 
 # Test reactions with constants in rate.
 let 
-    @variables t
     @species X(t) Y(t)
     
     tr_1 = TransportReaction(1.5, X)
@@ -221,7 +220,6 @@ end
 # Test creation of TransportReaction with non-parameters in rate.
 # Tests that it works even when rate is highly nested.
 let 
-    @variables t
     @species X(t) Y(t)
     @parameters D1 D2 D3
     @test_throws ErrorException TransportReaction(D1 + D2*(D3 + Y), X)

--- a/test/spatial_reaction_systems/lattice_reaction_systems_ODEs.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems_ODEs.jl
@@ -3,7 +3,7 @@
 # Fetch packages.
 using OrdinaryDiffEq
 using Random, Statistics, SparseArrays, Test
-import Catalyst: t_nounits as t
+t = default_t()
 
 # Fetch test networks.
 include("../spatial_test_networks.jl")

--- a/test/spatial_reaction_systems/lattice_reaction_systems_ODEs.jl
+++ b/test/spatial_reaction_systems/lattice_reaction_systems_ODEs.jl
@@ -3,6 +3,7 @@
 # Fetch packages.
 using OrdinaryDiffEq
 using Random, Statistics, SparseArrays, Test
+import Catalyst: t_nounits as t
 
 # Fetch test networks.
 include("../spatial_test_networks.jl")
@@ -323,7 +324,6 @@ let
     end
     @unpack dLigand, dSilane, Silane = CuH_Amination_system_alt_1
     @parameters dAmine_E dNewspecies1
-    @variables t
     @species Ligand(t) Amine_E(t) Newspecies1(t) 
     tr_alt_1_1 = TransportReaction(dLigand, Ligand)
     tr_alt_1_2 = TransportReaction(dSilane, Silane)
@@ -350,7 +350,6 @@ let
     end
     @unpack Decomposition, dCu_ELigand, Cu_ELigand  = CuH_Amination_system_alt_2
     @parameters dNewspecies2 dDecomposition
-    @variables t
     @species Newspecies2(t) 
     tr_alt_2_1 = @transport_reaction dLigand Ligand
     tr_alt_2_2 = @transport_reaction dSilane Silane

--- a/test/spatial_reaction_systems/simulate_PDEs.jl
+++ b/test/spatial_reaction_systems/simulate_PDEs.jl
@@ -51,7 +51,7 @@ let
     @test bpm == bpm2
 
     # Check we can build a PDESystem.
-    ∂t = Catalyst.D_nounits
+    ∂t = default_time_deriv()
     ∂x = Differential(x)
     ∂y = Differential(y)
     Δ(u) = (∂x^2)(u) + (∂y^2)(u)

--- a/test/spatial_reaction_systems/simulate_PDEs.jl
+++ b/test/spatial_reaction_systems/simulate_PDEs.jl
@@ -18,7 +18,7 @@ end
 
 let
     @parameters k[1:7] D[1:3] n0[1:3] A
-    @variables t x y
+    @variables x y
     @species U(x, y, t) V(x, y, t) W(x, y, t)
     rxs = [Reaction(k[1], [U, W], [V, W]),
         Reaction(k[2], [V], [W], [2], [1]),
@@ -51,7 +51,7 @@ let
     @test bpm == bpm2
 
     # Check we can build a PDESystem.
-    ∂t = Differential(t)
+    ∂t = Catalyst.D_nounits
     ∂x = Differential(x)
     ∂y = Differential(y)
     Δ(u) = (∂x^2)(u) + (∂y^2)(u)

--- a/test/visualization/latexify.jl
+++ b/test/visualization/latexify.jl
@@ -233,7 +233,7 @@ let
     base_network = @reaction_network begin
         k*r, X --> 0
     end
-    @variables t r(t)
+    @variables r(t)
     @named decaying_rate = NonlinearSystem([r ~ -1], [r], [])
     extended = extend(decaying_rate, base_network)
 


### PR DESCRIPTION
In v9, MTK creates default time and differential variables. This PRs make Catalyst use these (throughout tests and documentation). I.e. instead of 
```julia
@variables t
D = Differential(t)
```
we now do
```julia
import Catalyst: t_nounits as t, D_nounits as D
```
CI still cannot work due to `all_dimensionless` issue mentioned in https://github.com/SciML/Catalyst.jl/pull/785 (which this one depends on).