### PR TITLE
Expand conservation law tests

### DIFF
--- a/src/reactionsystem_conversions.jl
+++ b/src/reactionsystem_conversions.jl
@@ -653,7 +653,7 @@ function Base.convert(::Type{<:JumpSystem}, rs::ReactionSystem; name = nameof(rs
     spatial_convert_err(rs::ReactionSystem, JumpSystem)
 
     (remove_conserved !== nothing) &&
-        error("Catalyst does not support removing conserved species when converting to JumpSystems.")
+        throw(ArgumentError("Catalyst does not support removing conserved species when converting to JumpSystems."))
 
     flatrs = Catalyst.flatten(rs)
     error_if_constraints(JumpSystem, flatrs)

--- a/test/dsl/dsl_basic_model_construction.jl
+++ b/test/dsl/dsl_basic_model_construction.jl
@@ -71,7 +71,7 @@ let
           Set([:p, :k1, :k2, :k3, :k4, :k5, :k6, :d])
     basic_test(reaction_networks_hill[1], 4, [:X1, :X2],
                [:v1, :v2, :K1, :K2, :n1, :n2, :d1, :d2])
-    basic_test(reaction_networks_constraint[1], 6, [:X1, :X2, :X3],
+    basic_test(reaction_networks_conserved[1], 6, [:X1, :X2, :X3],
                [:k1, :k2, :k3, :k4, :k5, :k6])
     basic_test(reaction_networks_real[1], 4, [:X, :Y], [:A, :B])
     basic_test(reaction_networks_weird[1], 2, [:X], [:p, :d])
@@ -281,7 +281,7 @@ let
         Reaction(p + k5 * X2 * X3, nothing, [X5], nothing, [1]),
         Reaction(d, [X5], nothing, [1], nothing)]
     @named rs_2 = ReactionSystem(rxs_2, t, [X1, X2, X3, X4, X5], [k1, k2, k3, k4, p, k5, d])
-    push!(identical_networks_4, reaction_networks_constraint[3] => rs_2)
+    push!(identical_networks_4, reaction_networks_conserved[3] => rs_2)
 
     rxs_3 = [Reaction(k1, [X1], [X2], [1], [1]),
         Reaction(0, [X2], [X3], [1], [1]),
@@ -321,14 +321,14 @@ let
 
     for factor in [1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3]
         τ = rand(rng)
-        u = rnd_u0(reaction_networks_constraint[1], rng; factor)
+        u = rnd_u0(reaction_networks_conserved[1], rng; factor)
         p_2 = rnd_ps(time_network, rng; factor)
-        p_1 = [p_2; reaction_networks_constraint[1].k1 => τ; 
-               reaction_networks_constraint[1].k4 => τ; reaction_networks_constraint[1].k5 => τ]
+        p_1 = [p_2; reaction_networks_conserved[1].k1 => τ; 
+               reaction_networks_conserved[1].k4 => τ; reaction_networks_conserved[1].k5 => τ]
 
-        @test f_eval(reaction_networks_constraint[1], u, p_1, τ) ≈ f_eval(time_network, u, p_2, τ)
-        @test jac_eval(reaction_networks_constraint[1], u, p_1, τ) ≈ jac_eval(time_network, u, p_2, τ)
-        @test g_eval(reaction_networks_constraint[1], u, p_1, τ) ≈ g_eval(time_network, u, p_2, τ)
+        @test f_eval(reaction_networks_conserved[1], u, p_1, τ) ≈ f_eval(time_network, u, p_2, τ)
+        @test jac_eval(reaction_networks_conserved[1], u, p_1, τ) ≈ jac_eval(time_network, u, p_2, τ)
+        @test g_eval(reaction_networks_conserved[1], u, p_1, τ) ≈ g_eval(time_network, u, p_2, τ)
     end
 end
 

--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -1,7 +1,12 @@
 ### Prepares Tests ###
 
 # Fetch packages.
-using Catalyst, LinearAlgebra, NonlinearSolve, OrdinaryDiffEq
+using Catalyst, JumpProcesses, LinearAlgebra, NonlinearSolve, OrdinaryDiffEq, SteadyStateDiffEq, StochasticDiffEq, Test
+
+# Sets stable rng number.
+using StableRNGs
+rng = StableRNG(123456)
+seed = rand(rng, 1:100)
 
 # Fetch test networks.
 include("../test_networks.jl")
@@ -42,17 +47,18 @@ end
 
 # Tests conservation law computation on large number of networks where we know which have conservation laws.
 let
+    # networks for whch we know there is no conservation laws.
     Cs_standard = map(conservationlaws, reaction_networks_standard)
-    @test all(size(C, 1) == 0 for C in Cs_standard)
-
     Cs_hill = map(conservationlaws, reaction_networks_hill)
+    @test all(size(C, 1) == 0 for C in Cs_standard)
     @test all(size(C, 1) == 0 for C in Cs_hill)
 
+    # Networks for which there are known conservation laws (stored in `reaction_network_conslaws`).
     function consequiv(A, B)
         rank([A; B]) == rank(A) == rank(B)
     end
-    Cs_constraint = map(conservationlaws, reaction_networks_constraint)
-    @test all(consequiv.(Matrix{Int}.(Cs_constraint), reaction_network_constraints))
+    Cs_constraint = map(conservationlaws, reaction_networks_conserved)
+    @test all(consequiv.(Matrix{Int}.(Cs_constraint), reaction_network_conslaws))
 end
 
 # Tests additional conservation law-related functions.
@@ -74,8 +80,25 @@ let
     @test count(isequal.(conserved_quantity, Num(0))) == 2
 end
 
+# Tests that `conservationlaws`'s caches something.
+let 
+    # Creates network with/without cached conservation laws.
+    rn = @reaction_network rn begin
+        (k1,k2), X1 <--> X2
+    end
+    rn_cached = deepcopy(rn)
+    conservationlaws(rn_cached)
+    
+    # Checks that equality is correct (currently equality does not consider network property caching).
+    @test rn_cached == rn
+    @test Catalyst.get_networkproperties(rn_cached) != Catalyst.get_networkproperties(rn)
+end
+
+### Simulation & Solving Tests ###
+
 # Test conservation law elimination.
 let
+    # Declares the model
     rn = @reaction_network begin
         (k1, k2), A + B <--> C
         (m1, m2), D <--> E
@@ -83,47 +106,52 @@ let
         b23, F2 --> F3
         b31, F3 --> F1
     end
-    osys = complete(convert(ODESystem, rn; remove_conserved = true))
-    @unpack A, B, C, D, E, F1, F2, F3, k1, k2, m1, m2, b12, b23, b31 = osys
+    @unpack A, B, C, D, E, F1, F2, F3, k1, k2, m1, m2, b12, b23, b31 = rn
+    sps = species(rn)
     u0 = [A => 10.0, B => 10.0, C => 0.0, D => 10.0, E => 0.0, F1 => 8.0, F2 => 0.0,
         F3 => 0.0]
     p = [k1 => 1.0, k2 => 0.1, m1 => 1.0, m2 => 2.0, b12 => 1.0, b23 => 2.0, b31 => 0.1]
     tspan = (0.0, 20.0)
-    oprob = ODEProblem(osys, u0, tspan, p)
-    sol = solve(oprob, Tsit5(); abstol = 1e-10, reltol = 1e-10)
+
+    # Simulates model using ODEs and checks that simulations are identical.
+    osys = complete(convert(ODESystem, rn; remove_conserved = true))
+    oprob1 = ODEProblem(osys, u0, tspan, p)
     oprob2 = ODEProblem(rn, u0, tspan, p)
-    sol2 = solve(oprob2, Tsit5(); abstol = 1e-10, reltol = 1e-10)
     oprob3 = ODEProblem(rn, u0, tspan, p; remove_conserved = true)
-    sol3 = solve(oprob3, Tsit5(); abstol = 1e-10, reltol = 1e-10)
+    osol1 = solve(oprob1, Tsit5(); abstol = 1e-8, reltol = 1e-8, saveat= 0.2)
+    osol2 = solve(oprob2, Tsit5(); abstol = 1e-8, reltol = 1e-8, saveat= 0.2)
+    osol3 = solve(oprob3, Tsit5(); abstol = 1e-8, reltol = 1e-8, saveat= 0.2)
+    @test osol1[sps] ≈ osol2[sps] ≈ osol3[sps]
 
-    tv = range(tspan[1], tspan[2], length = 101)
-    for s in species(rn)
-        @test isapprox(sol(tv, idxs = s), sol2(tv, idxs = s))
-        @test isapprox(sol2(tv, idxs = s), sol2(tv, idxs = s))
-    end
-
+    # Checks that steady states found using nonlinear solving and steady state simulations are identical.
     nsys = complete(convert(NonlinearSystem, rn; remove_conserved = true))
-    nprob = NonlinearProblem{true}(nsys, u0, p)
-    nsol = solve(nprob, NewtonRaphson(); abstol = 1e-10)
-    nprob2 = ODEProblem(rn, u0, (0.0, 100.0 * tspan[2]), p)
-    nsol2 = solve(nprob2, Tsit5(); abstol = 1e-10, reltol = 1e-10)
+    nprob1 = NonlinearProblem{true}(nsys, u0, p)
+    nprob2 = NonlinearProblem(rn, u0, p)
     nprob3 = NonlinearProblem(rn, u0, p; remove_conserved = true)
-    nsol3 = solve(nprob3, NewtonRaphson(); abstol = 1e-10)
-    for s in species(rn)
-        @test isapprox(nsol[s], nsol2(tspan[2], idxs = s))
-        @test isapprox(nsol2(tspan[2], idxs = s), nsol3[s])
-    end
+    ssprob1 = SteadyStateProblem{true}(osys, u0, p)
+    ssprob2 = SteadyStateProblem(rn, u0, p)
+    ssprob3 = SteadyStateProblem(rn, u0, p; remove_conserved = true)
+    nsol1 = solve(nprob1, NewtonRaphson(); abstol = 1e-8)
+    # Nonlinear problems cannot find steady states properly without removing conserved species.
+    nsol3 = solve(nprob3, NewtonRaphson(); abstol = 1e-8)
+    sssol1 = solve(ssprob1, DynamicSS(Tsit5()); abstol = 1e-8, reltol = 1e-8)
+    sssol2 = solve(ssprob2, DynamicSS(Tsit5()); abstol = 1e-8, reltol = 1e-8)
+    sssol3 = solve(ssprob3, DynamicSS(Tsit5()); abstol = 1e-8, reltol = 1e-8)
+    @test nsol1[sps] ≈ nsol3[sps] ≈ sssol1[sps] ≈ sssol2[sps] ≈ sssol3[sps]
 
-    u0 = [A => 100.0, B => 20.0, C => 5.0, D => 10.0, E => 3.0, F1 => 8.0, F2 => 2.0,
+    # Creates SDEProblems using various approaches.
+    u0_sde = [A => 100.0, B => 20.0, C => 5.0, D => 10.0, E => 3.0, F1 => 8.0, F2 => 2.0,
         F3 => 20.0]
     ssys = complete(convert(SDESystem, rn; remove_conserved = true))
-    sprob = SDEProblem(ssys, u0, tspan, p)
-    sprob2 = SDEProblem(rn, u0, tspan, p)
-    sprob3 = SDEProblem(rn, u0, tspan, p; remove_conserved = true)
-    ists = ModelingToolkit.get_unknowns(ssys)
-    sts = ModelingToolkit.get_unknowns(rn)
-    istsidxs = findall(in(ists), sts)
-    u1 = copy(sprob.u0)
+    sprob1 = SDEProblem(ssys, u0_sde, tspan, p)
+    sprob2 = SDEProblem(rn, u0_sde, tspan, p)
+    sprob3 = SDEProblem(rn, u0_sde, tspan, p; remove_conserved = true)
+
+    # Checks that the SDEs f and g function evaluates to the same thing.
+    ind_us = ModelingToolkit.get_unknowns(ssys)
+    us = ModelingToolkit.get_unknowns(rn)
+    ind_uidxs = findall(in(ind_us), us)
+    u1 = copy(sprob1.u0)
     u2 = sprob2.u0
     u3 = copy(sprob3.u0)
     du1 = similar(u1)
@@ -132,19 +160,82 @@ let
     g1 = zeros(length(u1), numreactions(rn))
     g2 = zeros(length(u2), numreactions(rn))
     g3 = zeros(length(u3), numreactions(rn))
-    sprob.f(du1, u1, sprob.p, 1.0)
-    sprob2.f(du2, u2, sprob2.p, 1.0)
-    sprob3.f(du3, u3, sprob3.p, 1.0)
-    @test isapprox(du1, du2[istsidxs])
-    @test isapprox(du2[istsidxs], du3)
-    sprob.g(g1, u1, sprob.p, 1.0)
-    sprob2.g(g2, u2, sprob2.p, 1.0)
-    sprob3.g(g3, u3, sprob3.p, 1.0)
-    @test isapprox(g1, g2[istsidxs, :])
-    @test isapprox(g2[istsidxs, :], g3)
+    sprob1.f(du1, sprob1.u0, sprob1.p, 1.0)
+    sprob2.f(du2, sprob2.u0, sprob2.p, 1.0)
+    sprob3.f(du3, sprob3.u0, sprob3.p, 1.0)
+    @test du1 ≈ du2[ind_uidxs] ≈ du3
+    sprob1.g(g1, sprob1.u0, sprob1.p, 1.0)
+    sprob2.g(g2, sprob2.u0, sprob2.p, 1.0)
+    sprob3.g(g3, sprob3.u0, sprob3.p, 1.0)
+    @test g1 ≈ g2[ind_uidxs, :] ≈ g3
 end
 
-### ConservedParameter Metadata Tests ###
+# Tests simulations for various input types (using X, rn.X, and :X forms).
+# Tests that conservation laws can be generated for system with non-default parameter types.
+let 
+    # Prepares the model.
+    rn = @reaction_network rn begin
+        @parameters kB::Int64 
+        (kB,kD), X + Y <--> XY
+    end
+    sps = species(rn)
+    @unpack kB, kD, X, Y, XY = rn
+
+    # Creates `ODEProblem`s using three types of inputs. Checks that solutions are identical.
+    u0_1 = [X => 2.0, Y => 3.0, XY => 4.0]
+    u0_2 = [rn.X => 2.0, rn.Y => 3.0, rn.XY => 4.0]
+    u0_3 = [:X => 2.0, :Y => 3.0, :XY => 4.0]
+    ps = (kB => 2, kD => 1.5)
+    oprob1 = ODEProblem(rn, u0_1, 10.0, ps; remove_conserved = true)
+    oprob2 = ODEProblem(rn, u0_2, 10.0, ps; remove_conserved = true)
+    oprob3 = ODEProblem(rn, u0_3, 10.0, ps; remove_conserved = true)
+    @test solve(oprob1)[sps] ≈ solve(oprob2)[sps] ≈ solve(oprob3)[sps]
+end
+
+# Tests conservation laws in SDE simulation.
+let
+    # Creates `SDEProblem`s.
+    rn = @reaction_network begin
+        (k1,k2), X1 <--> X2
+    end
+    u0 = Dict([:X1 => 100.0, :X2 => 120.0])
+    ps = [:k1 => 0.2, :k2 => 0.15]
+    sprob = SDEProblem(rn, u0, 10.0, ps; remove_conserved = true)
+
+    # Checks that conservation laws hold in all simulations.
+    sol = solve(sprob, ImplicitEM(); seed)
+    @test sol[:X1] + sol[:X2] ≈ sol[rn.X1 + rn.X2] ≈ fill(u0[:X1] + u0[:X2], length(sol.t))
+end
+
+# Checks that the conservation law parameter's value can be changed in simulations.
+let 
+    # Prepares `ODEProblem`s.
+    rn = @reaction_network begin
+        (k1,k2), X1 <--> X2
+    end
+    osys = complete(convert(ODESystem, rn; remove_conserved = true))
+    u0 = [osys.X1 => 1.0, osys.X2 => 1.0]
+    ps_1 = [osys.k1 => 2.0, osys.k2 => 3.0]
+    ps_2 = [osys.k1 => 2.0, osys.k2 => 3.0, osys.Γ[1] => 4.0]
+    oprob1 = ODEProblem(osys, u0, 10.0, ps_1)
+    oprob2 = ODEProblem(osys, u0, 10.0, ps_2)
+
+    # Checks that the solutions generates the correct conserved quantities.
+    sol1 = solve(oprob1; saveat = 1.0)
+    sol2 = solve(oprob2; saveat = 1.0)
+    @test all(sol1[osys.X1 + osys.X2] .== 2.0)
+    @test all(sol2[osys.X1 + osys.X2] .== 4.0)
+end
+
+### Other Tests ###
+
+# Checks that `JumpSystem`s with conservation laws cannot be generated.
+let
+    rn = @reaction_network begin
+        (k1,k2), X1 <--> X2
+    end
+    @test_throws ArgumentError convert(JumpSystem, rn; remove_conserved = true)
+end
 
 # Checks that `conserved` metadata is added correctly to parameters.
 # Checks that the `isconserved` getter function works correctly.

--- a/test/simulation_and_solving/simulate_ODEs.jl
+++ b/test/simulation_and_solving/simulate_ODEs.jl
@@ -104,7 +104,7 @@ let
         du[2] = -k3 * X2 + k4 * X3 + k1 * X1 - k2 * X2
         du[3] = -k5 * X3 + k6 * X1 + k3 * X2 - k4 * X3
     end
-    push!(catalyst_networks, reaction_networks_constraint[1])
+    push!(catalyst_networks, reaction_networks_conserved[1])
     push!(manual_networks, real_functions_4)
     push!(u0_syms, [:X1, :X2, :X3])
     push!(ps_syms, [:k1, :k2, :k3, :k4, :k5, :k6])

--- a/test/simulation_and_solving/simulate_SDEs.jl
+++ b/test/simulation_and_solving/simulate_SDEs.jl
@@ -107,7 +107,7 @@ let
         du[7, 5] = sqrt(k5 * X5 * X6)
         du[7, 6] = -sqrt(k6 * X7)
     end
-    push!(catalyst_networks, reaction_networks_constraint[9])
+    push!(catalyst_networks, reaction_networks_conserved[9])
     push!(manual_networks, (f = real_f_3, g = real_g_3, nrp = zeros(7, 6)))
     push!(u0_syms, [:X1, :X2, :X3, :X4, :X5, :X6, :X7])
     push!(ps_syms, [:k1, :k2, :k3, :k4, :k5, :k6])

--- a/test/simulation_and_solving/simulate_jumps.jl
+++ b/test/simulation_and_solving/simulate_jumps.jl
@@ -117,7 +117,7 @@ let
     jump_3_5 = ConstantRateJump(rate_3_5, affect_3_5!)
     jump_3_6 = ConstantRateJump(rate_3_6, affect_3_6!)
     jumps_3 = (jump_3_1, jump_3_2, jump_3_3, jump_3_4, jump_3_5, jump_3_6)
-    push!(catalyst_networks, reaction_networks_constraint[5])
+    push!(catalyst_networks, reaction_networks_conserved[5])
     push!(manual_networks, jumps_3)
     push!(u0_syms, [:X1, :X2, :X3, :X4])
     push!(ps_syms, [:k1, :k2, :k3, :k4, :k5, :k6])

--- a/test/test_networks.jl
+++ b/test/test_networks.jl
@@ -3,8 +3,8 @@
 # Declares the vectors which contains the various test sets.
 reaction_networks_standard = Vector{ReactionSystem}(undef, 10)
 reaction_networks_hill = Vector{ReactionSystem}(undef, 10)
-reaction_networks_constraint = Vector{ReactionSystem}(undef, 10)
-reaction_network_constraints = Vector{Matrix{Int}}(undef, 10)
+reaction_networks_conserved = Vector{ReactionSystem}(undef, 10)
+reaction_network_conslaws = Vector{Matrix{Int}}(undef, 10)
 reaction_networks_real = Vector{ReactionSystem}(undef, 4)
 reaction_networks_weird = Vector{ReactionSystem}(undef, 10)
 
@@ -160,69 +160,69 @@ end
 
 ### Reaction networks were some linear combination concentrations remain fixed (steady state values depends on initial conditions). ###
 
-reaction_networks_constraint[1] = @reaction_network rnc1 begin
+reaction_networks_conserved[1] = @reaction_network rnc1 begin
     (k1, k2), X1 ↔ X2
     (k3, k4), X2 ↔ X3
     (k5, k6), X3 ↔ X1
 end
-reaction_network_constraints[1] = [1 1 1]
+reaction_network_conslaws[1] = [1 1 1]
 
-reaction_networks_constraint[2] = @reaction_network rnc2 begin
+reaction_networks_conserved[2] = @reaction_network rnc2 begin
     (k1, k2), X1 ↔ 2X1
     (k3, k4), X1 + X2 ↔ X3
     (k5, k6), X3 ↔ X2
 end
-reaction_network_constraints[2] = [0 1 1]
+reaction_network_conslaws[2] = [0 1 1]
 
-reaction_networks_constraint[3] = @reaction_network rnc3 begin
+reaction_networks_conserved[3] = @reaction_network rnc3 begin
     (k1, k2 * X5), X1 ↔ X2
     (k3 * X5, k4), X3 ↔ X4
     (p + k5 * X2 * X3, d), ∅ ↔ X5
 end
-reaction_network_constraints[3] = [0 0 1 1 0; 1 1 0 0 0]
+reaction_network_conslaws[3] = [0 0 1 1 0; 1 1 0 0 0]
 
-reaction_networks_constraint[4] = @reaction_network rnc4 begin
+reaction_networks_conserved[4] = @reaction_network rnc4 begin
     (k1, k2), X1 + X2 ↔ X3
     (mm(X3, v, K), d), ∅ ↔ X4
 end
-reaction_network_constraints[4] = [0 1 1 0; -1 1 0 0]
+reaction_network_conslaws[4] = [0 1 1 0; -1 1 0 0]
 
-reaction_networks_constraint[5] = @reaction_network rnc5 begin
+reaction_networks_conserved[5] = @reaction_network rnc5 begin
     (k1, k2), X1 ↔ 2X2
     (k3, k4), 2X2 ↔ 3X3
     (k5, k6), 3X3 ↔ 4X4
 end
-reaction_network_constraints[5] = [12 6 4 3]
+reaction_network_conslaws[5] = [12 6 4 3]
 
-reaction_networks_constraint[6] = @reaction_network rnc6 begin
+reaction_networks_conserved[6] = @reaction_network rnc6 begin
     mmr(X1, v1, K1), X1 → X2
     mmr(X2, v2, K2), X2 → X3
     mmr(X3, v3, K3), X3 → X1
 end
-reaction_network_constraints[6] = [1 1 1]
+reaction_network_conslaws[6] = [1 1 1]
 
-reaction_networks_constraint[7] = @reaction_network rnc7 begin
+reaction_networks_conserved[7] = @reaction_network rnc7 begin
     (k1, k2), X1 + X2 ↔ X3
     (mm(X3, v, K), d), ∅ ↔ X2
     (k3, k4), X2 ↔ X4
 end
-reaction_network_constraints[7] = [1 0 1 0]
+reaction_network_conslaws[7] = [1 0 1 0]
 
-reaction_networks_constraint[8] = @reaction_network rnc8 begin
+reaction_networks_conserved[8] = @reaction_network rnc8 begin
     (k1, k2), X1 + X2 ↔ X3
     (mm(X3, v1, K1), mm(X4, v2, K2)), X3 ↔ X4
 end
-reaction_network_constraints[8] = [-1 1 0 0; 0 1 1 1]
+reaction_network_conslaws[8] = [-1 1 0 0; 0 1 1 1]
 
-reaction_networks_constraint[9] = @reaction_network rnc9 begin
+reaction_networks_conserved[9] = @reaction_network rnc9 begin
     (k1, k2), X1 + X2 ↔ X3
     (k3, k4), X3 + X4 ↔ X5
     (k5, k6), X5 + X6 ↔ X7
 end
-reaction_network_constraints[9] = [1 0 1 0 1 0 1; -1 1 0 0 0 0 0; 0 0 0 1 1 0 1;
+reaction_network_conslaws[9] = [1 0 1 0 1 0 1; -1 1 0 0 0 0 0; 0 0 0 1 1 0 1;
                                    0 0 0 0 0 1 1]
 
-reaction_networks_constraint[10] = @reaction_network rnc10 begin
+reaction_networks_conserved[10] = @reaction_network rnc10 begin
     kDeg, (w, w2, w2v, v, w2v2, vP, σB, w2σB) ⟶ ∅
     kDeg, vPp ⟶ phos
     (kBw, kDw), 2w ⟷ w2
@@ -238,7 +238,7 @@ reaction_networks_constraint[10] = @reaction_network rnc10 begin
     λW * v0 * ((1 + F * σB) / (K + σB)), ∅ ⟶ w
     λV * v0 * ((1 + F * σB) / (K + σB)), ∅ ⟶ v
 end;
-reaction_network_constraints[10] = [0 0 0 0 0 0 0 0 1 1]
+reaction_network_conslaws[10] = [0 0 0 0 0 0 0 0 1 1]
 
 ### Reaction networks that are actual models that have been used ###
 
@@ -350,6 +350,6 @@ end
 ### Gathers all netowkrs in a simgle array ###
 reaction_networks_all = [reaction_networks_standard...,
     reaction_networks_hill...,
-    reaction_networks_constraint...,
+    reaction_networks_conserved...,
     reaction_networks_real...,
     reaction_networks_weird...]


### PR DESCRIPTION
Adds additional tests of conservation laws, especially relating to when attempting to simulate them. 

Only non-test change is that 
```julia
convert(JumpSystem, rs; remove_conserved = true)
```
now throws an `ArgumentError` (as opposed to a generic error). The reason was that this was I could write a test to check that it does throw a specific error (and not just one from wrong input).