### PR TITLE
`arguments` -> `sorted_arguments` updates

### DIFF
--- a/ext/CatalystHomotopyContinuationExtension/homotopy_continuation_extension.jl
+++ b/ext/CatalystHomotopyContinuationExtension/homotopy_continuation_extension.jl
@@ -70,10 +70,10 @@ end
 function ___make_int_exps(expr)
     !iscall(expr) && return expr
     if (operation(expr) == ^)
-        if isinteger(arguments(expr)[2])
-            return arguments(expr)[1]^Int64(arguments(expr)[2])
+        if isinteger(sorted_arguments(expr)[2])
+            return sorted_arguments(expr)[1]^Int64(sorted_arguments(expr)[2])
         else
-            error("An non integer ($(arguments(expr)[2])) was found as a variable exponent. Non-integer exponents are not supported for homotopy continuation based steady state finding.")
+            error("An non integer ($(sorted_arguments(expr)[2])) was found as a variable exponent. Non-integer exponents are not supported for homotopy continuation based steady state finding.")
         end
     end
 end
@@ -83,7 +83,7 @@ function remove_denominators(expr)
     s_expr = simplify_fractions(expr)
     !iscall(expr) && return expr
     if operation(s_expr) == /
-        return remove_denominators(arguments(s_expr)[1])
+        return remove_denominators(sorted_arguments(s_expr)[1])
     end
     if operation(s_expr) == +
         return sum(remove_denominators(arg) for arg in arguments(s_expr))

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -23,7 +23,7 @@ using RuntimeGeneratedFunctions
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 import Symbolics: BasicSymbolic
-using Symbolics: iscall
+using Symbolics: iscall, sorted_arguments
 using ModelingToolkit: Symbolic, value, get_unknowns, get_ps, get_iv, get_systems,
                        get_eqs, get_defaults, toparam, get_var_to_name, get_observed,
                        getvar

--- a/src/chemistry_functionality.jl
+++ b/src/chemistry_functionality.jl
@@ -106,7 +106,7 @@ function make_compound(expr)
 
     # Expression which when evaluated gives a vector with all the ivs of the components.
     ivs_get_expr = :(unique(reduce(
-        vcat, [arguments(ModelingToolkit.unwrap(comp))
+        vcat, [sorted_arguments(ModelingToolkit.unwrap(comp))
                for comp in $components])))
 
     # Creates the found expressions that will create the compound species.

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -776,7 +776,7 @@ function read_observed_options(options, species_n_vars_declared, ivs_sorted)
                 dep_var_expr = :(filter(!MT.isparameter,
                     Symbolics.get_variables($(obs_eq.args[3]))))
                 ivs_get_expr = :(unique(reduce(
-                    vcat, [arguments(MT.unwrap(dep))
+                    vcat, [sorted_arguments(MT.unwrap(dep))
                            for dep in $dep_var_expr])))
                 ivs_get_expr_sorted = :(sort($(ivs_get_expr);
                     by = iv -> findfirst(MT.getname(iv) == ivs for ivs in $ivs_sorted)))

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -37,7 +37,7 @@ function Latexify.infer_output(env, rs::ReactionSystem, args...)
 end
 
 function processsym(s)
-    args = Symbolics.sorted_arguments(s)
+    args = sorted_arguments(s)
     name = MT.getname(s)
     if length(args) <= 1
         var = value(Symbolics.variable(name))

--- a/src/registered_functions.jl
+++ b/src/registered_functions.jl
@@ -140,7 +140,7 @@ end
 # it in its expanded form. If not, returns the input expression.
 function expand_catalyst_function(expr)
     is_catalyst_function(expr) || (return expr)
-    args = arguments(expr)
+    args = sorted_arguments(expr)
     if operation(expr) == Catalyst.mm
         return args[2] * args[1] / (args[1] + args[3])
     elseif operation(expr) == Catalyst.mmr

--- a/test/dsl/dsl_options.jl
+++ b/test/dsl/dsl_options.jl
@@ -575,8 +575,8 @@ let
         end
     end
     V,W = getfield.(observed(rn), :lhs)
-    @test isequal(arguments(ModelingToolkit.unwrap(V)), Any[Catalyst.get_iv(rn), Catalyst.get_sivs(rn)[1], Catalyst.get_sivs(rn)[2]])
-    @test isequal(arguments(ModelingToolkit.unwrap(W)), Any[Catalyst.get_iv(rn), Catalyst.get_sivs(rn)[2]])
+    @test isequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(V)), Any[Catalyst.get_iv(rn), Catalyst.get_sivs(rn)[1], Catalyst.get_sivs(rn)[2]])
+    @test isequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(W)), Any[Catalyst.get_iv(rn), Catalyst.get_sivs(rn)[2]])
 end
 
 # Checks that metadata is written properly.

--- a/test/miscellaneous_tests/compound_macro.jl
+++ b/test/miscellaneous_tests/compound_macro.jl
@@ -121,11 +121,11 @@ let
     @compound SO2(t,x,y) ~ S + 2O
     
     # Checks they have the correct independent variables.
-    @test issetequal(arguments(ModelingToolkit.unwrap(CO2)), [t])
-    @test issetequal(arguments(ModelingToolkit.unwrap(NH4)), [x])
-    @test issetequal(arguments(ModelingToolkit.unwrap(H2O)), [t, x])
-    @test issetequal(arguments(ModelingToolkit.unwrap(PH4)), [t, x])
-    @test issetequal(arguments(ModelingToolkit.unwrap(SO2)), [t, x, y])
+    @test issetequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(CO2)), [t])
+    @test issetequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(NH4)), [x])
+    @test issetequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(H2O)), [t, x])
+    @test issetequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(PH4)), [t, x])
+    @test issetequal(Symbolics.sorted_arguments(ModelingToolkit.unwrap(SO2)), [t, x, y])
 end
 
 ### Interpolation Tests ###


### PR DESCRIPTION
fixes some remaining cases where `arguments` should be `sorted_arguments` with the new Symbolics update