### PR TITLE
Rename `reactionparams` and similar functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Catalyst unreleased (master branch)
 
 ## Catalyst 14.0
+- Rename `reactionparams`, `numreactionparams`, and `reactionparamsmap` to `reactionsystemparams`, `numreactionsystemparams`, and `reactionsystemparamsmap`, respectively.
 - To be more consistent with ModelingToolkit's immutability requirement for systems, we have removed API functions that mutate `ReactionSystem`s such as `addparam!`, `addreaction!`, `addspecies`, `@add_reactions`, and `merge!`. Please use `ModelingToolkit.extend` and `ModelingToolkit.compose` to generate new merged and/or composed `ReactionSystem`s from multiple component systems.
 - Added CatalystStructuralIdentifiabilityExtension, which permits StructuralIdentifiability.jl function to be applied directly to Catalyst systems. E.g. use
 ```julia

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## Catalyst unreleased (master branch)
 
 ## Catalyst 14.0
-- Rename `reactionparams`, `numreactionparams`, and `reactionparamsmap` to `reactionsystemparams`, `numreactionsystemparams`, and `reactionsystemparamsmap`, respectively.
+- The `reactionparams`, `numreactionparams`, and `reactionparamsmap`  functions have been removed.
 - To be more consistent with ModelingToolkit's immutability requirement for systems, we have removed API functions that mutate `ReactionSystem`s such as `addparam!`, `addreaction!`, `addspecies`, `@add_reactions`, and `merge!`. Please use `ModelingToolkit.extend` and `ModelingToolkit.compose` to generate new merged and/or composed `ReactionSystem`s from multiple component systems.
 - Added CatalystStructuralIdentifiabilityExtension, which permits StructuralIdentifiability.jl function to be applied directly to Catalyst systems. E.g. use
 ```julia

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -128,7 +128,7 @@ can call:
   the system and any sub-systems that are also `ReactionSystems`.
 * `ModelingToolkit.parameters(rn)` returns all parameters across the
   system, *all sub-systems*, and all constraint systems.
-* [`reactionparams(rn)`](@ref) is a vector of all the parameters within the
+* [`reactionsystemparams(rn)`](@ref) is a vector of all the parameters within the
   system and any sub-systems that are also `ReactionSystem`s. These include all
   parameters that appear within some `Reaction`.
 * `ModelingToolkit.equations(rn)` returns all [`Reaction`](@ref)s and all
@@ -155,16 +155,16 @@ accessor functions.
 ```@docs
 species
 nonspecies
-reactionparams
+reactionsystemparams
 reactions
 nonreactions
 numspecies
 numparams
 numreactions
-numreactionparams
+numreactionsystemparams
 speciesmap
 paramsmap
-reactionparamsmap
+reactionsystemparamsmap
 isspecies
 Catalyst.isconstant
 Catalyst.isbc

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -128,9 +128,6 @@ can call:
   the system and any sub-systems that are also `ReactionSystems`.
 * `ModelingToolkit.parameters(rn)` returns all parameters across the
   system, *all sub-systems*, and all constraint systems.
-* [`reactionsystemparams(rn)`](@ref) is a vector of all the parameters within the
-  system and any sub-systems that are also `ReactionSystem`s. These include all
-  parameters that appear within some `Reaction`.
 * `ModelingToolkit.equations(rn)` returns all [`Reaction`](@ref)s and all
   `Symbolics.Equations` defined across the system, *all sub-systems*, and all
   constraint systems. `Reaction`s are ordered ahead of `Equation`s with the

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -100,7 +100,7 @@ include("reactionsystem.jl")
 export ReactionSystem, isspatial
 export species, nonspecies, reactions, nonreactions, speciesmap, paramsmap
 export numspecies, numreactions, setdefaults!
-export make_empty_network, 
+export make_empty_network
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export reactionrates
 export isequivalent

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -98,9 +98,9 @@ export get_noise_scaling, has_noise_scaling
 # The `ReactionSystem` structure and its functions.
 include("reactionsystem.jl")
 export ReactionSystem, isspatial
-export species, nonspecies, reactionsystemparams, reactions, nonreactions, speciesmap, paramsmap
-export numspecies, numreactions, numreactionsystemparams, setdefaults!
-export make_empty_network, reactionsystemparamsmap
+export species, nonspecies, reactions, nonreactions, speciesmap, paramsmap
+export numspecies, numreactions, setdefaults!
+export make_empty_network, 
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export reactionrates
 export isequivalent

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -98,9 +98,9 @@ export get_noise_scaling, has_noise_scaling
 # The `ReactionSystem` structure and its functions.
 include("reactionsystem.jl")
 export ReactionSystem, isspatial
-export species, nonspecies, reactionparams, reactions, nonreactions, speciesmap, paramsmap
-export numspecies, numreactions, numreactionparams, setdefaults!
-export make_empty_network, reactionparamsmap
+export species, nonspecies, reactionsystemparams, reactions, nonreactions, speciesmap, paramsmap
+export numspecies, numreactions, numreactionsystemparams, setdefaults!
+export make_empty_network, reactionsystemparamsmap
 export dependants, dependents, substoichmat, prodstoichmat, netstoichmat
 export reactionrates
 export isequivalent

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -723,7 +723,7 @@ function get_indep_sts(rs::ReactionSystem, remove_conserved = false)
 end
 
 """
-    reactionparams(network)
+reactionsystemparams(network)
 
 Given a [`ReactionSystem`](@ref), return a vector of all parameters defined
 within the system and any subsystems that are of type `ReactionSystem`. To get
@@ -733,11 +733,11 @@ subsystems, use `parameters(network)`.
 Notes:
 - Allocates and has to calculate these dynamically by comparison for each reaction.
 """
-function reactionparams(network)
+function reactionsystemparams(network)
     ps = get_ps(network)
     systems = filter_nonrxsys(network)
     isempty(systems) && return ps
-    unique([ps; reduce(vcat, map(sys -> species(sys, reactionparams(sys)), systems))])
+    unique([ps; reduce(vcat, map(sys -> species(sys, reactionsystemparams(sys)), systems))])
 end
 
 """
@@ -765,13 +765,13 @@ function paramsmap(network)
 end
 
 """
-    reactionparamsmap(network)
+    reactionsystemparamsmap(network)
 
 Given a [`ReactionSystem`](@ref), return a Dictionary mapping from parameters that
-appear within `Reaction`s to their index within [`reactionparams(network)`](@ref).
+appear within `Reaction`s to their index within [`reactionsystemparams(network)`](@ref).
 """
-function reactionparamsmap(network)
-    Dict(p => i for (i, p) in enumerate(reactionparams(network)))
+function reactionsystemparamsmap(network)
+    Dict(p => i for (i, p) in enumerate(reactionsystemparams(network)))
 end
 
 # used in the next function (`reactions(network)`).
@@ -824,18 +824,18 @@ function nonreactions(network)
 end
 
 """
-    numreactionparams(network)
+    numreactionsystemparams(network)
 
 Return the total number of parameters within the given [`ReactionSystem`](@ref)
 and subsystems that are `ReactionSystem`s.
 
 Notes
 - If there are no subsystems this will be fast.
-- As this calls [`reactionparams`](@ref), it can be slow and will allocate if
+- As this calls [`reactionsystemparams`](@ref), it can be slow and will allocate if
   there are any subsystems.
 """
-function numreactionparams(network)
-    length(reactionparams(network))
+function numreactionsystemparams(network)
+    length(reactionsystemparams(network))
 end
 
 """

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -723,24 +723,6 @@ function get_indep_sts(rs::ReactionSystem, remove_conserved = false)
 end
 
 """
-reactionsystemparams(network)
-
-Given a [`ReactionSystem`](@ref), return a vector of all parameters defined
-within the system and any subsystems that are of type `ReactionSystem`. To get
-the parameters in the system and all subsystems, including non-`ReactionSystem`
-subsystems, use `parameters(network)`.
-
-Notes:
-- Allocates and has to calculate these dynamically by comparison for each reaction.
-"""
-function reactionsystemparams(network)
-    ps = get_ps(network)
-    systems = filter_nonrxsys(network)
-    isempty(systems) && return ps
-    unique([ps; reduce(vcat, map(sys -> species(sys, reactionsystemparams(sys)), systems))])
-end
-
-"""
     numparams(network)
 
 Return the total number of parameters within the given system and all subsystems.
@@ -762,16 +744,6 @@ parameters that appear within the system to their index within
 """
 function paramsmap(network)
     Dict(p => i for (i, p) in enumerate(parameters(network)))
-end
-
-"""
-    reactionsystemparamsmap(network)
-
-Given a [`ReactionSystem`](@ref), return a Dictionary mapping from parameters that
-appear within `Reaction`s to their index within [`reactionsystemparams(network)`](@ref).
-"""
-function reactionsystemparamsmap(network)
-    Dict(p => i for (i, p) in enumerate(reactionsystemparams(network)))
 end
 
 # used in the next function (`reactions(network)`).
@@ -821,21 +793,6 @@ Notes:
 """
 function nonreactions(network)
     equations(network)[(numreactions(network) + 1):end]
-end
-
-"""
-    numreactionsystemparams(network)
-
-Return the total number of parameters within the given [`ReactionSystem`](@ref)
-and subsystems that are `ReactionSystem`s.
-
-Notes
-- If there are no subsystems this will be fast.
-- As this calls [`reactionsystemparams`](@ref), it can be slow and will allocate if
-  there are any subsystems.
-"""
-function numreactionsystemparams(network)
-    length(reactionsystemparams(network))
 end
 
 """

--- a/test/compositional_modelling/component_based_model_creation.jl
+++ b/test/compositional_modelling/component_based_model_creation.jl
@@ -297,7 +297,6 @@ let
     # Test API functions for composed model.
     @test issetequal(species(rs), [A, B, C])
     @test issetequal(unknowns(rs), [A, B, C, ns.D])
-    @test issetequal(reactionsystemparams(rs), [r₊, r₋])
     @test issetequal(parameters(rs), [r₊, r₋, ns.β])
     @test issetequal(reactions(rs), union(rxs1, rxs2))
     @test issetequal(filter(eq -> eq isa Reaction, equations(rs)), union(rxs1, rxs2))
@@ -340,7 +339,6 @@ let
     @test issetequal(unknowns(rs1), [A1, rs2.A2a, ns2.A2b, rs2.rs3.A3a, rs2.ns3.A3b])
     @test issetequal(species(rs1), [A1, rs2.A2a, rs2.rs3.A3a])
     @test issetequal(parameters(rs1), [p1, rs2.p2a, rs2.p2b, rs2.rs3.p3a, rs2.ns3.p3b])
-    @test issetequal(reactionsystemparams(rs1), [p1, rs2.p2a, rs2.p2b, rs2.rs3.p3a])
     @test issetequal(rxs, reactions(rs1))
     @test issetequal(eqs, equations(rs1))
     @test Catalyst.combinatoric_ratelaws(rs1)

--- a/test/compositional_modelling/component_based_model_creation.jl
+++ b/test/compositional_modelling/component_based_model_creation.jl
@@ -297,7 +297,7 @@ let
     # Test API functions for composed model.
     @test issetequal(species(rs), [A, B, C])
     @test issetequal(unknowns(rs), [A, B, C, ns.D])
-    @test issetequal(reactionparams(rs), [r₊, r₋])
+    @test issetequal(reactionsystemparams(rs), [r₊, r₋])
     @test issetequal(parameters(rs), [r₊, r₋, ns.β])
     @test issetequal(reactions(rs), union(rxs1, rxs2))
     @test issetequal(filter(eq -> eq isa Reaction, equations(rs)), union(rxs1, rxs2))
@@ -340,7 +340,7 @@ let
     @test issetequal(unknowns(rs1), [A1, rs2.A2a, ns2.A2b, rs2.rs3.A3a, rs2.ns3.A3b])
     @test issetequal(species(rs1), [A1, rs2.A2a, rs2.rs3.A3a])
     @test issetequal(parameters(rs1), [p1, rs2.p2a, rs2.p2b, rs2.rs3.p3a, rs2.ns3.p3b])
-    @test issetequal(reactionparams(rs1), [p1, rs2.p2a, rs2.p2b, rs2.rs3.p3a])
+    @test issetequal(reactionsystemparams(rs1), [p1, rs2.p2a, rs2.p2b, rs2.rs3.p3a])
     @test issetequal(rxs, reactions(rs1))
     @test issetequal(eqs, equations(rs1))
     @test Catalyst.combinatoric_ratelaws(rs1)

--- a/test/dsl/dsl_advanced_model_construction.jl
+++ b/test/dsl/dsl_advanced_model_construction.jl
@@ -35,7 +35,6 @@ let
         @test ModelingToolkit.nameof(rn) == name
         @test numreactions(rn) == 0
         @test numspecies(rn) == 0
-        @test numreactionsystemparams(rn) == 0
     end
 
     rn = @reaction_network name begin

--- a/test/dsl/dsl_advanced_model_construction.jl
+++ b/test/dsl/dsl_advanced_model_construction.jl
@@ -35,7 +35,7 @@ let
         @test ModelingToolkit.nameof(rn) == name
         @test numreactions(rn) == 0
         @test numspecies(rn) == 0
-        @test numreactionparams(rn) == 0
+        @test numreactionsystemparams(rn) == 0
     end
 
     rn = @reaction_network name begin

--- a/test/miscellaneous_tests/api.jl
+++ b/test/miscellaneous_tests/api.jl
@@ -83,14 +83,14 @@ let
     @test pmat == prodstoichmat(rnmat) == Matrix(prodstoichmat(rnmat, sparse = true))
 end
 
-# Tests `reactionparamsmap`, `reactionrates`, and `symmap_to_varmap` getters.
+# Tests `reactionsystemparamsmap`, `reactionrates`, and `symmap_to_varmap` getters.
 let
     rn = @reaction_network begin
         (p,d), 0 <--> X
         (kB,kD), 2X <--> X
     end
     @unpack p, d, kB, kD = rn
-    isequal(reactionparamsmap(rn), Dict([p => 1, d => 2, kB => 3, kD => 4]))
+    isequal(reactionsystemparamsmap(rn), Dict([p => 1, d => 2, kB => 3, kD => 4]))
     issetequal(reactionrates(rn), [p, d, kB, kD])
     isequal(symmap_to_varmap(rn, [:p => 1.0, :kB => 3.0]), [p => 1.0, kB => 3.0])
 end

--- a/test/miscellaneous_tests/api.jl
+++ b/test/miscellaneous_tests/api.jl
@@ -83,14 +83,13 @@ let
     @test pmat == prodstoichmat(rnmat) == Matrix(prodstoichmat(rnmat, sparse = true))
 end
 
-# Tests `reactionsystemparamsmap`, `reactionrates`, and `symmap_to_varmap` getters.
+# Tests `reactionrates`, and `symmap_to_varmap` getters.
 let
     rn = @reaction_network begin
         (p,d), 0 <--> X
         (kB,kD), 2X <--> X
     end
     @unpack p, d, kB, kD = rn
-    isequal(reactionsystemparamsmap(rn), Dict([p => 1, d => 2, kB => 3, kD => 4]))
     issetequal(reactionrates(rn), [p, d, kB, kD])
     isequal(symmap_to_varmap(rn, [:p => 1.0, :kB => 3.0]), [p => 1.0, kB => 3.0])
 end

--- a/test/reactionsystem_core/coupled_equation_crn_systems.jl
+++ b/test/reactionsystem_core/coupled_equation_crn_systems.jl
@@ -251,9 +251,7 @@ let
 
     # Check parameters-related accessors.
     @test issetequal(parameters(coupled_rs), [p, d, v])
-    @test issetequal(reactionsystemparams(coupled_rs), [p, d, v])
     @test numparams(coupled_rs) == 3
-    @test numreactionsystemparams(coupled_rs) == 3
 
     # Check other accessors.
     @test !isspatial(coupled_rs)

--- a/test/reactionsystem_core/coupled_equation_crn_systems.jl
+++ b/test/reactionsystem_core/coupled_equation_crn_systems.jl
@@ -251,9 +251,9 @@ let
 
     # Check parameters-related accessors.
     @test issetequal(parameters(coupled_rs), [p, d, v])
-    @test issetequal(reactionparams(coupled_rs), [p, d, v])
+    @test issetequal(reactionsystemparams(coupled_rs), [p, d, v])
     @test numparams(coupled_rs) == 3
-    @test numreactionparams(coupled_rs) == 3
+    @test numreactionsystemparams(coupled_rs) == 3
 
     # Check other accessors.
     @test !isspatial(coupled_rs)


### PR DESCRIPTION
Rename `reactionparams`, `numreactionparams`, and `reactionparamsmap` to `reactionsystemparams`, `numreactionsystemparams`, and `reactionsystemparamsmap`, respectively.