### PR TITLE
Fix bug where `expand_registered_functions` mutated original reaction system

### DIFF
--- a/src/registered_functions.jl
+++ b/src/registered_functions.jl
@@ -116,7 +116,7 @@ expand_registered_functions(expr)
 
 Takes an expression, and expands registered function expressions. E.g. `mm(X,v,K)` is replaced with v*X/(X+K). Currently supported functions: `mm`, `mmr`, `hill`, `hillr`, and `hill`.
 """
-function expand_registered_functions(expr)
+function expand_registered_functions!(expr)
     iscall(expr) || return expr
     args = arguments(expr)
     if operation(expr) == Catalyst.mm
@@ -132,13 +132,13 @@ function expand_registered_functions(expr)
                ((args[1])^args[5] + (args[2])^args[5] + (args[4])^args[5])
     end
     for i in 1:length(args)
-        args[i] = expand_registered_functions(args[i])
+        args[i] = expand_registered_functions!(args[i])
     end
     return expr
 end
 # If applied to a Reaction, return a reaction with its rate modified.
 function expand_registered_functions(rx::Reaction)
-    Reaction(expand_registered_functions(rx.rate), rx.substrates, rx.products,
+    Reaction(expand_registered_functions!(deepcopy(rx.rate)), rx.substrates, rx.products,
         rx.substoich, rx.prodstoich, rx.netstoich, rx.only_use_rate, rx.metadata)
 end
 # If applied to a Equation, returns it with it applied to lhs and rhs

--- a/test/reactionsystem_core/custom_crn_functions.jl
+++ b/test/reactionsystem_core/custom_crn_functions.jl
@@ -155,3 +155,17 @@ let
     @test isequal(Catalyst.expand_registered_functions(eq4), 0 ~ V * (K^N) / (X^N + K^N))
     @test isequal(Catalyst.expand_registered_functions(eq5), 0 ~ V * (X^N) / (X^N + Y^N + K^N))
 end
+
+# Ensures that original system is not modified.
+let
+    # Create model with a registered function.
+    @species X(t)
+    @parameters v K
+    rxs = [Reaction(mm(X,v,K), [], [X])]
+    @named rs = ReactionSystem(rxs, t)
+
+    # Check that `expand_registered_functions` does not mutate original model.
+    rs_expanded_funcs = Catalyst.expand_registered_functions(rs)
+    @test isequal(only(Catalyst.get_rxs(rs)).rate, Catalyst.mm(X,v,K))
+    @test isequal(only(Catalyst.get_rxs(rs_expanded_funcs)).rate, v*X/(X + K))
+end


### PR DESCRIPTION
Previously `expand_registered_functions` would unintentionally apply the operation on the input system. E.g.
```julia
rs_expanded_funcs = Catalyst.expand_registered_functions(rs)
```
would result in both `rs` and `rs_expanded_funcs` having their functions expanded. This fixes this, and adds a test to ensure this remains the case.
