### PR TITLE
[v14 - Ready] Fixes latexify tests

### DIFF
--- a/test/visualisation/latexify.jl
+++ b/test/visualisation/latexify.jl
@@ -29,6 +29,8 @@ include("../test_networks.jl")
 ### Just be sure to remove all such macros before you commit a change since it
 ### will cause issues with Travis.
 
+# Generally, for all latexify tests, the lines after `@test latexify(rn) == replace(` must
+# start without any tabs, hence the somewhat weird formatting.
 
 ### Basic Tests ###
 
@@ -48,68 +50,68 @@ let
         (d1,d2,d3,d4,d5,d6), (X1,X2,X3,X4,X5,X6)  ⟶ ∅
     end
 
-    # Latexify.@generate_test latexify(rn)
-    @test_broken latexify(rn; expand_functions = false) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
-    \varnothing &\xrightarrow{\mathrm{hill}\left( X5, v2, K2, n2 \right)} \mathrm{X2} \\
-    \varnothing &\xrightarrow{\mathrm{hill}\left( X3, v3, K3, n3 \right)} \mathrm{X3} \\
-    \varnothing &\xrightarrow{\mathrm{hillr}\left( X1, v4, K4, n4 \right)} \mathrm{X4} \\
-    \varnothing &\xrightarrow{\mathrm{hill}\left( X2, v5, K5, n5 \right)} \mathrm{X5} \\
-    \varnothing &\xrightarrow{\mathrm{hillar}\left( X1, X6, v6, K6, n6 \right)} \mathrm{X6} \\
-    \mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
-    \mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
-    3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
-    \mathrm{X1} &\xrightarrow{d1} \varnothing \\
-    \mathrm{X2} &\xrightarrow{d2} \varnothing \\
-    \mathrm{X3} &\xrightarrow{d3} \varnothing \\
-    \mathrm{X4} &\xrightarrow{d4} \varnothing \\
-    \mathrm{X5} &\xrightarrow{d5} \varnothing \\
-    \mathrm{X6} &\xrightarrow{d6} \varnothing  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    # Latexify.@generate_test latexify(rn; expand_functions = false)
+    @test latexify(rn; expand_functions = false) == replace(
+raw"\begin{align*}
+\varnothing &\xrightarrow{\mathrm{hillr}\left( X2, v1, K1, n1 \right) \mathrm{hill}\left( X4, v1, K1, n1 \right)} \mathrm{X1} \\
+\varnothing &\xrightarrow{\mathrm{hill}\left( X5, v2, K2, n2 \right)} \mathrm{X2} \\
+\varnothing &\xrightarrow{\mathrm{hill}\left( X3, v3, K3, n3 \right)} \mathrm{X3} \\
+\varnothing &\xrightarrow{\mathrm{hillr}\left( X1, v4, K4, n4 \right)} \mathrm{X4} \\
+\varnothing &\xrightarrow{\mathrm{hill}\left( X2, v5, K5, n5 \right)} \mathrm{X5} \\
+\varnothing &\xrightarrow{\mathrm{hillar}\left( X1, X6, v6, K6, n6 \right)} \mathrm{X6} \\
+\mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
+\mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
+3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
+\mathrm{X1} &\xrightarrow{d1} \varnothing \\
+\mathrm{X2} &\xrightarrow{d2} \varnothing \\
+\mathrm{X3} &\xrightarrow{d3} \varnothing \\
+\mathrm{X4} &\xrightarrow{d4} \varnothing \\
+\mathrm{X5} &\xrightarrow{d5} \varnothing \\
+\mathrm{X6} &\xrightarrow{d6} \varnothing  
+ \end{align*}
+", "\r\n"=>"\n")
 
-    #Latexify.@generate_test latexify(rn; expand_functions=false)
-    @test_broken latexify(rn; expand_functions = false) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
-    \varnothing &\xrightarrow{\mathrm{mm}\left( X5, v2, K2 \right)} \mathrm{X2} \\
-    \varnothing &\xrightarrow{\mathrm{mmr}\left( X3, v3, K3 \right)} \mathrm{X3} \\
-    \varnothing &\xrightarrow{\mathrm{hillr}\left( X1, v4, K4, n4 \right)} \mathrm{X4} \\
-    \varnothing &\xrightarrow{\mathrm{hill}\left( X2, v5, K5, n5 \right)} \mathrm{X5} \\
-    \varnothing &\xrightarrow{\mathrm{hillar}\left( X1, X6, v6, K6, n6 \right)} \mathrm{X6} \\
-    \mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
-    \mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
-    3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
-    \mathrm{X1} &\xrightarrow{d1} \varnothing \\
-    \mathrm{X2} &\xrightarrow{d2} \varnothing \\
-    \mathrm{X3} &\xrightarrow{d3} \varnothing \\
-    \mathrm{X4} &\xrightarrow{d4} \varnothing \\
-    \mathrm{X5} &\xrightarrow{d5} \varnothing \\
-    \mathrm{X6} &\xrightarrow{d6} \varnothing  
-    \end{align*}
-    ", "\r\n"=>"\n")
-
-    # Latexify.@generate_test latexify(rn, mathjax=false)
-    @test_broken latexify(rn, mathjax = false) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
-    \varnothing &\xrightarrow{\frac{X5 v2}{K2 + X5}} \mathrm{X2} \\
-    \varnothing &\xrightarrow{\frac{K3 v3}{K3 + X3}} \mathrm{X3} \\
-    \varnothing &\xrightarrow{\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}} \mathrm{X4} \\
-    \varnothing &\xrightarrow{\frac{v5 X2^{n5}}{X2^{n5} + K5^{n5}}} \mathrm{X5} \\
-    \varnothing &\xrightarrow{\frac{v6 X1^{n6}}{X6^{n6} + K6^{n6} + X1^{n6}}} \mathrm{X6} \\
-    \mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
-    \mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
-    3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
-    \mathrm{X1} &\xrightarrow{d1} \varnothing \\
-    \mathrm{X2} &\xrightarrow{d2} \varnothing \\
-    \mathrm{X3} &\xrightarrow{d3} \varnothing \\
-    \mathrm{X4} &\xrightarrow{d4} \varnothing \\
-    \mathrm{X5} &\xrightarrow{d5} \varnothing \\
-    \mathrm{X6} &\xrightarrow{d6} \varnothing  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    # Latexify.@generate_test latexify(rn; expand_functions = true)
+    @test latexify(rn; expand_functions = true) == replace(
+raw"\begin{align*}
+\varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
+\varnothing &\xrightarrow{\frac{v2 X5^{n2}}{X5^{n2} + K2^{n2}}} \mathrm{X2} \\
+\varnothing &\xrightarrow{\frac{v3 X3^{n3}}{X3^{n3} + K3^{n3}}} \mathrm{X3} \\
+\varnothing &\xrightarrow{\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}} \mathrm{X4} \\
+\varnothing &\xrightarrow{\frac{v5 X2^{n5}}{X2^{n5} + K5^{n5}}} \mathrm{X5} \\
+\varnothing &\xrightarrow{\frac{v6 X1^{n6}}{X6^{n6} + K6^{n6} + X1^{n6}}} \mathrm{X6} \\
+\mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
+\mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
+3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
+\mathrm{X1} &\xrightarrow{d1} \varnothing \\
+\mathrm{X2} &\xrightarrow{d2} \varnothing \\
+\mathrm{X3} &\xrightarrow{d3} \varnothing \\
+\mathrm{X4} &\xrightarrow{d4} \varnothing \\
+\mathrm{X5} &\xrightarrow{d5} \varnothing \\
+\mathrm{X6} &\xrightarrow{d6} \varnothing  
+ \end{align*}
+", "\r\n"=>"\n")
+        
+    # Latexify.@generate_test latexify(rn, mathjax = false)
+    @test latexify(rn, mathjax = false) == replace(
+raw"\begin{align*}
+\varnothing &\xrightarrow{\frac{X4^{n1} v1^{2} K1^{n1}}{\left( K1^{n1} + X4^{n1} \right) \left( K1^{n1} + X2^{n1} \right)}} \mathrm{X1} \\
+\varnothing &\xrightarrow{\frac{v2 X5^{n2}}{X5^{n2} + K2^{n2}}} \mathrm{X2} \\
+\varnothing &\xrightarrow{\frac{v3 X3^{n3}}{X3^{n3} + K3^{n3}}} \mathrm{X3} \\
+\varnothing &\xrightarrow{\frac{v4 K4^{n4}}{K4^{n4} + X1^{n4}}} \mathrm{X4} \\
+\varnothing &\xrightarrow{\frac{v5 X2^{n5}}{X2^{n5} + K5^{n5}}} \mathrm{X5} \\
+\varnothing &\xrightarrow{\frac{v6 X1^{n6}}{X6^{n6} + K6^{n6} + X1^{n6}}} \mathrm{X6} \\
+\mathrm{X2} &\xrightleftharpoons[k2]{k1} \mathrm{X1} + 2 \mathrm{X4} \\
+\mathrm{X4} &\xrightleftharpoons[k4]{k3} \mathrm{X3} \\
+3 \mathrm{X5} + \mathrm{X1} &\xrightleftharpoons[k6]{k5} \mathrm{X2} \\
+\mathrm{X1} &\xrightarrow{d1} \varnothing \\
+\mathrm{X2} &\xrightarrow{d2} \varnothing \\
+\mathrm{X3} &\xrightarrow{d3} \varnothing \\
+\mathrm{X4} &\xrightarrow{d4} \varnothing \\
+\mathrm{X5} &\xrightarrow{d5} \varnothing \\
+\mathrm{X6} &\xrightarrow{d6} \varnothing  
+ \end{align*}
+", "\r\n"=>"\n")
 end
 
 # Tests basic functions on simple network (2).
@@ -121,22 +123,22 @@ let
     end
 
     # Latexify.@generate_test latexify(rn)
-    @test_broken latexify(rn) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightleftharpoons[d_{a}]{\frac{p_{a} B^{n}}{k^{n} + B^{n}}} \mathrm{A} \\
-    \varnothing &\xrightleftharpoons[d_{b}]{p_{b}} \mathrm{B} \\
-    3 \mathrm{B} &\xrightleftharpoons[r_{b}]{r_{a}} \mathrm{A}  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    @test latexify(rn) == replace(
+raw"\begin{align*}
+\varnothing &\xrightleftharpoons[d_{a}]{\frac{p_{a} B^{n}}{k^{n} + B^{n}}} \mathrm{A} \\
+\varnothing &\xrightleftharpoons[d_{b}]{p_{b}} \mathrm{B} \\
+3 \mathrm{B} &\xrightleftharpoons[r_{b}]{r_{a}} \mathrm{A}  
+ \end{align*}
+", "\r\n"=>"\n")
 
-    # Latexify.@generate_test latexify(rn, mathjax=false)
-    @test_broken latexify(rn, mathjax = false) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightleftharpoons[d_{a}]{\frac{p_{a} B^{n}}{k^{n} + B^{n}}} \mathrm{A} \\
-    \varnothing &\xrightleftharpoons[d_{b}]{p_{b}} \mathrm{B} \\
-    3 \mathrm{B} &\xrightleftharpoons[r_{b}]{r_{a}} \mathrm{A}  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    # Latexify.@generate_test latexify(rn, mathjax = false)
+    @test latexify(rn, mathjax = false) == replace(
+raw"\begin{align*}
+\varnothing &\xrightleftharpoons[d_{a}]{\frac{p_{a} B^{n}}{k^{n} + B^{n}}} \mathrm{A} \\
+\varnothing &\xrightleftharpoons[d_{b}]{p_{b}} \mathrm{B} \\
+3 \mathrm{B} &\xrightleftharpoons[r_{b}]{r_{a}} \mathrm{A}  
+ \end{align*}
+", "\r\n"=>"\n")
 end
 
 # Tests for system with parametric stoichiometry.
@@ -144,12 +146,26 @@ let
     rn = @reaction_network begin
         p, 0 --> (m + n)*X
     end
-    
-    @test_broken latexify(rn) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightarrow{p} (m + n)\mathrm{X}  
-     \end{align*}
-    ", "\r\n"=>"\n")
+
+    # Latexify.@generate_test latexify(rn)
+    @test latexify(rn) == replace(
+raw"\begin{align*}
+\varnothing &\xrightarrow{p} (m + n)\mathrm{X}  
+ \end{align*}
+", "\r\n"=>"\n")
+end
+
+# Checks for systems with vector species/parameters.
+# Technically tests would work, however, the display is non-ideal (https://github.com/SciML/Catalyst.jl/issues/932, https://github.com/JuliaSymbolics/Symbolics.jl/issues/1167).
+let
+    rn = @reaction_network begin
+        @parameters k[1:2] x[1:2] [isconstantspecies=true]
+        @species (X(t))[1:2] (K(t))[1:2]
+        (k[1]*K[1],k[2]*K[2]), X[1] + x[1] <--> X[2] + x[2]
+    end
+
+    # Latexify.@generate_test latexify(rn)
+    @test_broken false
 end
 
 ### Tests the `form` Option ###
@@ -170,21 +186,15 @@ let
     end
 
     # Latexify.@generate_test latexify(rn; form=:ode)
-    @test_broken latexify(rn; form = :ode) == replace(
-    raw"$\begin{align}
-    \frac{\mathrm{d} X\left( t \right)}{\mathrm{d}t} =& p - \left( X\left( t \right) \right)^{2} kB - d X\left( t \right) + 2 kD \mathrm{X2}\left( t \right) \\
-    \frac{\mathrm{d} \mathrm{X2}\left( t \right)}{\mathrm{d}t} =& \frac{1}{2} \left( X\left( t \right) \right)^{2} kB - kD \mathrm{X2}\left( t \right)
-    \end{align}
-    $", "\r\n"=>"\n")
+    @test latexify(rn; form = :ode) == replace(
+raw"$\begin{align}
+\frac{\mathrm{d} X\left( t \right)}{\mathrm{d}t} =& p - d X\left( t \right) + 2 kD \mathrm{X2}\left( t \right) - \left( X\left( t \right) \right)^{2} kB \\
+\frac{\mathrm{d} \mathrm{X2}\left( t \right)}{\mathrm{d}t} =&  - kD \mathrm{X2}\left( t \right) + \frac{1}{2} \left( X\left( t \right) \right)^{2} kB
+\end{align}
+$", "\r\n"=>"\n")
 
-    # Currently latexify doesn't handle SDE systems properly, and they look identical to ode systems.
-    # The "==" shoudl be a "!=", but due to latexify tests not working, for the broken test to work, I changed it.
-    @test_broken latexify(rn; form=:sde) == replace(
-    raw"$\begin{align}
-    \frac{\mathrm{d} X\left( t \right)}{\mathrm{d}t} =& p - \left( X\left( t \right) \right)^{2} kB - d X\left( t \right) + 2 kD \mathrm{X2}\left( t \right) \\
-    \frac{\mathrm{d} \mathrm{X2}\left( t \right)}{\mathrm{d}t} =& \frac{1}{2} \left( X\left( t \right) \right)^{2} kB - kD \mathrm{X2}\left( t \right)
-    \end{align}
-    $", "\r\n"=>"\n")
+    # Currently latexify doesn't handle SDE systems properly, and they look identical to ode systems (https://github.com/SciML/ModelingToolkit.jl/issues/2782).
+    @test_broken false
 
     # Tests that erroneous form gives error.
     @test_throws ErrorException latexify(rn; form=:xxx)
@@ -229,14 +239,15 @@ let
     end
 
     # Latexify.@generate_test latexify(rn)
-    @test_broken latexify(rn) == replace(
-    raw"\begin{align*}
-    \varnothing &\xrightarrow{p} (m + n)\mathrm{X}  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    @test latexify(rn) == replace(
+raw"\begin{align*}
+\mathrm{Y} &\xrightarrow{Y k} \varnothing  
+ \end{align*}
+", "\r\n"=>"\n")
 end
 
 # Checks when combined with equations (nonlinear system).
+# Technically tests would work, however, the display is non-ideal (https://github.com/SciML/Catalyst.jl/issues/927).
 let
     t = default_t()
     base_network = @reaction_network begin
@@ -247,18 +258,8 @@ let
     extended = extend(decaying_rate, base_network)
 
     # Latexify.@generate_test latexify(extended)
-    @test_broken latexify(extended) == replace(
-    raw"\begin{align*}
-    \mathrm{X} &\xrightarrow{k r} \varnothing  
-    0 &= -1 - x\left( t \right)  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    @test_broken false
 
     # Latexify.@generate_test latexify(extended, mathjax=false)
-    @test_broken latexify(extended, mathjax = false) == replace(
-    raw"\begin{align*}
-    \mathrm{X} &\xrightarrow{k r} \varnothing  
-    0 &= -1 - x\left( t \right)  
-    \end{align*}
-    ", "\r\n"=>"\n")
+    @test_broken false
 end


### PR DESCRIPTION
Fixes the latexify tests. Mostly the errors were due to tabs.

There are a couple that we technically can generate passing tests for, however, the display is non-desired (for various reasons). For these I have just created a `test_broken` and linked the relevant issue.

The display of the tests that are marked as passing looks fine:
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/82a47c82-2eae-43dc-bde7-60e8a1e29253)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/d4947879-cfac-4d55-9ce1-7f1538f95721)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/dbfec74d-2b54-4a44-8d39-5a16543f1a4c)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/88b72eae-8b43-462b-8111-6c44c9f6a030)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/f98801d9-3452-4c0e-90a1-bd41b926fc3c)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/4c44508b-5589-4b5b-b18d-bf82fd4688ca)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/2e0989b8-ed58-46dd-899a-ed3279dd9704)
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/732b61fd-6107-461a-afcb-01164d4fae95)

