### PR TITLE
test: remove unnecessarily specific parameter type annotations

### DIFF
--- a/test/reactionsystem_core/parameter_type_designation.jl
+++ b/test/reactionsystem_core/parameter_type_designation.jl
@@ -17,8 +17,8 @@ t = default_t()
 # Declares a simple model to run tests on.
 begin
     t = default_t()
-    @parameters p1 p2::Float64 p3::Int64 p4::Float32 p5::Rational{Int64}
-    @parameters d1 d2::Float64 = 1.2 d3::Int64 = 2 [description = "A parameter"] d4::Rational{Int64} d5::Float32
+    @parameters p1 p2 p3::Int64 p4 p5::Rational{Int64}
+    @parameters d1 d2 = 1.2 d3::Int64 = 2 [description = "A parameter"] d4::Rational{Int64} d5
     @species X1(t) X2(t) X3(t) X4(t) X5(t)
 
     rxs = [
@@ -49,14 +49,14 @@ end
 let
     @test Symbolics.unwrap(rs.p1) isa BasicSymbolic{Real}
     @test Symbolics.unwrap(rs.d1) isa BasicSymbolic{Real}
-    @test Symbolics.unwrap(rs.p2) isa BasicSymbolic{Float64}
-    @test Symbolics.unwrap(rs.d2) isa BasicSymbolic{Float64}
+    @test Symbolics.unwrap(rs.p2) isa BasicSymbolic{Real}
+    @test Symbolics.unwrap(rs.d2) isa BasicSymbolic{Real}
     @test Symbolics.unwrap(rs.p3) isa BasicSymbolic{Int64}
     @test Symbolics.unwrap(rs.d3) isa BasicSymbolic{Int64}
-    @test Symbolics.unwrap(rs.p4) isa BasicSymbolic{Float32}
+    @test Symbolics.unwrap(rs.p4) isa BasicSymbolic{Real}
     @test Symbolics.unwrap(rs.d4) isa BasicSymbolic{Rational{Int64}}
     @test Symbolics.unwrap(rs.p5) isa BasicSymbolic{Rational{Int64}}
-    @test Symbolics.unwrap(rs.d5) isa BasicSymbolic{Float32}
+    @test Symbolics.unwrap(rs.d5) isa BasicSymbolic{Real}
 end
 
 # Tests that simulations with differentially typed variables yields correct results.
@@ -96,10 +96,10 @@ let
         @test unwrap(mtk_struct.ps[d2]) isa Float64
         @test unwrap(mtk_struct.ps[p3]) isa Int64
         @test unwrap(mtk_struct.ps[d3]) isa Int64
-        @test unwrap(mtk_struct.ps[p4]) isa Float32
+        @test unwrap(mtk_struct.ps[p4]) isa Float64
         @test unwrap(mtk_struct.ps[d4]) isa Rational{Int64}
         @test unwrap(mtk_struct.ps[p5]) isa Rational{Int64}
-        @test unwrap(mtk_struct.ps[d5]) isa Float32
+        @test unwrap(mtk_struct.ps[d5]) isa Float64
 
         # Checks that all parameters have the correct value.
         @test unwrap(mtk_struct.ps[p1]) == 1.0


### PR DESCRIPTION
With https://github.com/SciML/ModelingToolkit.jl/pull/2908, tunables are being merged into one `Vector{T}`, where `T` is some floating point number. This is because tunables are intended for optimization and sensitivity analysis, but AD doesn't work for integers. Not splitting into `Tuple{Vector{T1}, Vector{T2}}` also has performance benefits for sensitivity analysis, and helps reduce a significant number of bugs. Array tunables are also concatenated into this vector. Accessing these functions is done through a view to prevent unnecessary performance overhead, even in MTK's generated functions.

To this end, parameters are promoted to a common type. Overly specific type annotations are also in general invalid, since the parameters could also be duals.

This PR is a draft so it can be rerun once to aforementioned MTK PR is merged and tagged.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
