### PR TITLE
Revert SDE change

### DIFF
--- a/src/reactionsystem_conversions.jl
+++ b/src/reactionsystem_conversions.jl
@@ -109,7 +109,7 @@ function assemble_diffusion(rs, sts, ispcs; combinatoric_ratelaws = true,
     num_bcsts = count(isbc, get_unknowns(rs))
 
     # we make a matrix sized by the number of reactions
-    eqs = Matrix{Num}(undef, length(sts) + num_bcsts, length(get_rxs(rs)))
+    eqs = Matrix{Any}(undef, length(sts) + num_bcsts, length(get_rxs(rs)))
     eqs .= 0
     species_to_idx = Dict((x => i for (i, x) in enumerate(ispcs)))
     nps = get_networkproperties(rs)


### PR DESCRIPTION
Currently, MTK requires a matrix to be `Matrix{Num}`, which is not good. However, and update which changes so that `Matrix{Any}` will work again seems like it is out soon. When it is we can merge this and things should be all good again.