### PR TITLE
Fix `merge!` to include the `var_to_name` map

### DIFF
--- a/src/networkapi.jl
+++ b/src/networkapi.jl
@@ -1559,6 +1559,7 @@ function Base.merge!(network1::ReactionSystem, network2::ReactionSystem)
     union!(get_observed(network1), get_observed(network2))
     union!(get_systems(network1), get_systems(network2))
     merge!(get_defaults(network1), get_defaults(network2))
+    merge!(getfield(network1, :var_to_name), getfield(network2, :var_to_name))
     union!(MT.get_continuous_events(network1), MT.get_continuous_events(network2))
     union!(MT.get_discrete_events(network1), MT.get_discrete_events(network2))
 

--- a/test/miscellaneous_tests/api.jl
+++ b/test/miscellaneous_tests/api.jl
@@ -49,6 +49,7 @@ let
     addreaction!(rs3, Reaction(k3, [S], [D]))
     addreaction!(rs3, Reaction(k4, [S, I], [D]))
     merge!(rs, rs3)
+    @test rs.k3 isa Num
     addspecies!(rs2, S)
     addspecies!(rs2, D)
     addparam!(rs2, k3)

--- a/test/programmatic_model_creation/programmatic_model_expansion.jl
+++ b/test/programmatic_model_creation/programmatic_model_expansion.jl
@@ -75,7 +75,13 @@ let
         (k7, k8), X7 ↔ X8
     end
     @test length(get_states(unfinished_network)) == 8
+    @test all(Symbol("X$i") for i in 1:8) do p
+        hasproperty(unfinished_network, p) && getproperty(unfinished_network, p) isa Num
+    end
     @test length(get_ps(unfinished_network)) == 9
+    @test all(Symbol("k$i") for i in 0:8) do p
+        hasproperty(unfinished_network, p) && getproperty(unfinished_network, p) isa Num
+    end
 end
 
 # Compares test network to identical network constructed via @add_reactions.


### PR DESCRIPTION
Previously, parameters defined in the second `ReactionSystem` would not be accessible as properties on the merged system. This also affected `@add_reactions`.