### PR TITLE
Add `conservedquantity` metadata

### DIFF
--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -543,7 +543,7 @@ end
 ### Conservation Laws ###
 
 # Implements the `conservationquantity` parameter metadata.
-struct ConservationQuantity end
+struct ConservedParameter end
 Symbolics.option_to_metadata_type(::Val{:conservationquantity}) = ConservationQuantity
 
 """

--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -544,7 +544,7 @@ end
 
 # Implements the `conservationquantity` parameter metadata.
 struct ConservedParameter end
-Symbolics.option_to_metadata_type(::Val{:conservationquantity}) = ConservationQuantity
+Symbolics.option_to_metadata_type(::Val{:conserved}) = ConservationQuantity
 
 """
     isconservationquantity(p)

--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -542,6 +542,23 @@ end
 
 ### Conservation Laws ###
 
+# Implements the `conservationquantity` parameter metadata.
+struct ConservationQuantity end
+Symbolics.option_to_metadata_type(::Val{:conservationquantity}) = ConservationQuantity
+
+"""
+    isconservationquantity(p)
+
+Checks if the input parameter (`p`) is a conserved quantity (i.e. have the `conservationquantity`)
+metadata.
+"""
+isconservationquantity(x::Num, args...) = isconservationquantity(Symbolics.unwrap(x), args...)
+function isconservationquantity(x, default = false)
+    p = Symbolics.getparent(x, nothing)
+    p === nothing || (x = p)
+    Symbolics.getmetadata(x, ConservationQuantity, default)
+end
+
 """
     conservedequations(rn::ReactionSystem)
 
@@ -635,7 +652,8 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     indepspecs = sts[indepidxs]
     depidxs = col_order[(r + 1):end]
     depspecs = sts[depidxs]
-    constants = MT.unwrap.(MT.scalarize((@parameters Γ[1:nullity])[1]))
+    constants = MT.unwrap.(MT.scalarize(only(
+                @parameters $(CONSERVED_CONSTANT_SYMBOL)[1:nullity] [conservationquantity=true])))
 
     conservedeqs = Equation[]
     constantdefs = Equation[]

--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -542,21 +542,21 @@ end
 
 ### Conservation Laws ###
 
-# Implements the `conservationquantity` parameter metadata.
+# Implements the `conserved` parameter metadata.
 struct ConservedParameter end
-Symbolics.option_to_metadata_type(::Val{:conserved}) = ConservationQuantity
+Symbolics.option_to_metadata_type(::Val{:conserved}) = ConservedParameter
 
 """
-    isconservationquantity(p)
+isconserved(p)
 
-Checks if the input parameter (`p`) is a conserved quantity (i.e. have the `conservationquantity`)
+Checks if the input parameter (`p`) is a conserved quantity (i.e. have the `conserved`)
 metadata.
 """
-isconservationquantity(x::Num, args...) = isconservationquantity(Symbolics.unwrap(x), args...)
-function isconservationquantity(x, default = false)
+isconserved(x::Num, args...) = isconserved(Symbolics.unwrap(x), args...)
+function isconserved(x, default = false)
     p = Symbolics.getparent(x, nothing)
     p === nothing || (x = p)
-    Symbolics.getmetadata(x, ConservationQuantity, default)
+    Symbolics.getmetadata(x, ConservedParameter, default)
 end
 
 """
@@ -653,7 +653,7 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     depidxs = col_order[(r + 1):end]
     depspecs = sts[depidxs]
     constants = MT.unwrap.(MT.scalarize(only(
-                @parameters $(CONSERVED_CONSTANT_SYMBOL)[1:nullity] [conservationquantity=true])))
+                @parameters $(CONSERVED_CONSTANT_SYMBOL)[1:nullity] [conserved=true])))
 
     conservedeqs = Equation[]
     constantdefs = Equation[]

--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -154,7 +154,7 @@ let
         (k1,k2), X1 <--> X2
         (k1,k2), Y1 <--> Y2
     end
-    osys = convert(ODESystem, rs)
+    osys = convert(ODESystem, rs; remove_conserved = true)
 
     # Checks that the correct parameters have the `conservationquantity` metadata.
     @test Catalyst.isconservationquantity(osys.Γ[1])

--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -143,3 +143,22 @@ let
     @test isapprox(g1, g2[istsidxs, :])
     @test isapprox(g2[istsidxs, :], g3)
 end
+
+### ConservedQuantity Metadata Tests ###
+
+# Checks that `conservationquantity` metadata is added correctly to parameters.
+# Checks that the `isconservationquantity` getter function works correctly.
+let
+    # Creates ODESystem with conserved quantities.
+    rs = @reaction_network begin
+        (k1,k2), X1 <--> X2
+        (k1,k2), Y1 <--> Y2
+    end
+    osys = convert(ODESystem, rs)
+
+    # Checks that the correct parameters have the `conservationquantity` metadata.
+    @test Catalyst.isconservationquantity(osys.Γ[1])
+    @test Catalyst.isconservationquantity(osys.Γ[2])
+    @test !Catalyst.isconservationquantity(osys.k1)
+    @test !Catalyst.isconservationquantity(osys.k2)
+end

--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -144,10 +144,10 @@ let
     @test isapprox(g2[istsidxs, :], g3)
 end
 
-### ConservedQuantity Metadata Tests ###
+### ConservedParameter Metadata Tests ###
 
-# Checks that `conservationquantity` metadata is added correctly to parameters.
-# Checks that the `isconservationquantity` getter function works correctly.
+# Checks that `conserved` metadata is added correctly to parameters.
+# Checks that the `isconserved` getter function works correctly.
 let
     # Creates ODESystem with conserved quantities.
     rs = @reaction_network begin
@@ -156,9 +156,9 @@ let
     end
     osys = convert(ODESystem, rs; remove_conserved = true)
 
-    # Checks that the correct parameters have the `conservationquantity` metadata.
-    @test Catalyst.isconservationquantity(osys.Γ[1])
-    @test Catalyst.isconservationquantity(osys.Γ[2])
-    @test !Catalyst.isconservationquantity(osys.k1)
-    @test !Catalyst.isconservationquantity(osys.k2)
+    # Checks that the correct parameters have the `conserved` metadata.
+    @test Catalyst.isconserved(osys.Γ[1])
+    @test Catalyst.isconserved(osys.Γ[2])
+    @test !Catalyst.isconserved(osys.k1)
+    @test !Catalyst.isconserved(osys.k2)
 end


### PR DESCRIPTION
Add a `conservedquantity = true` metadata to all conserved quantity parameters. These permits e.g. detecting these in e.g. StrucuralIdentifiability outputs, and eliminating them from here.