### PR TITLE
Add two new reaction metadata

### DIFF
--- a/src/reaction.jl
+++ b/src/reaction.jl
@@ -470,16 +470,16 @@ end
 """
 has_noise_scaling(reaction::Reaction)
 
-Checks whether a specific reaction has the metadata field `noise_scaing`. If so, returns `true`, else
-returns `false`.
+Returns `true` if the input reaction has the `noise_scaing` metadata field assigned, else `false`.
 
 Arguments:
-- `reaction`: The reaction for which we wish to check.
+- `reaction`: The reaction we wish to check for the `noise_scaing` metadata field.
 
 Example:
 ```julia
 reaction = @reaction k, 0 --> X, [noise_scaling=0.0]
 has_noise_scaling(reaction)
+```
 """
 function has_noise_scaling(reaction::Reaction)
     return hasmetadata(reaction, :noise_scaling)
@@ -488,21 +488,104 @@ end
 """
 get_noise_scaling(reaction::Reaction)
 
-Returns the noise_scaling metadata from a specific reaction.
+Returns `noise_scaing` metadata field for the input reaction.
 
 Arguments:
-- `reaction`: The reaction for which we wish to retrive all metadata.
+- `reaction`: The reaction we wish to retrieve the `noise_scaing` metadata field.
 
 Example:
 ```julia
 reaction = @reaction k, 0 --> X, [noise_scaling=0.0]
 get_noise_scaling(reaction)
+```
 """
 function get_noise_scaling(reaction::Reaction)
     if has_noise_scaling(reaction)
         return getmetadata(reaction, :noise_scaling)
     else
         error("Attempts to access noise_scaling metadata field for a reaction which does not have a value assigned for this metadata.")
+    end
+end
+
+# Description.
+"""
+has_description(reaction::Reaction)
+
+Returns `true` if the input reaction has the `description` metadata field assigned, else `false`.
+
+Arguments:
+- `reaction`: The reaction we wish to check for the `description` metadata field.
+
+Example:
+```julia
+reaction = @reaction k, 0 --> X, [description="A reaction"]
+has_description(reaction)
+```
+"""
+function has_description(reaction::Reaction)
+    return hasmetadata(reaction, :description)
+end
+
+"""
+get_description(reaction::Reaction)
+
+Returns `description` metadata field for the input reaction.
+
+Arguments:
+- `reaction`: The reaction we wish to retrieve the `description` metadata field.
+
+Example:
+```julia
+reaction = @reaction k, 0 --> X, [description="A reaction"]
+get_description(reaction)
+```
+"""
+function get_description(reaction::Reaction)
+    if has_description(reaction)
+        return getmetadata(reaction, :description)
+    else
+        error("Attempts to access `description` metadata field for a reaction which does not have a value assigned for this metadata.")
+    end
+end
+
+# Misc.
+"""
+has_misc(reaction::Reaction)
+
+Returns `true` if the input reaction has the `misc` metadata field assigned, else `false`.
+
+Arguments:
+- `reaction`: The reaction we wish to check for the `misc` metadata field.
+
+Example:
+```julia
+reaction = @reaction k, 0 --> X, [misc="A reaction"]
+misc(reaction)
+```
+"""
+function has_misc(reaction::Reaction)
+    return hasmetadata(reaction, :misc)
+end
+
+"""
+get_misc(reaction::Reaction)
+
+Returns `misc` metadata field for the input reaction.
+
+Arguments:
+- `reaction`: The reaction we wish to retrieve the `misc` metadata field.
+
+Example:
+```julia
+reaction = @reaction k, 0 --> X, [misc="A reaction"]
+get_misc(reaction)
+```
+"""
+function get_misc(reaction::Reaction)
+    if has_description(reaction)
+        return getmetadata(reaction, :misc)
+    else
+        error("Attempts to access `misc` metadata field for a reaction which does not have a value assigned for this metadata.")
     end
 end
 

--- a/src/reaction.jl
+++ b/src/reaction.jl
@@ -580,9 +580,17 @@ Example:
 reaction = @reaction k, 0 --> X, [misc="A reaction"]
 get_misc(reaction)
 ```
+
+Notes:
+- The `misc` field can contain any valid Julia structure. This mean that Catalyst cannot check it
+for symbolci variables that are added here. This means that symbolic variables (e.g. parameters of 
+species) that are stored here are not accessible to Catalyst. This can cause troubles when e.g. 
+creating a `ReactionSystem` programmatically (in which case any symbolic variables stored in the
+`misc` metadata field should also be explicitly provided to the `ReactionSystem` constructor). 
+
 """
 function get_misc(reaction::Reaction)
-    if has_description(reaction)
+    if has_misc(reaction)
         return getmetadata(reaction, :misc)
     else
         error("Attempts to access `misc` metadata field for a reaction which does not have a value assigned for this metadata.")

--- a/test/reactionsystem_core/reaction.jl
+++ b/test/reactionsystem_core/reaction.jl
@@ -116,5 +116,5 @@ let
     @test !Catalyst.has_misc(r1)
     @test Catalyst.has_misc(r2)
     @test_throws Exception Catalyst.get_misc(r1)
-    @test isequal(Catalyst.get_misc(r2), ('C', :C))
+    @test isequal(Catalyst.get_misc(r2), ('M', :M))
 end

--- a/test/reactionsystem_core/reaction.jl
+++ b/test/reactionsystem_core/reaction.jl
@@ -80,13 +80,41 @@ let
     @parameters k η  
     @species X(t) X2(t)
 
-    metadata = Pair{Symbol,Any}[]
-    push!(metadata, :noise_scaling => η)
     r1 = Reaction(k, [X], [X2], [2], [1])
-    r2 = Reaction(k, [X], [X2], [2], [1]; metadata=metadata)
+    r2 = Reaction(k, [X], [X2], [2], [1]; metadata=[:noise_scaling => η])
 
     @test !Catalyst.has_noise_scaling(r1)
     @test Catalyst.has_noise_scaling(r2)
     @test_throws Exception Catalyst.get_noise_scaling(r1)
     @test isequal(Catalyst.get_noise_scaling(r2), η)
+end
+
+# Tests the description metadata.
+let
+    @variables t
+    @parameters k η  
+    @species X(t) X2(t)
+
+    r1 = Reaction(k, [X], [X2], [2], [1])
+    r2 = Reaction(k, [X], [X2], [2], [1]; metadata=[:description => "A reaction"])
+
+    @test !Catalyst.has_description(r1)
+    @test Catalyst.has_description(r2)
+    @test_throws Exception Catalyst.get_description(r1)
+    @test isequal(Catalyst.get_description(r2), "A reaction")
+end
+
+# Tests the misc metadata.
+let
+    @variables t
+    @parameters k η  
+    @species X(t) X2(t)
+
+    r1 = Reaction(k, [X], [X2], [2], [1])
+    r2 = Reaction(k, [X], [X2], [2], [1]; metadata=[:misc => ('M', :M)])
+
+    @test !Catalyst.has_misc(r1)
+    @test Catalyst.has_misc(r2)
+    @test_throws Exception Catalyst.get_misc(r1)
+    @test isequal(Catalyst.get_misc(r2), ('C', :C))
 end


### PR DESCRIPTION
I have added two more `Reaction` metadata that we support with getters:
- `description`
- `misc`

There are two main uses of this PR:
- These two metadata should be usable by the user to support any metadata they would like to use, without us having to support the addition of user-designated metadata.
- They are good metadata to introduce the concept of reaction metadata in the docs (rather than noise scaling, which is non-obvious what it is). This way I do not have to introduce `Reaction` metadata in the SDE tutorials.