### PR TITLE
make `t` a parameter now

### DIFF
--- a/docs/src/model_creation/model_file_loading_and_export.md
+++ b/docs/src/model_creation/model_file_loading_and_export.md
@@ -30,7 +30,7 @@ Here, `include` is used to execute the Julia code from any file. This means that
 let
 
 # Independent variable:
-@variables t
+@parameters t
 
 # Parameters:
 ps = @parameters kB kD kP
@@ -52,7 +52,7 @@ complete(rs)
 end
 ```
 !!! note
-    The code that `save_reactionsystem` prints uses [programmatic modelling](@ref programmatic_CRN_construction) to generate the written model. 
+    The code that `save_reactionsystem` prints uses [programmatic modelling](@ref programmatic_CRN_construction) to generate the written model.
 
 In addition to transferring models between Julia sessions, the `save_reactionsystem` function can also be used or print a model to a text file where you can easily inspect its components.
 
@@ -76,7 +76,7 @@ A general-purpose format for storing CRN models is so-called .net files. These c
 using ReactionNetworkImporters
 prn = loadrxnetwork(BNGNetwork(), "repressilator.net")
 ```
-Here, .net files not only contain information regarding the reaction network itself, but also the numeric values (initial conditions and parameter values) required for simulating it. Hence, `loadrxnetwork` generates a `ParsedReactionNetwork` structure, containing all this information. You can access the model as `prn.rn`, the initial conditions as `prn.u0`, and the parameter values as `prn.p`. Furthermore, these initial conditions and parameter values are also made [*default* values](@ref dsl_advanced_options_default_vals) of the model. 
+Here, .net files not only contain information regarding the reaction network itself, but also the numeric values (initial conditions and parameter values) required for simulating it. Hence, `loadrxnetwork` generates a `ParsedReactionNetwork` structure, containing all this information. You can access the model as `prn.rn`, the initial conditions as `prn.u0`, and the parameter values as `prn.p`. Furthermore, these initial conditions and parameter values are also made [*default* values](@ref dsl_advanced_options_default_vals) of the model.
 
 A parsed reaction network's content can then be provided to various problem types for simulation. E.g. here we perform an ODE simulation of our repressilator model:
 ```julia
@@ -128,7 +128,7 @@ Above, we described how to use SBMLImporter to import SBML files. Alternatively,
 While CRN models can be represented through various file formats, they can also be represented in various matrix forms. E.g. a CRN with $m$ species and $n$ reactions (and with constant rates) can be represented with either
 - An $mxn$ substrate matrix (with each species's substrate stoichiometry in each reaction) and an $nxm$ product matrix (with each species's product stoichiometry in each reaction).
 
-Or 
+Or
 - An $mxn$ complex stoichiometric matrix (...) and a $2mxn$ incidence matrix (...).
 
 The advantage of these forms is that they offer a compact and very general way to represent a large class of CRNs. ReactionNetworkImporters have the functionality for converting matrices of these forms directly into Catalyst `ReactionSystem` models. Instructions on how to do this are available in [ReactionNetworkImporter's documentation](https://docs.sciml.ai/ReactionNetworkImporters/stable/#Loading-a-matrix-representation).

--- a/ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl
+++ b/ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl
@@ -1,17 +1,17 @@
 ### Structural Identifiability ODE Creation ###
 
-# For a reaction system, list of measured quantities and known parameters, generate a StructuralIdentifiability compatible ODE. 
+# For a reaction system, list of measured quantities and known parameters, generate a StructuralIdentifiability compatible ODE.
 """
 make_si_ode(rs::ReactionSystem; measured_quantities=observed(rs), known_p = [], ignore_no_measured_warn=false)
 
-Creates a reaction rate equation ODE system of the form used within the StructuralIdentifiability.jl package. The output system is compatible with all StructuralIdentifiability functions. 
+Creates a reaction rate equation ODE system of the form used within the StructuralIdentifiability.jl package. The output system is compatible with all StructuralIdentifiability functions.
 
 Arguments:
 - `rs::ReactionSystem`; The reaction system we wish to convert to an ODE.
-- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.x`, or the symbol `:x`). 
+- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.x`, or the symbol `:x`).
 - `known_p = []`: List of parameters for which their values are assumed to be known.
-- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty. 
-- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly). 
+- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
+- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
 
 Example:
 ```julia
@@ -45,10 +45,10 @@ Applies StructuralIdentifiability.jl's `assess_local_identifiability` function t
 
 Arguments:
 - `rs::ReactionSystem`; The reaction system for which we wish to compute structural identifiability of the associated reaction rate equation ODE model.
-- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.s`, or the symbol `:x`). 
-- `known_p = []`: List of parameters which values are known. 
-- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty. 
-- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly). 
+- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.s`, or the symbol `:x`).
+- `known_p = []`: List of parameters which values are known.
+- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
+- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
 
 Example:
 ```julia
@@ -85,10 +85,10 @@ Applies StructuralIdentifiability.jl's `assess_identifiability` function to a Ca
 
 Arguments:
 - `rs::ReactionSystem`; The reaction system we wish to compute structural identifiability for.
-- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.s`, or the symbol `:x`). 
-- `known_p = []`: List of parameters which values are known. 
-- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty. 
-- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly). 
+- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.s`, or the symbol `:x`).
+- `known_p = []`: List of parameters which values are known.
+- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
+- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
 
 Example:
 ```julia
@@ -125,10 +125,10 @@ Applies StructuralIdentifiability.jl's `find_identifiable_functions` function to
 
 Arguments:
 - `rs::ReactionSystem`; The reaction system we wish to compute structural identifiability for.
-- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.s`, or the symbol `:x`). 
-- `known_p = []`: List of parameters which values are known. 
-- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty. 
-- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly). 
+- `measured_quantities=[]`: The quantities of the system we can measure. May either be equations (e.g. `x1 + x2`), or single species (e.g. the symbolic `x`, `rs.s`, or the symbol `:x`).
+- `known_p = []`: List of parameters which values are known.
+- `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
+- `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
 
 Example:
 ```julia
@@ -158,7 +158,7 @@ end
 
 ### Helper Functions ###
 
-# From a reaction system, creates the corresponding MTK-style ODESystem for SI application 
+# From a reaction system, creates the corresponding MTK-style ODESystem for SI application
 # Also compute the, later needed, conservation law equations and list of system symbols (unknowns and parameters).
 function make_osys(rs::ReactionSystem; remove_conserved = true)
     # Creates the ODESystem corresponding to the ReactionSystem (expanding functions and flattening it).
@@ -200,7 +200,7 @@ function make_measured_quantities(
 
     # Creates one internal observation variable for each measured quantity (`___internal_observables`).
     # Creates a vector of equations, setting each measured quantity equal to one observation variable.
-    @variables t (___internal_observables(Catalyst.get_iv(rs)))[1:length(mqs)]
+    @variables (___internal_observables(Catalyst.get_iv(rs)))[1:length(mqs)]
     return Equation[(q isa Equation) ? q : (___internal_observables[i] ~ q)
                     for (i, q) in enumerate(mqs)]
 end

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -324,10 +324,10 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
     if haskey(options, :ivs)
         ivs = Tuple(extract_syms(options, :ivs))
         ivexpr = copy(options[:ivs])
-        ivexpr.args[1] = Symbol("@", "variables")
+        ivexpr.args[1] = Symbol("@", "parameters")
     else
         ivs = (DEFAULT_IV_SYM,)
-        ivexpr = :(@variables $(DEFAULT_IV_SYM))
+        ivexpr = :($(DEFAULT_IV_SYM) = default_t())
     end
     tiv = ivs[1]
     sivs = (length(ivs) > 1) ? Expr(:vect, ivs[2:end]...) : nothing
@@ -877,7 +877,7 @@ function make_reaction(ex::Expr)
     sexprs = get_sexpr(species, Dict{Symbol, Expr}())
     pexprs = get_pexpr(parameters, Dict{Symbol, Expr}())
     rxexpr = get_rxexprs(reaction)
-    iv = :(@variables $(DEFAULT_IV_SYM))
+    iv = :($(DEFAULT_IV_SYM) = default_t())
 
     # Returns the rephrased expression.
     quote

--- a/src/reactionsystem_serialisation/serialise_fields.jl
+++ b/src/reactionsystem_serialisation/serialise_fields.jl
@@ -8,7 +8,7 @@ end
 # Extract a string which declares the system's independent variable.
 function get_iv_string(rn::ReactionSystem)
     iv_dec = MT.get_iv(rn)
-    return "@variables $(iv_dec)"
+    return "@parameters $(iv_dec)"
 end
 
 # Creates an annotation for the system's independent variable.
@@ -92,12 +92,12 @@ function handle_us_n_ps(file_text::String, rn::ReactionSystem, annotate::Bool,
 
         # Pre-declares the sets with written/remaining parameters/species/variables.
         # Whenever all/none are written depends on whether there were any initial dependencies.
-        # `deepcopy` is required as these get mutated by `dependency_split!`. 
+        # `deepcopy` is required as these get mutated by `dependency_split!`.
         remaining_ps = (p_deps ? deepcopy(ps_all) : [])
         remaining_sps = (sp_deps ? deepcopy(sps_all) : [])
         remaining_vars = (var_deps ? deepcopy(vars_all) : [])
 
-        # Iteratively loops through all parameters, species, and/or variables. In each iteration, 
+        # Iteratively loops through all parameters, species, and/or variables. In each iteration,
         # adds the declaration of those that can still be declared.
         while !(isempty(remaining_ps) && isempty(remaining_sps) && isempty(remaining_vars))
             # Checks which parameters/species/variables can be written. The `dependency_split`
@@ -145,7 +145,7 @@ function seri_has_parameters(rn::ReactionSystem)
     return !isempty(get_ps(rn))
 end
 
-# Extract a string which declares the system's parameters. Uses multiline declaration (a 
+# Extract a string which declares the system's parameters. Uses multiline declaration (a
 # `begin ... end` block) if more than 3 parameters have a "complicated" declaration (if they
 # have metadata, default value, or type designation).
 function get_parameters_string(ps)
@@ -167,7 +167,7 @@ function seri_has_species(rn::ReactionSystem)
     return !isempty(get_species(rn))
 end
 
-# Extract a string which declares the system's species. Uses multiline declaration (a 
+# Extract a string which declares the system's species. Uses multiline declaration (a
 # `begin ... end` block) if more than 3 species have a "complicated" declaration (if they
 # have metadata, default value, or type designation).
 function get_species_string(sps)
@@ -189,7 +189,7 @@ function seri_has_variables(rn::ReactionSystem)
     return length(get_unknowns(rn)) > length(get_species(rn))
 end
 
-# Extract a string which declares the system's variables. Uses multiline declaration (a 
+# Extract a string which declares the system's variables. Uses multiline declaration (a
 # `begin ... end` block) if more than 3 variables have a "complicated" declaration (if they
 # have metadata, default value, or type designation).
 function get_variables_string(vars)
@@ -222,7 +222,7 @@ function get_reactions_string(rn::ReactionSystem)
         return "rxs = [$(reaction_string(get_rxs(rn)[1], strip_call_dict))]"
     end
 
-    # Creates the string corresponding to the code which generates the system's reactions. 
+    # Creates the string corresponding to the code which generates the system's reactions.
     rxs_string = "rxs = ["
     for rx in get_rxs(rn)
         @string_append! rxs_string "\n\t"*reaction_string(rx, strip_call_dict) ","
@@ -286,7 +286,7 @@ function get_equations_string(rn::ReactionSystem)
         return "eqs = [$(expression_2_string(get_eqs(rn)[end]; strip_call_dict))]"
     end
 
-    # Creates the string corresponding to the code which generates the system's reactions. 
+    # Creates the string corresponding to the code which generates the system's reactions.
     eqs_string = "eqs = ["
     for eq in get_eqs(rn)[(length(get_rxs(rn)) + 1):end]
         @string_append! eqs_string "\n\t" expression_2_string(eq; strip_call_dict) ","
@@ -392,7 +392,7 @@ function get_continuous_events_string(rn::ReactionSystem)
         return "continuous_events = [$(continuous_event_string(MT.get_continuous_events(rn)[1], strip_call_dict))]"
     end
 
-    # Creates the string corresponding to the code which generates the system's reactions. 
+    # Creates the string corresponding to the code which generates the system's reactions.
     continuous_events_string = "continuous_events = ["
     for continuous_event in MT.get_continuous_events(rn)
         @string_append! continuous_events_string "\n\t" continuous_event_string(
@@ -450,7 +450,7 @@ function get_discrete_events_string(rn::ReactionSystem)
         return "discrete_events = [$(discrete_event_string(MT.get_discrete_events(rn)[1], strip_call_dict))]"
     end
 
-    # Creates the string corresponding to the code which generates the system's reactions. 
+    # Creates the string corresponding to the code which generates the system's reactions.
     discrete_events_string = "discrete_events = ["
     for discrete_event in MT.get_discrete_events(rn)
         @string_append! discrete_events_string "\n\t" discrete_event_string(
@@ -493,7 +493,7 @@ DISCRETE_EVENTS_FS = (seri_has_discrete_events, get_discrete_events_string,
 ### Handles Systems ###
 
 # Specific `push_field` function, which is used for the system field (where the annotation option
-# must be passed to the `get_component_string` function). Since non-ReactionSystem systems cannot be 
+# must be passed to the `get_component_string` function). Since non-ReactionSystem systems cannot be
 # written to file, this function throws an error if any such systems are encountered.
 function push_systems_field(file_text::String, rn::ReactionSystem, annotate::Bool,
         top_level::Bool)

--- a/src/spatial_reaction_systems/spatial_reactions.jl
+++ b/src/spatial_reaction_systems/spatial_reactions.jl
@@ -59,7 +59,7 @@ function make_transport_reaction(rateex, species)
     # Creates expressions corresponding to actual code from the internal DSL representation.
     sexprs = get_sexpr([species], Dict{Symbol, Expr}())
     pexprs = get_pexpr(parameters, Dict{Symbol, Expr}())
-    iv = :(@variables $(DEFAULT_IV_SYM))
+    iv = :($(DEFAULT_IV_SYM) = default_t())
     trxexpr = :(TransportReaction($rateex, $species))
 
     # Appends `edgeparameter` metadata to all declared parameters.
@@ -86,12 +86,12 @@ function check_spatial_reaction_validity(rs::ReactionSystem, tr::TransportReacti
         edge_parameters = [])
     # Checks that the species exist in the reaction system.
     # (ODE simulation code becomes difficult if this is not required,
-    # as non-spatial jacobian and f function generated from rs are of the wrong size).  
+    # as non-spatial jacobian and f function generated from rs are of the wrong size).
     if !any(isequal(tr.species), species(rs))
         error("Currently, species used in TransportReactions must have previously been declared within the non-spatial ReactionSystem. This is not the case for $(tr.species).")
     end
 
-    # Checks that the rate does not depend on species.    
+    # Checks that the rate does not depend on species.
     rate_vars = ModelingToolkit.getname.(Symbolics.get_variables(tr.rate))
     if !isempty(intersect(ModelingToolkit.getname.(species(rs)), rate_vars))
         error("The following species were used in rates of a transport reactions: $(setdiff(ModelingToolkit.getname.(species(rs)), rate_vars)).")

--- a/test/dsl/dsl_advanced_model_construction.jl
+++ b/test/dsl/dsl_advanced_model_construction.jl
@@ -154,7 +154,7 @@ end
 # Tests reaction metadata accessor functions.
 let
     # Creates reactions directly.
-    @variables t
+    t = default_t()
     @parameters k η
     @species X(t) X2(t)
 
@@ -195,7 +195,7 @@ let
     @test Catalyst.hasmetadata(rxs[2], :md_1)
     @test !Catalyst.hasmetadata(rxs[3], :noise_scaling)
     @test !Catalyst.hasmetadata(rxs[3], :md_1)
-    
+
     @test isequal(Catalyst.getmetadata(rxs[1], :noise_scaling), η)
     @test isequal(Catalyst.getmetadata(rxs[2], :md_1), 1.0)
 
@@ -211,11 +211,11 @@ let
 end
 
 # Checks that repeated metadata throws errors.
-let 
-    @test_throws LoadError @eval @reaction k, 0 --> X, [md1=1.0, md1=2.0] 
+let
+    @test_throws LoadError @eval @reaction k, 0 --> X, [md1=1.0, md1=2.0]
     @test_throws LoadError @eval @reaction_network begin
-        k, 0 --> X, [md1=1.0, md1=1.0] 
-    end 
+        k, 0 --> X, [md1=1.0, md1=1.0]
+    end
 end
 
 # Tests for nested metadata.
@@ -233,14 +233,14 @@ let
         k8, Y7 --> X7, [md7="Hello"]
         k8, Y8 --> X7, [md7="Hi",md8="Yo"]
     end
-    
+
     rn2 = @reaction_network reactions begin
         (k1,k2,k3), (X1,X2,X3) --> (Y1,Y2,Y3), ([md1=1.0,md2=2.0],[md1=0.0],[md3="Hello world"])
         k, (X4,X5) --> (Y4,Y5), [md4=:sym]
         (k6, k6), X6 <--> Y6, ([md6=0.0],[md6=2.0])
         (k7,k8), X7 <--> (Y7,Y8), ([md7="Hi"],([md7="Hello"],[md7="Hi",md8="Yo"]))
     end
-    
+
     @test isequal(rn1, rn2)
 end
 
@@ -254,7 +254,7 @@ let
         k5, 3X5 --> Z5, [unnecessary_metadata=[1,2,3]]
         k6, X6 => Z6, [unnecessary_metadata=true]
     end
-    
+
     rn2 = @reaction_network reactions begin
         k1*X1, X1 + 2Y1 --> Z1, [only_use_rate=false]
         k2, 4X2 --> Z2 + W3, [only_use_rate=true]
@@ -263,7 +263,7 @@ let
         k5, 3X5 --> Z5, [only_use_rate=false, unnecessary_metadata=[1,2,3]]
         k6, X6 --> Z6, [only_use_rate=true, unnecessary_metadata=true]
     end
-    
+
     @test isequal(rn1,rn2)
 end
 

--- a/test/miscellaneous_tests/reactionsystem_serialisation.jl
+++ b/test/miscellaneous_tests/reactionsystem_serialisation.jl
@@ -20,7 +20,7 @@ D = default_time_deriv()
 # Checks for a simple reaction network (containing variables, equations, and observables).
 # Checks that declaration via DSL works.
 # Checks annotated and non-annotated files against manually written ones.
-let 
+let
     # Creates and serialises the model.
     rn = @reaction_network rn begin
         @observables X2 ~ 2X
@@ -36,7 +36,7 @@ let
     file_string_annotated_real = """let
 
     # Independent variable:
-    @variables t
+    @parameters t
 
     # Parameters:
     ps = @parameters d
@@ -64,7 +64,7 @@ let
     end"""
     file_string_real = """let
 
-    @variables t
+    @parameters t
     ps = @parameters d
     sps = @species X(t)
     vars = @variables V(t)
@@ -90,7 +90,7 @@ end
 # and metadata recorded correctly (these are not considered for system equality is tested).
 # Checks that various types (processed by the `x_2_string` function) are serialised properly.
 # Checks that `ReactionSystem` and `Reaction` metadata fields are recorded properly.
-let 
+let
     # Prepares various stuff to add as metadata.
     bool_md = false
     int_md = 3
@@ -103,7 +103,7 @@ let
     @parameters s r
     symb_md = s
     expr_md = 2s + r^3
-    pair_md = rat_md => symb_md 
+    pair_md = rat_md => symb_md
     tup_md = (float_md, str_md, expr_md)
     vec_md = [float_md, sym_md, tup_md]
     dict_md = Dict([c_md => str_md, symb_md => vec_md])
@@ -211,7 +211,7 @@ end
 # Checks systems where parameters/species/variables have complicated interdependency are correctly
 # serialised.
 # Checks for system with non-default independent variable.
-let 
+let
     # Prepares parameters/variables/species with complicated dependencies.
     @variables τ
     @parameters begin
@@ -255,7 +255,7 @@ end
 
 
 # Tests for multi-layered hierarchical system. Tests with spatial independent variables,
-# variables, (differential and algebraic) equations, observables (continuous and discrete) events, 
+# variables, (differential and algebraic) equations, observables (continuous and discrete) events,
 # and with various species/variables/parameter/reaction/system metadata.
 # Tests for complete and incomplete system.
 let
@@ -269,7 +269,7 @@ let
         t_2::Float64
         t_3, [description="A parameter."]
         t_4::Float32 = p, [description="A parameter."]
-    end 
+    end
     @species X(t) X2_1(t) X2_2(t) X2_3(t) X2_4(t)=p [description="A species."]
     @variables A(t)=p [description="A variable."] B_1(t) B_2(t) B_3(t) B_4(t)
 
@@ -335,16 +335,16 @@ let
 
     # Creates the systems.
     @named rs_4 = ReactionSystem(eqs_4, t; continuous_events = continuous_events_4,
-                                discrete_events = discrete_events_4, spatial_ivs = sivs, 
+                                discrete_events = discrete_events_4, spatial_ivs = sivs,
                                 metadata = "System 4", systems = [])
     @named rs_2 = ReactionSystem(eqs_2, t; continuous_events = continuous_events_2,
-                                discrete_events = discrete_events_2, spatial_ivs = sivs, 
+                                discrete_events = discrete_events_2, spatial_ivs = sivs,
                                 metadata = "System 2", systems = [])
     @named rs_3 = ReactionSystem(eqs_3, t; continuous_events = continuous_events_3,
-                                discrete_events = discrete_events_3, spatial_ivs = sivs, 
+                                discrete_events = discrete_events_3, spatial_ivs = sivs,
                                 metadata = "System 3", systems = [rs_4])
     @named rs_1 = ReactionSystem(eqs_1, t; continuous_events = continuous_events_1,
-                                discrete_events = discrete_events_1, spatial_ivs = sivs, 
+                                discrete_events = discrete_events_1, spatial_ivs = sivs,
                                 metadata = "System 1", systems = [rs_2, rs_3])
     rs = complete(rs_1)
 
@@ -361,7 +361,7 @@ end
 # Tests for cases where the number of input is untested (i.e. multiple observables and continuous
 # events, but single equations and discrete events).
 # Tests with and without `safety_check`.
-let 
+let
     # Declares the model.
     rs = @reaction_network begin
         @equations D(V) ~ 1 - V
@@ -444,7 +444,7 @@ end
 
 # Checks that completeness is recorded correctly.
 # Checks without turning off the `safety_check` option.
-let 
+let
     # Checks for complete system.
     rs_complete = @reaction_network begin
         (p,d), 0 <--> X
@@ -470,7 +470,7 @@ let
     rs = @reaction_network begin
         @equations D(V) ~ -V
     end
-    
+
     # Checks its serialisation.
     save_reactionsystem("test_serialisation.jl", rs; safety_check = false)
     isequal(rs, include("../test_serialisation.jl"))
@@ -492,7 +492,7 @@ let
         d*X2, X => 0
         (k1,k2), 2X <--> X2
     end
-    
+
     # Checks its serialisation.
     save_reactionsystem("test_serialisation.jl", rs; safety_check = false)
     isequal(rs, include("../test_serialisation.jl"))
@@ -524,5 +524,3 @@ let
     @test (@test_logs (:warn, ) match_mode=:any Catalyst.get_connection_type_string(rs)) == ""
     @test Catalyst.get_connection_type_annotation(rs) == "Connection types:: (OBS: Currently not supported, and hence empty)"
 end
-
-

--- a/test/miscellaneous_tests/units.jl
+++ b/test/miscellaneous_tests/units.jl
@@ -12,7 +12,7 @@ using ModelingToolkit: get_iv, get_unit, validate, ValidationError
 # Checks that units work with programmatic model creation.
 let
     # Creates a `ReactionSystem` programmatically, while designating units.
-    @variables t [unit=u"s"]
+    @parameters t [unit=u"s"]
     @species A(t) [unit=u"mol/m^3"] B(t) [unit=u"mol/m^3"] C(t) [unit=u"mol/m^3"]
     @parameters k1 [unit=u"mol/(m^3*s)"] k2 [unit=u"s^(-1)"] k3 [unit=u"(m^3)/(s*mol)"]
     rxs = [Reaction(k1, nothing, [A]),
@@ -101,7 +101,7 @@ begin
     @test_logs (:warn, ) match_mode=:any @reaction_network begin
         @ivs t [unit=u"1/s"] # Here, t's unit is wrong.
         @species begin
-            A(t), [unit=u"mol/m^3"] 
+            A(t), [unit=u"mol/m^3"]
             B(t), [unit=u"mol/m^3"]
             C(t), [unit=u"mol/m^3"]
         end
@@ -117,7 +117,7 @@ begin
     @test_logs (:warn, ) match_mode=:any @reaction_network begin
         @ivs t [unit=u"s"]
         @species begin
-            A(t), [unit=u"mol/m^3"] 
+            A(t), [unit=u"mol/m^3"]
             B(t), [unit=u"mol/m^3"]
             C(t), [unit=u"mol/m^3"]
         end

--- a/test/reactionsystem_core/events.jl
+++ b/test/reactionsystem_core/events.jl
@@ -13,7 +13,7 @@ t = default_t()
 D = default_time_deriv()
 
 
-### Basic Tests ### 
+### Basic Tests ###
 
 # Test discrete event is propagated to ODE solver correctly.
 let
@@ -44,7 +44,7 @@ let
     @parameters α=5.0 β=1.0
     @species V(t)=0.0
     rxs = [
-        Reaction(α, nothing, [V]), 
+        Reaction(α, nothing, [V]),
         Reaction(β, [V], nothing)
     ]
     continuous_events = [V ~ 2.5] => [α ~ 0, β ~ 0]
@@ -212,7 +212,8 @@ let
     end
 
     # Creates model programmatically.
-    @variables t Z(t)
+    t = default_t()
+    @variables Z(t)
     @species X(t) Y(t)
     @parameters p dX dY thres=7.0 dY_up
     rxs = [
@@ -326,13 +327,13 @@ let
         (p,d), 0 <--> X
         (p,d), 0 <--> Y
     end
-    
+
     # Simulates the model for conditions where it *definitely* will cross `X = 1000.0`
     u0 = [:X => 999.9, :Y => 999.9]
     ps = [:p => 10.0, :d => 0.001]
     sprob = SDEProblem(rn, u0, (0.0, 2.0), ps)
     sol = solve(sprob, ImplicitEM(); seed)
-    
+
     # Checks that all `e` parameters have been updated properly.
     @test sol.ps[:e1] == 1
     @test sol.ps[:e2] == 1
@@ -353,14 +354,14 @@ let
         end
         (p,d), 0 <--> X
     end
-    
+
     # Simulates the model for conditions where it *definitely* will cross `X = 1000.0`
     u0 = [:X => 999]
     ps = [:p => 10.0, :d => 0.001]
     dprob = DiscreteProblem(rn, u0, (0.0, 2.0), ps)
     jprob = JumpProblem(rn, dprob, Direct(); rng)
     sol = solve(jprob, SSAStepper(); seed)
-    
+
     # Checks that all `e` parameters have been updated properly.
     # Note that periodic discrete events are currently broken for jump processes (and unlikely to be fixed soon due to periodic callbacks using the internals of ODE integrator and Datastructures heap implementations).
     @test sol.ps[:e1] == 1

--- a/test/reactionsystem_core/reaction.jl
+++ b/test/reactionsystem_core/reaction.jl
@@ -69,7 +69,7 @@ let
     @parameters k n1 n2::Int32
     @species X(t) Y(t) Z(t)
     @variables A(t)
-    
+
     # Neither substrates nor products.
     @test_throws ArgumentError Reaction(k*A, [], [])
 
@@ -99,19 +99,19 @@ let
     @parameters k1 k2 n1 n2 η1 η2 p
     @species X(t) Y(t) Z(t)
     @variables A(t)
-    
+
     # Create `Reaction`s.
     rx1 = Reaction(k1, [], [X])
     rx2 = Reaction(k1 + k2, [X], [Y], [1], [n1]; metadata = [:noise_scaling => η1])
     rx3 = Reaction(k1 + k2 + A, [X], [X, Y, Z], [1], [n1 + n2, 2, 1])
     rx4 = Reaction(X + t, [], [Y]; metadata = [:noise_scaling => η1 + η2])
-    
+
     # Test `get_variables!`.
     @test issetequal(get_variables!([value(p)], rx1), [k1, X, p])
     @test issetequal(get_variables!([value(p)], rx2), [k1, k2, X, Y, n1, η1, p])
     @test issetequal(get_variables!([value(p)], rx3), [k1, k2, A, X, Y, Z, n1, n2, p])
     @test issetequal(get_variables!([value(p)], rx4), [X, t, Y, η1, η2, p])
-    
+
     # Test `get_symbolics`.
     @test issetequal(get_symbolics(rx1), [k1, X])
     @test issetequal(get_symbolics(rx2), [k1, k2, X, Y, n1, η1])
@@ -178,7 +178,7 @@ let
     @test Catalyst.hasmetadata(r, :md_5)
     @test Catalyst.hasmetadata(r, :md_6)
     @test !Catalyst.hasmetadata(r, :md_8)
-    
+
     @test isequal(Catalyst.getmetadata(r, :md_1), 1.0)
     @test isequal(Catalyst.getmetadata(r, :md_2), false)
     @test isequal(Catalyst.getmetadata(r, :md_3), "Hello world")
@@ -189,7 +189,7 @@ end
 
 # Tests the noise scaling metadata.
 let
-    @parameters k η  
+    @parameters k η
     @species X(t) X2(t)
 
     r1 = Reaction(k, [X], [X2], [2], [1])
@@ -203,8 +203,8 @@ end
 
 # Tests the description metadata.
 let
-    @variables t
-    @parameters k η  
+    t = default_t()
+    @parameters k η
     @species X(t) X2(t)
 
     r1 = Reaction(k, [X], [X2], [2], [1])
@@ -218,8 +218,8 @@ end
 
 # Tests the misc metadata.
 let
-    @variables t
-    @parameters k η  
+    t = default_t()
+    @parameters k η
     @species X(t) X2(t)
 
     r1 = Reaction(k, [X], [X2], [2], [1])

--- a/test/simulation_and_solving/simulate_SDEs.jl
+++ b/test/simulation_and_solving/simulate_SDEs.jl
@@ -134,7 +134,7 @@ let
 end
 
 # Checks that simulations for a large number of potential systems are completed (and don't error).
-# (cannot solve as solution likely to go into negatives). 
+# (cannot solve as solution likely to go into negatives).
 let
     for rn in reaction_networks_all
         u0 = rnd_u0(rn, rng)
@@ -146,8 +146,8 @@ end
 
 ### Noise Scaling ###
 
-# Compares noise scaling with manually declared noise function. 
-let 
+# Compares noise scaling with manually declared noise function.
+let
     function real_g_3(du, u, P, t)
         X1, X2 = u
         η1, η2, p, k1, k2, d = P
@@ -156,36 +156,36 @@ let
         du[1, 2] = - η2 * sqrt(k1 * X1)
         du[1, 3] = (2 * η2 + 1) * sqrt(k2 * X2)
         du[1, 4] = 0.0
-        du[2, 1] = 0.0 
+        du[2, 1] = 0.0
         du[2, 2] = η2 * sqrt(k1 * X1)
         du[2, 3] = - (2 * η2 + 1) * sqrt(k2 * X2)
         du[2, 4] = 0.0
         return du
     end
-    
-    noise_scaling_network = @reaction_network begin 
+
+    noise_scaling_network = @reaction_network begin
         @parameters η1 η2
         @default_noise_scaling η1
         p, 0 --> X1
-        (k1, k2), X1 ↔ X2, ([noise_scaling=η2],[noise_scaling=2 * η2 + 1]) 
+        (k1, k2), X1 ↔ X2, ([noise_scaling=η2],[noise_scaling=2 * η2 + 1])
         d, X2 --> 0, [noise_scaling = 0.0]
     end
-    
+
     u0_1 = rnd_u0(noise_scaling_network, rng)
     ps_1 = rnd_ps(noise_scaling_network, rng)
     u0_2 = map_to_vec(u0_1, [:X1, :X2])
     ps_2 = map_to_vec(ps_1, [:η1, :η2, :p, :k1, :k2, :d])
-    
+
     @test g_eval(noise_scaling_network, u0_1, ps_1, 0.0) == real_g_3(zeros(2, 4), u0_2, ps_2, 0.0)
 end
 
 # Tests with multiple noise scaling parameters directly in the macro.
 # If the correct noise scaling is applied, the variance in the individual species should be (widely) different.
-let 
+let
     # Tries with normally declared parameters.
-    noise_scaling_network_1 = @reaction_network begin 
+    noise_scaling_network_1 = @reaction_network begin
         @parameters η1 η2
-        (k1, k2), X1 ↔ X2, ([noise_scaling=η1],[noise_scaling=η2]) 
+        (k1, k2), X1 ↔ X2, ([noise_scaling=η1],[noise_scaling=η2])
     end
     u0 = [:X1 => 1000.0, :X2 => 3000.0]
     sprob_1_1 = SDEProblem(noise_scaling_network_1, u0, (0.0, 1000.0), [:k1 => 2.0, :k2 => 0.66, :η1 => 2.0, :η2 => 2.0])
@@ -195,13 +195,13 @@ let
         sol_1_1 = solve(sprob_1_1, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
         sol_1_2 = solve(sprob_1_2, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
         sol_1_3 = solve(sprob_1_3, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
-        @test var(sol_1_1[:X1]) > var(sol_1_2[:X1]) > var(sol_1_3[:X1]) 
+        @test var(sol_1_1[:X1]) > var(sol_1_2[:X1]) > var(sol_1_3[:X1])
     end
 
     # Tries with an array parameter.
-    noise_scaling_network_2 = @reaction_network begin 
+    noise_scaling_network_2 = @reaction_network begin
         @parameters η[1:2]
-        (k1, k2), X1 ↔ X2, ([noise_scaling=η[1]],[noise_scaling=η[2]])  
+        (k1, k2), X1 ↔ X2, ([noise_scaling=η[1]],[noise_scaling=η[2]])
     end
     @unpack k1, k2, η = noise_scaling_network_2
     sprob_2_1 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η[1] => 2.0, η[2] => 2.0])
@@ -211,7 +211,7 @@ let
         sol_2_1 = solve(sprob_2_1, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
         sol_2_2 = solve(sprob_2_2, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
         sol_2_3 = solve(sprob_2_3, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
-        @test var(sol_2_1[:X1]) > var(sol_2_2[:X1]) > var(sol_2_3[:X1]) 
+        @test var(sol_2_1[:X1]) > var(sol_2_2[:X1]) > var(sol_2_3[:X1])
     end
 end
 
@@ -220,7 +220,7 @@ end
 # Tests @noise_scaling_parameters macro.
 let
     η_stored = :η
-    @variables t
+    t = default_t()
     @species X1(t) X2(t)
     p_syms = @parameters $(η_stored) k1 k2
 
@@ -237,17 +237,17 @@ end
 # Complicated test with many combinations of options.
 # Tests the noise_scaling_parameters getter.
 let
-    noise_scaling_network = @reaction_network begin 
+    noise_scaling_network = @reaction_network begin
         @parameters k1 par1 [description="Parameter par1"] par2 η1 η2=0.0 [description="Parameter η2"] η3=1.0 η4
-        (p, d), 0 ↔ X1, ([noise_scaling=η1],[noise_scaling=η2]) 
-        (k1, k2), X1 ↔ X2, ([noise_scaling=η3],[noise_scaling=η4])  
+        (p, d), 0 ↔ X1, ([noise_scaling=η1],[noise_scaling=η2])
+        (k1, k2), X1 ↔ X2, ([noise_scaling=η3],[noise_scaling=η4])
     end
     u0 = [:X1 => 500.0, :X2 => 500.0]
     p = [:p => 20.0, :d => 0.1, :η1 => 0.0, :η3 => 0.0, :η4 => 0.0, :k1 => 2.0, :k2 => 2.0, :par1 => 1000.0, :par2 => 1000.0]
-    
+
     @test ModelingToolkit.getdescription(parameters(noise_scaling_network)[2]) == "Parameter par1"
     @test ModelingToolkit.getdescription(parameters(noise_scaling_network)[5]) == "Parameter η2"
-    
+
     sprob = SDEProblem(noise_scaling_network, u0, (0.0, 1000.0), p)
     @test sprob.ps[:η1] == sprob.ps[:η2] == sprob.ps[:η3] == sprob.ps[:η4] == 0.0
 end
@@ -263,15 +263,15 @@ let
         (p,d), 0 <--> X2, ([description="Y"],[description="Y"])
         (p,d), 0 <--> X3
     end
-    
+
     u0 = [:X1 => 1000.0, :X2 => 1000.0, :X3 => 1000.0]
     ps = [noise_scaling_network.p => 1000.0, noise_scaling_network.d => 1.0, noise_scaling_network.η1 => 1.0]
     sprob = SDEProblem(noise_scaling_network, u0, (0.0, 1000.0), ps)
-    
+
     for repeat in 1:5
         sol = solve(sprob, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
-        @test var(sol[:X1]) < var(sol[:X2]) 
-        @test var(sol[:X1]) < var(sol[:X3]) 
+        @test var(sol[:X1]) < var(sol[:X2])
+        @test var(sol[:X1]) < var(sol[:X3])
     end
 end
 
@@ -282,9 +282,9 @@ let
         @species N1(t) N2(t)=0.5
         @variables N3(t)
         @default_noise_scaling η1 + N1 + 5.0
-        p, 0 --> X1 
+        p, 0 --> X1
         p, 0 --> X2, [noise_scaling=0.33η2^1.2 + N2]
-        p, 0 --> X3, [noise_scaling=N3*η3] 
+        p, 0 --> X3, [noise_scaling=N3*η3]
         p, 0 --> X4, [noise_scaling=exp(-η4) - 0.008]
         p, 0 --> X5, [noise_scaling=0.0]
         d, (X1, X2, X3, X4, X5) --> 0, ([], [noise_scaling=0.33η2^1.2 + N2], [noise_scaling=N3*η3], [noise_scaling=exp(-η4) - 0.008], [noise_scaling=0.0])
@@ -311,7 +311,7 @@ end
 
 # Tests noise scaling is added properly for programmatically created system.
 # Tests noise scaling for interpolation into the `@reaction macro`.
-# Tests that species, variables, and parameters are extracted from noise scaling metadata when 
+# Tests that species, variables, and parameters are extracted from noise scaling metadata when
 # `ReactionSystems`s are declared programmatically.
 let
     # Programmatically creates a model with noise scaling.
@@ -345,7 +345,7 @@ let
     @parameters η2
     @species Y(t)
     @variables V(t)
-    
+
     noise_scaling_network2 = set_default_noise_scaling(noise_scaling_network1, η1 + η2 + Y + V)
     @test isequal(reactions(noise_scaling_network2)[1].metadata, [:noise_scaling => 2.0])
     @test isequal(reactions(noise_scaling_network2)[2].metadata, [:noise_scaling => η1 + η2 + Y + V])
@@ -357,7 +357,7 @@ end
 
 # Tests the `remake_noise_scaling` function on a hierarchical model.
 # Checks that species, variables, and parameters not part of the original system is added properly.
-let        
+let
     # Creates hierarchical model.
     rn1 = @reaction_network rn1 begin
         p, 0 --> X, [noise_scaling=2.0]
@@ -385,8 +385,8 @@ end
 
 # Tests simulating a network without parameters.
 let
-    no_param_network = @reaction_network begin 
-        (1.2, 5), X1 ↔ X2 
+    no_param_network = @reaction_network begin
+        (1.2, 5), X1 ↔ X2
     end
     for factor in [1e3, 1e4]
         u0 = rnd_u0(no_param_network, rng; factor)

--- a/test/spatial_modelling/lattice_reaction_systems.jl
+++ b/test/spatial_modelling/lattice_reaction_systems.jl
@@ -13,26 +13,26 @@ grids = [very_small_2d_cartesian_grid, very_small_2d_masked_grid, very_small_2d_
 ### Tests LatticeReactionSystem Getters Correctness ###
 
 # Test case 1.
-let 
+let
     rs = @reaction_network begin
         (p, 1), 0 <--> X
     end
-    tr = @transport_reaction d X   
-    for grid in grids 
+    tr = @transport_reaction d X
+    for grid in grids
         lrs = LatticeReactionSystem(rs, [tr], grid)
 
         @unpack X, p = rs
         d = edge_parameters(lrs)[1]
-        @test issetequal(species(lrs), [X])  
-        @test issetequal(spatial_species(lrs), [X])   
-        @test issetequal(parameters(lrs), [p, d])   
-        @test issetequal(vertex_parameters(lrs), [p])  
-        @test issetequal(edge_parameters(lrs), [d])      
+        @test issetequal(species(lrs), [X])
+        @test issetequal(spatial_species(lrs), [X])
+        @test issetequal(parameters(lrs), [p, d])
+        @test issetequal(vertex_parameters(lrs), [p])
+        @test issetequal(edge_parameters(lrs), [d])
     end
 end
 
 # Test case 2.
-let 
+let
     rs = @reaction_network begin
         @parameters p1 p2 [edgeparameter=true]
     end
@@ -43,14 +43,14 @@ let
 end
 
 # Test case 3.
-let 
+let
     rs = @reaction_network begin
         @parameters pX pY dX [edgeparameter=true] dY
         (pX, 1), 0 <--> X
         (pY, 1), 0 <--> Y
     end
-    tr_1 = @transport_reaction dX X  
-    tr_2 = @transport_reaction dY Y    
+    tr_1 = @transport_reaction dX X
+    tr_2 = @transport_reaction dY Y
     for grid in grids
         lrs = LatticeReactionSystem(rs, [tr_1, tr_2], grid)
 
@@ -64,13 +64,13 @@ let
 end
 
 # Test case 4.
-let 
+let
     rs = @reaction_network begin
         @parameters dX p
         (pX, 1), 0 <--> X
         (pY, 1), 0 <--> Y
     end
-    tr_1 = @transport_reaction dX X   
+    tr_1 = @transport_reaction dX X
     for grid in grids
         lrs = LatticeReactionSystem(rs, [tr_1], grid)
 
@@ -84,7 +84,7 @@ let
 end
 
 # Test case 5.
-let 
+let
     rs = @reaction_network begin
         @species W(t)
         @parameters pX pY dX [edgeparameter=true] dY
@@ -95,14 +95,14 @@ let
     end
     @unpack dX, X, V = rs
     @parameters dV dW
-    @variables t
+    t = default_t()
     @species W(t)
-    tr_1 = TransportReaction(dX, X)  
-    tr_2 = @transport_reaction dY Y    
-    tr_3 = @transport_reaction dZ Z 
-    tr_4 = TransportReaction(dV, V)  
-    tr_5 = TransportReaction(dW, W)   
-    for grid in grids  
+    tr_1 = TransportReaction(dX, X)
+    tr_2 = @transport_reaction dY Y
+    tr_3 = @transport_reaction dZ Z
+    tr_4 = TransportReaction(dV, V)
+    tr_5 = TransportReaction(dW, W)
+    for grid in grids
         lrs = LatticeReactionSystem(rs, [tr_1, tr_2, tr_3, tr_4, tr_5], grid)
 
         @unpack pX, pY, pZ, pV, dX, dY, X, Y, Z, V = rs
@@ -116,11 +116,11 @@ let
 end
 
 # Test case 6.
-let 
+let
     rs = @reaction_network customname begin
         (p, 1), 0 <--> X
     end
-    tr = @transport_reaction d X    
+    tr = @transport_reaction d X
     for grid in grids
         lrs = LatticeReactionSystem(rs, [tr], grid)
 
@@ -162,18 +162,18 @@ end
 ### Tests Error generation ###
 
 # Network where diffusion species is not declared in non-spatial network.
-let 
+let
     rs = @reaction_network begin
         (p, d), 0 <--> X
     end
-    tr = @transport_reaction D Y    
+    tr = @transport_reaction D Y
     for grid in grids
         @test_throws ErrorException LatticeReactionSystem(rs, [tr], grid)
     end
 end
 
 # Network where the rate depend on a species
-let 
+let
     rs = @reaction_network begin
         @species Y(t)
         (p, d), 0 <--> X
@@ -185,7 +185,7 @@ let
 end
 
 # Network with edge parameter in non-spatial reaction rate.
-let 
+let
     rs = @reaction_network begin
         @parameters p [edgeparameter=true]
         (p, d), 0 <--> X
@@ -197,7 +197,7 @@ let
 end
 
 # Network where metadata has been added in rs (which is not seen in transport reaction).
-let 
+let
     rs = @reaction_network begin
         @species X(t) [description="Species with added metadata"]
         (p, d), 0 <--> X
@@ -272,7 +272,7 @@ end
 ### Tests Grid Vertex and Edge Number Computation ###
 
 # Tests that the correct numbers are computed for num_edges.
-let 
+let
     # Function counting the values in an iterator by stepping through it.
     function iterator_count(iterator)
         count = 0
@@ -281,18 +281,18 @@ let
     end
 
     # Cartesian and masked grid (test diagonal edges as well).
-    for lattice in [small_1d_cartesian_grid, small_2d_cartesian_grid, small_3d_cartesian_grid, 
+    for lattice in [small_1d_cartesian_grid, small_2d_cartesian_grid, small_3d_cartesian_grid,
                 random_1d_masked_grid, random_2d_masked_grid, random_3d_masked_grid]
         lrs1 = LatticeReactionSystem(SIR_system, SIR_srs_1, lattice)
         lrs2 = LatticeReactionSystem(SIR_system, SIR_srs_1, lattice; diagonal_connections=true)
-        @test num_edges(lrs1) == iterator_count(edge_iterator(lrs1))    
-        @test num_edges(lrs2) == iterator_count(edge_iterator(lrs2))    
+        @test num_edges(lrs1) == iterator_count(edge_iterator(lrs1))
+        @test num_edges(lrs2) == iterator_count(edge_iterator(lrs2))
     end
 
     # Graph grids (cannot test diagonal connections).
     for lattice in [small_2d_graph_grid, small_3d_graph_grid, undirected_cycle, small_directed_cycle, unconnected_graph]
         lrs1 = LatticeReactionSystem(SIR_system, SIR_srs_1, lattice)
-        @test num_edges(lrs1) == iterator_count(edge_iterator(lrs1))    
+        @test num_edges(lrs1) == iterator_count(edge_iterator(lrs1))
     end
 end
 
@@ -308,15 +308,15 @@ let
     function make_edge_p_value(src_vert, dst_vert)
         return prod(src_vert) + prod(dst_vert)
     end
-    
+
     # Loops through a variety of grids, checks that `make_edge_p_values` yields the correct values.
     for grid in [small_1d_cartesian_grid, small_2d_cartesian_grid, small_3d_cartesian_grid,
-                 small_1d_masked_grid, small_2d_masked_grid, small_3d_masked_grid, 
+                 small_1d_masked_grid, small_2d_masked_grid, small_3d_masked_grid,
                  random_1d_masked_grid, random_2d_masked_grid, random_3d_masked_grid]
         lrs = LatticeReactionSystem(rn, [tr], grid)
         flat_to_grid_idx = Catalyst.get_index_converters(lattice(lrs), num_verts(lrs))[1]
         edge_values = make_edge_p_values(lrs, make_edge_p_value)
-    
+
         for e in edge_iterator(lrs)
             @test edge_values[e[1], e[2]] == make_edge_p_value(flat_to_grid_idx[e[1]], flat_to_grid_idx[e[2]])
         end
@@ -375,17 +375,17 @@ let
     tr = @transport_reaction D X
     tspan = (0.0, 10000.0)
     make_edge_p_value(src_vert, dst_vert) = rand()
-    
+
     # Graph grids.
     lrs = LatticeReactionSystem(rn, [tr], path_graph(5))
     @test_throws Exception make_edge_p_values(lrs, make_edge_p_value,)
     @test_throws Exception make_directed_edge_values(lrs, (1.0, 0.0))
-    
+
     # Wrong dimensions to `make_directed_edge_values`.
     lrs_1d = LatticeReactionSystem(rn, [tr], CartesianGrid(5))
     lrs_2d = LatticeReactionSystem(rn, [tr], fill(true,5,5))
     lrs_3d = LatticeReactionSystem(rn, [tr], CartesianGrid((5,5,5)))
-    
+
     @test_throws Exception make_directed_edge_values(lrs_1d, (1.0, 0.0), (1.0, 0.0))
     @test_throws Exception make_directed_edge_values(lrs_1d, (1.0, 0.0), (1.0, 0.0), (1.0, 0.0))
     @test_throws Exception make_directed_edge_values(lrs_2d, (1.0, 0.0))

--- a/test/spatial_modelling/spatial_reactions.jl
+++ b/test/spatial_modelling/spatial_reactions.jl
@@ -7,19 +7,19 @@ using Catalyst, Test
 ### TransportReaction Creation Tests ###
 
 # Tests TransportReaction with non-trivial rate.
-let 
+let
     rs = @reaction_network begin
-        @parameters dV dE [edgeparameter=true] 
+        @parameters dV dE [edgeparameter=true]
         (p,1), 0 <--> X
     end
     @unpack dV, dE, X = rs
-    
+
     tr = TransportReaction(dV*dE, X)
     @test isequal(tr.rate, dV*dE)
 end
 
 # Tests transport_reactions function for creating TransportReactions.
-let 
+let
     rs = @reaction_network begin
         @parameters d
         (p,1), 0 <--> X
@@ -30,15 +30,15 @@ let
 end
 
 # Test reactions with constants in rate.
-let 
-    @variables t
+let
+    t = default_t()
     @species X(t) Y(t)
-    
+
     tr_1 = TransportReaction(1.5, X)
     tr_1_macro = @transport_reaction 1.5 X
     @test isequal(tr_1.rate, tr_1_macro.rate)
     @test isequal(tr_1.species, tr_1_macro.species)
-    
+
     tr_2 = TransportReaction(π, Y)
     tr_2_macro = @transport_reaction π Y
     @test isequal(tr_2.rate, tr_2_macro.rate)
@@ -48,9 +48,9 @@ end
 ### Spatial Reactions Getters Correctness ###
 
 # Test case 1.
-let 
-    tr_1 = @transport_reaction dX X    
-    tr_2 = @transport_reaction dY1*dY2 Y   
+let
+    tr_1 = @transport_reaction dX X
+    tr_2 = @transport_reaction dY1*dY2 Y
 
     # @test ModelingToolkit.getname.(species(tr_1)) == ModelingToolkit.getname.(spatial_species(tr_1)) == [:X] # species(::TransportReaction) currently not supported.
     # @test ModelingToolkit.getname.(species(tr_2)) == ModelingToolkit.getname.(spatial_species(tr_2)) == [:Y]
@@ -86,8 +86,8 @@ end
 
 # Tests that creation of TransportReaction with non-parameters in rate yield errors.
 # Tests that errors are throw even when the rate is highly nested.
-let 
-    @variables t
+let
+    t = default_t()
     @species X(t) Y(t)
     @parameters D1 D2 D3
     @test_throws ErrorException TransportReaction(D1 + D2*(D3 + Y), X)
@@ -105,7 +105,7 @@ let
     end
     @unpack X, Y, Z, dX, dY1, dY2, dZ = rs
     rate1 = dX
-    rate2 = dY1*dY2 
+    rate2 = dY1*dY2
     species3 = Z
     tr_1 = TransportReaction(dX, X)
     tr_2 = TransportReaction(dY1*dY2, Y)
@@ -114,9 +114,9 @@ let
     tr_macro_2 = @transport_reaction $(rate2) Y
     @test_broken false
     # tr_macro_3 = @transport_reaction dZ $species3 # Currently does not work, something with meta programming.
-    
+
     @test isequal(tr_1, tr_macro_1)
-    @test isequal(tr_2, tr_macro_2) 
+    @test isequal(tr_2, tr_macro_2)
     # @test isequal(tr_3, tr_macro_3)
 end
 


### PR DESCRIPTION
Some `@variables t` to `t = default_t()` were missed, and the DSL needed updating in places to use `default_t()`.

@TorkelE please review to make sure I haven't screwed up the serialization part in particular. 