### PR TITLE
Add `nonreaction` function

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -157,6 +157,7 @@ species
 nonspecies
 reactionparams
 reactions
+nonreactions
 numspecies
 numparams
 numreactions

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -98,7 +98,7 @@ export get_noise_scaling, has_noise_scaling
 # The `ReactionSystem` structure and its functions.
 include("reactionsystem.jl")
 export ReactionSystem, isspatial
-export species, nonspecies, reactionparams, reactions, speciesmap, paramsmap
+export species, nonspecies, reactionparams, reactions, nonreactions, speciesmap, paramsmap
 export numspecies, numreactions, numreactionparams, setdefaults!
 export make_empty_network, reactionparamsmap
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -812,6 +812,18 @@ function numreactions(network)
 end
 
 """
+    nonreactions(network)
+
+Return the non-reaction equations within the network (i.e. algebraic and differnetial equations).
+
+Notes:
+- Allocates a new array to store the non-species variables.
+"""
+function nonreactions(network)
+    equations(network)[(numreactions(network) + 1):end]
+end
+
+"""
     numreactionparams(network)
 
 Return the total number of parameters within the given [`ReactionSystem`](@ref)

--- a/test/reactionsystem_core/coupled_equation_crn_systems.jl
+++ b/test/reactionsystem_core/coupled_equation_crn_systems.jl
@@ -211,6 +211,24 @@ let
 end
 
 
+### Accessor Tests ###
+
+# Checks that basic accessors gives correct output.
+let
+    # Creates a basic model with combination of equations and reactions.
+    coupled_rs = @reaction_network coupled_rs begin
+        @variables VV(t)
+        @equations begin
+            D(V) ~ X - V
+            VV^2 ~ log(V) + X 
+        end
+        (p,d), 0 <--> X
+    end
+
+
+end
+
+
 ### Species, Variables, and Parameter Handling ###
 
 # Checks that coupled systems contain the correct species, variables, and parameters.


### PR DESCRIPTION
Returns all `Equation`s in a reaction system (like `nonspecies` returns variables). Also adds some additional tests for this kind of accessor functions on couple CRN/equation models.