### PR TITLE
cleanup DSL generated expression for readability

### DIFF
--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -397,7 +397,7 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
 
         remake_ReactionSystem_internal(
             make_ReactionSystem_internal(
-                rx_eq_vec, $tiv, vars, $pssym; 
+                rx_eq_vec, $tiv, vars, $pssym;
                 name = $name, spatial_ivs = sivs_vec, observed = obseqs,
                 continuous_events = cevents, discrete_events = devents,
                 combinatoric_ratelaws = $combinatoric_ratelaws);

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -87,13 +87,13 @@ macro species(ex...)
     resize!(vars.args, idx + length(lastarg.args) + 1)
     for sym in lastarg.args
         vars.args[idx] = :($sym = ModelingToolkit.wrap(setmetadata(
-            ModelingToolkit.value($sym), VariableSpecies, true)))
+            ModelingToolkit.value($sym), Catalyst.VariableSpecies, true)))
         idx += 1
     end
 
     # check nothing was declared isconstantspecies
     ex = quote
-        all(!isconstant ∘ ModelingToolkit.value, $lastarg) ||
+        all(!Catalyst.isconstant ∘ ModelingToolkit.value, $lastarg) ||
             throw(ArgumentError("isconstantspecies metadata can only be used with parameters."))
     end
     vars.args[idx] = ex
@@ -150,7 +150,7 @@ macro reaction_network(name::Expr, ex::Expr)
         MacroTools.striplines(ex); name = :($(esc(name.args[1])))))))
 end
 
-macro reaction_network(ex::Expr)
+macro reaction_network(ex::Expr)    
     ex = MacroTools.striplines(ex)
 
     # no name but equations: @reaction_network begin ... end ...

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -150,7 +150,7 @@ macro reaction_network(name::Expr, ex::Expr)
         MacroTools.striplines(ex); name = :($(esc(name.args[1])))))))
 end
 
-macro reaction_network(ex::Expr)
+macro reaction_network(ex::Expr)    
     ex = MacroTools.striplines(ex)
 
     # no name but equations: @reaction_network begin ... end ...
@@ -388,17 +388,18 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
         $comps
         $diffexpr
 
-        spatial_ivs = $sivs
+        sivs_vec = $sivs
         rx_eq_vec = $rxexprs
         vars = setdiff(union($spssym, $varssym, $compssym), $obs_syms)
-        observed = $observed_eqs
-        continuous_events = $continuous_events_expr
-        discrete_events = $discrete_events_expr
+        obseqs = $observed_eqs
+        cevents = $continuous_events_expr
+        devents = $discrete_events_expr
 
         remake_ReactionSystem_internal(
             make_ReactionSystem_internal(
-                rx_eq_vec, $tiv, vars, $pssym; name = $name, spatial_ivs, observed,
-                continuous_events, discrete_events,
+                rx_eq_vec, $tiv, vars, $pssym;
+                name = $name, spatial_ivs = sivs_vec, observed = obseqs,
+                continuous_events = cevents, discrete_events = devents,
                 combinatoric_ratelaws = $combinatoric_ratelaws);
             default_reaction_metadata = $default_reaction_metadata)
     end

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -380,23 +380,28 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
     end
 
     quote
-        $ps
         $ivexpr
+        $ps
         $vars
         $sps
         $observed_vars
         $comps
         $diffexpr
 
+        sivs_vec = $sivs
+        rx_eq_vec = $rxexprs
+        vars = setdiff(union($spssym, $varssym, $compssym), $obs_syms)
+        obseqs = $observed_eqs
+        cevents = $continuous_events_expr
+        devents = $discrete_events_expr
+
         Catalyst.remake_ReactionSystem_internal(
             Catalyst.make_ReactionSystem_internal(
-                $rxexprs, $tiv, setdiff(union($spssym, $varssym, $compssym), $obs_syms),
-                $pssym; name = $name, spatial_ivs = $sivs, observed = $observed_eqs,
-                continuous_events = $continuous_events_expr,
-                discrete_events = $discrete_events_expr,
+                rx_eq_vec, $tiv, vars, $pssym; 
+                name = $name, spatial_ivs = sivs_vec, observed = obseqs,
+                continuous_events = cevents, discrete_events = devents,
                 combinatoric_ratelaws = $combinatoric_ratelaws);
-            default_reaction_metadata = $default_reaction_metadata
-        )
+            default_reaction_metadata = $default_reaction_metadata)
     end
 end
 

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -388,18 +388,17 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
         $comps
         $diffexpr
 
-        sivs_vec = $sivs
+        spatial_ivs = $sivs
         rx_eq_vec = $rxexprs
         vars = setdiff(union($spssym, $varssym, $compssym), $obs_syms)
-        obseqs = $observed_eqs
-        cevents = $continuous_events_expr
-        devents = $discrete_events_expr
+        observed = $observed_eqs
+        continuous_events = $continuous_events_expr
+        discrete_events = $discrete_events_expr
 
         remake_ReactionSystem_internal(
             make_ReactionSystem_internal(
-                rx_eq_vec, $tiv, vars, $pssym;
-                name = $name, spatial_ivs = sivs_vec, observed = obseqs,
-                continuous_events = cevents, discrete_events = devents,
+                rx_eq_vec, $tiv, vars, $pssym; name = $name, spatial_ivs, observed,
+                continuous_events, discrete_events,
                 combinatoric_ratelaws = $combinatoric_ratelaws);
             default_reaction_metadata = $default_reaction_metadata)
     end

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -87,13 +87,13 @@ macro species(ex...)
     resize!(vars.args, idx + length(lastarg.args) + 1)
     for sym in lastarg.args
         vars.args[idx] = :($sym = ModelingToolkit.wrap(setmetadata(
-            ModelingToolkit.value($sym), Catalyst.VariableSpecies, true)))
+            ModelingToolkit.value($sym), VariableSpecies, true)))
         idx += 1
     end
 
     # check nothing was declared isconstantspecies
     ex = quote
-        all(!Catalyst.isconstant ∘ ModelingToolkit.value, $lastarg) ||
+        all(!isconstant ∘ ModelingToolkit.value, $lastarg) ||
             throw(ArgumentError("isconstantspecies metadata can only be used with parameters."))
     end
     vars.args[idx] = ex
@@ -371,7 +371,7 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
     vars, varssym = scalarize_macro(!isempty(variables), vexprs, "vars")
     sps, spssym = scalarize_macro(!isempty(species), sexprs, "specs")
     comps, compssym = scalarize_macro(!isempty(compound_species), compound_expr, "comps")
-    rxexprs = :(Catalyst.CatalystEqType[])
+    rxexprs = :(CatalystEqType[])
     for reaction in reactions
         push!(rxexprs.args, get_rxexprs(reaction))
     end

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -395,8 +395,8 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
         cevents = $continuous_events_expr
         devents = $discrete_events_expr
 
-        Catalyst.remake_ReactionSystem_internal(
-            Catalyst.make_ReactionSystem_internal(
+        remake_ReactionSystem_internal(
+            make_ReactionSystem_internal(
                 rx_eq_vec, $tiv, vars, $pssym; 
                 name = $name, spatial_ivs = sivs_vec, observed = obseqs,
                 continuous_events = cevents, discrete_events = devents,

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -150,7 +150,7 @@ macro reaction_network(name::Expr, ex::Expr)
         MacroTools.striplines(ex); name = :($(esc(name.args[1])))))))
 end
 
-macro reaction_network(ex::Expr)    
+macro reaction_network(ex::Expr)
     ex = MacroTools.striplines(ex)
 
     # no name but equations: @reaction_network begin ... end ...

--- a/test/dsl/dsl_advanced_model_construction.jl
+++ b/test/dsl/dsl_advanced_model_construction.jl
@@ -132,7 +132,8 @@ let
     # Line number nodes aren't ignored so have to be manually removed
     Base.remove_linenums!(ex)
     exsys = Catalyst.make_reaction_system(ex)
-    @test (@eval Catalyst $exsys) isa ReactionSystem
+    sys = @eval Catalyst $exsys
+    @test sys isa ReactionSystem
 end
 
 # Miscellaneous interpolation tests. Unsure what they do here (not related to DSL).

--- a/test/dsl/dsl_advanced_model_construction.jl
+++ b/test/dsl/dsl_advanced_model_construction.jl
@@ -131,7 +131,8 @@ let
     end
     # Line number nodes aren't ignored so have to be manually removed
     Base.remove_linenums!(ex)
-    @test eval(Catalyst.make_reaction_system(ex)) isa ReactionSystem
+    exsys = Catalyst.make_reaction_system(ex)
+    @test (@eval Catalyst $exsys) isa ReactionSystem
 end
 
 # Miscellaneous interpolation tests. Unsure what they do here (not related to DSL).


### PR DESCRIPTION
This introduces a bunch of intermediate variables to store inputs to `make_ReactionSystem_internal`, with the goal of making the generated expression easier to read when debugging. It also makes the creation of `t` the first thing in the generated code, which should be a first step to allowing time-dependent parameters (something MTK is working on better supporting).