### PR TITLE
Update bifurcationkit doc page

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -37,7 +37,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 BenchmarkTools = "1.5"
-BifurcationKit = "0.3"
+BifurcationKit = "0.3.4"
 CairoMakie = "0.12"
 Catalyst = "13"
 DataFrames = "1.6"

--- a/docs/src/steady_state_functionality/bifurcation_diagrams.md
+++ b/docs/src/steady_state_functionality/bifurcation_diagrams.md
@@ -43,7 +43,7 @@ nothing # hide
 
 Finally, we compute our bifurcation diagram using:
 ```@example ex1
-bif_dia = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside = true)
+bif_dia = bifurcationdiagram(bprob, PALC(), 2, opts_br; bothside = true)
 nothing # hide
 ```
 Where `PALC()` designates that we wish to use the pseudo arclength continuation method to track our solution. The third argument (`2`) designates the maximum number of recursions when branches of branches are computed (branches appear as continuation encounters certain bifurcation points). For diagrams with highly branched structures (rare for many common small chemical reaction networks) this input is important. Finally, `bothside = true` designates that we wish to perform continuation on both sides of the initial point (which is typically the case). 
@@ -69,7 +69,7 @@ opt_newton = NewtonPar(tol = 1e-9, max_iterations = 1000)
 opts_br = ContinuationPar(p_min = p_span[1], p_max = p_span[2], 
                           dsmin = 0.001, dsmax = 0.01, max_steps = 1000,
                           newton_options = opt_newton)
-bif_dia = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside = true)
+bif_dia = bifurcationdiagram(bprob, PALC(), 2, opts_br; bothside = true)
 nothing # hide
 ```
 (however, in this case these additional settings have no significant effect on the result)
@@ -79,7 +79,7 @@ Let's consider the previous case, but instead compute the bifurcation diagram ov
 ```@example ex1
 p_span = (2.0, 15.0)
 opts_br = ContinuationPar(p_min = p_span[1], p_max = p_span[2], max_steps = 1000)
-bif_dia = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside = true)
+bif_dia = bifurcationdiagram(bprob, PALC(), 2, opts_br; bothside = true)
 plot(bif_dia; xguide = "k1", yguide = "X")
 ```
 Here, in the bistable region, we only see a single branch. The reason is that the continuation algorithm starts at our initial guess (here made at $k1 = 4.0$ for $(X,Y) = (5.0,2.0)$) and tracks the diagram from there. However, with the upper bound set at $k1=15.0$ the bifurcation diagram has a disjoint branch structure, preventing the full diagram from being computed by continuation alone. In this case it could be solved by increasing the bound from $k1=15.0$, however, this is not possible in all cases. In these cases, *deflation* can be used. This is described in the [BifurcationKit documentation](https://bifurcationkit.github.io/BifurcationKitDocs.jl/dev/tutorials/tutorials2/#Snaking-computed-with-deflation).
@@ -103,7 +103,7 @@ bprob = BifurcationProblem(kinase_model, u_guess, p_start, :d; plot_var = :Xp, u
 
 p_span = (0.1, 10.0)
 opts_br = ContinuationPar(p_min = p_span[1], p_max = p_span[2], max_steps = 1000)
-bif_dia = bifurcationdiagram(bprob, PALC(), 2, (args...) -> opts_br; bothside = true)
+bif_dia = bifurcationdiagram(bprob, PALC(), 2, opts_br; bothside = true)
 plot(bif_dia; xguide = "d", yguide = "Xp")
 ```
 This bifurcation diagram does not contain any interesting features (such as bifurcation points), and only shows how the steady state concentration of $Xp$ is reduced as $d$ increases. 


### PR DESCRIPTION
Now we can (supposedly) use `opts_br` instead of `(args...) -> opts_br` as input, so modify the doc accordingly