### PR TITLE
change doc collapse level

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,7 +32,7 @@ include("pages.jl")
 
 makedocs(sitename = "Catalyst.jl",
          authors = "Samuel Isaacson",
-         format = Documenter.HTML(; analytics = "UA-90474609-3",
+         format = Documenter.HTML(; analytics = "UA-90474609-3", collapselevel = 1,
                                   prettyurls = (get(ENV, "CI", nothing) == "true"),
                                   assets = ["assets/favicon.ico"],
                                   canonical = "https://docs.sciml.ai/Catalyst/stable/"),


### PR DESCRIPTION
Given that the number of doc pages are increasing, we might want to change so that the top sections start collapsed, e.g. like
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/25a35497-ae69-4452-b050-0d58e6fccf21)
