### PR TITLE
Handle figure in Catalyst introduction which affects build times

### DIFF
--- a/docs/src/introduction_to_catalyst/introduction_to_catalyst.md
+++ b/docs/src/introduction_to_catalyst/introduction_to_catalyst.md
@@ -196,7 +196,9 @@ jprob = JumpProblem(repressilator, dprob, Direct(), save_positions=(false,false)
 # now, let's solve and plot the jump process:
 sol = solve(jprob, SSAStepper(), saveat=10.)
 plot(sol)
+nothing # hide
 ```
+![Repressilator SSA Simulation](../assets/long_ploting_times/introduction_repressilator_ssa.svg)
 
 We see that oscillations remain, but become much noisier. Note, in constructing
 the `JumpProblem` we could have used any of the SSAs that are part of JumpProcesses


### PR DESCRIPTION
Doc build times have increased recently, and I narrowed it down pretty much to this figure in the introduction to catalyst page:
![image](https://github.com/SciML/Catalyst.jl/assets/18099310/5a9581c0-de5e-4733-a3bf-6c2195c97fdf)

Basically, the rendering of large figures using e.g. `plot` can really increase doc build times disproportionally. Right now I simply replaced it with a version already generated and saved from file (which admittedly means that the display is not built dynamically). An alternative would be to reduce the sampling (which has already been reduced, probably for this purpose). However, to have a significant effect, I think we would have to reduce it enough that one really see an effect in the plot.

Something should be done though. This small change reduced my local build time from almost 700 seconds to just under 90 seconds (!). The impact on the GitHub build time will probably be a bit less pronounced (but likely higher once the caching fix is incorporated). And quick local build times are also useful when developing docs.
