### PR TITLE
Update warn only

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,7 +41,7 @@ makedocs(sitename = "Catalyst.jl",
     clean = true,
     pages = pages,
     pagesonly = true,
-    warnonly = [:missing_docs])
+    warnonly = [:footnote, :cross_references])
 
 deploydocs(repo = "github.com/SciML/Catalyst.jl.git";
     push_preview = true)


### PR DESCRIPTION
Sorry @isaacsas I messed up when we updated this one. I think the `warnonly` lists the warning types that *does not* generate errors and instead only warnings (with `warnonly = true` being equivalent to listing all).

This update should prevent doc build errors from missing cross_references and footnotes that occur as an entry only. 

For the missing cross_references I plan to make an update today/tomorrow which removes all `[text](@ref ref)` entries. They are meant to mark places where we should put an entry when the doc they reference is added (e.g. Jump performance). However, having a PR which just removes them from the text should be enough, later on, I can just check that one where there were changes and add them back in. 

The footnote thing we use in a few places where there are general references that does not directly fit in, e.g.
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/c19e12ef-762b-4512-a436-3ec44f3b1653)
In the intro to Catalyst for new Julia users doc, so I think that one should probably stay.