### PR TITLE
drop scalarizing

### DIFF
--- a/docs/src/model_creation/dsl_advanced.md
+++ b/docs/src/model_creation/dsl_advanced.md
@@ -256,7 +256,7 @@ Sometimes, one wishes to declare a large number of similar parameters or species
 using Catalyst # hide
 two_state_model = @reaction_network begin
     @parameters k[1:2]
-    @species X(t)[1:2]
+    @species (X(t))[1:2]
     (k[1],k[2]), X[1] <--> X[2]
 end
 ```

--- a/docs/src/model_creation/examples/programmatic_generative_linear_pathway.md
+++ b/docs/src/model_creation/examples/programmatic_generative_linear_pathway.md
@@ -84,7 +84,7 @@ t = default_t()
 @parameters τ
 function generate_lp(n)
     # Creates a vector `X` with n+1 species.
-    @species X(t)[1:n+1]
+    @species (X(t))[1:n+1]
     @species Xend(t)
 
     # Generate

--- a/docs/src/model_creation/examples/smoluchowski_coagulation_equation.md
+++ b/docs/src/model_creation/examples/smoluchowski_coagulation_equation.md
@@ -98,7 +98,7 @@ for n = 1:nr
                            [1, 1], [1]))
     end
 end
-@named rs = ReactionSystem(rx, t, collect(X), collect(k))
+@named rs = ReactionSystem(rx, t, collect(X), [k])
 rs = complete(rs)
 ```
 We now convert the [`ReactionSystem`](@ref) into a `ModelingToolkit.JumpSystem`, and solve it using Gillespie's direct method. For details on other possible solvers (SSAs), see the [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/types/jump_types/) documentation

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -369,10 +369,10 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
     sexprs = get_sexpr(species_extracted, options; iv_symbols = ivs)
     vexprs = get_sexpr(vars_extracted, options, :variables; iv_symbols = ivs)
     pexprs = get_pexpr(parameters_extracted, options)
-    ps, pssym = scalarize_macro(!isempty(parameters), pexprs, "ps")
-    vars, varssym = scalarize_macro(!isempty(variables), vexprs, "vars")
-    sps, spssym = scalarize_macro(!isempty(species), sexprs, "specs")
-    comps, compssym = scalarize_macro(!isempty(compound_species), compound_expr, "comps")
+    ps, pssym = assign_expr_to_var(!isempty(parameters), pexprs, "ps")
+    vars, varssym = assign_expr_to_var(!isempty(variables), vexprs, "vars", true)
+    sps, spssym = assign_expr_to_var(!isempty(species), sexprs, "specs", true)
+    comps, compssym = assign_expr_to_var(!isempty(compound_species), compound_expr, "comps", true)
     rxexprs = :(CatalystEqType[])
     for reaction in reactions
         push!(rxexprs.args, get_rxexprs(reaction))
@@ -381,8 +381,6 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
         equation = escape_equation_RHS!(equation)
         push!(rxexprs.args, equation)
     end
-
-    #println(observed_vars)
 
     # Output code corresponding to the reaction system. 
     quote
@@ -593,14 +591,21 @@ function get_rxexprs(rxstruct)
 end
 
 # takes a ModelingToolkit declaration macro like @parameters and returns an expression
-# that calls the macro and then scalarizes all the symbols created into a vector of Nums
-function scalarize_macro(nonempty, ex, name)
+# that calls the macro and saves it in a variable named namesym. 
+# also scalarizes if desired
+function assign_expr_to_var(nonempty, ex, name, scalarize = false)
     namesym = gensym(name)
     if nonempty
-        symvec = gensym()
-        ex = quote
-            $symvec = $ex
-            $namesym = reduce(vcat, Symbolics.scalarize($symvec))
+        if scalarize
+            symvec = gensym()
+            ex = quote
+                $symvec = $ex
+                $namesym = reduce(vcat, Symbolics.scalarize($symvec))
+            end
+        else
+            ex = quote
+                $namesym = $ex
+            end
         end
     else
         ex = :($namesym = Num[])

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -382,6 +382,8 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
         push!(rxexprs.args, equation)
     end
 
+    #println(observed_vars)
+
     # Output code corresponding to the reaction system. 
     quote
         $ivexpr

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -370,10 +370,10 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
     vexprs = get_sexpr(vars_extracted, options, :variables; iv_symbols = ivs)
     pexprs = get_pexpr(parameters_extracted, options)
     ps, pssym = assign_expr_to_var(!isempty(parameters), pexprs, "ps")
-    vars, varssym = assign_expr_to_var(!isempty(variables), vexprs, "vars"; 
+    vars, varssym = assign_expr_to_var(!isempty(variables), vexprs, "vars";
         scalarize = true)
-    sps, spssym = assign_expr_to_var(!isempty(species), sexprs, "specs"; scalarize =  true)
-    comps, compssym = assign_expr_to_var(!isempty(compound_species), compound_expr, 
+    sps, spssym = assign_expr_to_var(!isempty(species), sexprs, "specs"; scalarize = true)
+    comps, compssym = assign_expr_to_var(!isempty(compound_species), compound_expr,
         "comps"; scalarize = true)
     rxexprs = :(CatalystEqType[])
     for reaction in reactions

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -370,9 +370,11 @@ function make_reaction_system(ex::Expr; name = :(gensym(:ReactionSystem)))
     vexprs = get_sexpr(vars_extracted, options, :variables; iv_symbols = ivs)
     pexprs = get_pexpr(parameters_extracted, options)
     ps, pssym = assign_expr_to_var(!isempty(parameters), pexprs, "ps")
-    vars, varssym = assign_expr_to_var(!isempty(variables), vexprs, "vars", true)
-    sps, spssym = assign_expr_to_var(!isempty(species), sexprs, "specs", true)
-    comps, compssym = assign_expr_to_var(!isempty(compound_species), compound_expr, "comps", true)
+    vars, varssym = assign_expr_to_var(!isempty(variables), vexprs, "vars"; 
+        scalarize = true)
+    sps, spssym = assign_expr_to_var(!isempty(species), sexprs, "specs"; scalarize =  true)
+    comps, compssym = assign_expr_to_var(!isempty(compound_species), compound_expr, 
+        "comps"; scalarize = true)
     rxexprs = :(CatalystEqType[])
     for reaction in reactions
         push!(rxexprs.args, get_rxexprs(reaction))
@@ -591,9 +593,9 @@ function get_rxexprs(rxstruct)
 end
 
 # takes a ModelingToolkit declaration macro like @parameters and returns an expression
-# that calls the macro and saves it in a variable named namesym. 
-# also scalarizes if desired
-function assign_expr_to_var(nonempty, ex, name, scalarize = false)
+# that calls the macro and saves it in a variable given by namesym based on name.
+# scalarizes if desired
+function assign_expr_to_var(nonempty, ex, name; scalarize = false)
     namesym = gensym(name)
     if nonempty
         if scalarize

--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -665,7 +665,8 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     for (i, depidx) in enumerate(depidxs)
         scaleby = (N[i, depidx] != 1) ? N[i, depidx] : one(eltype(N))
         (scaleby != 0) || error("Error, found a zero in the conservation law matrix where "
-              * "one was not expected.")
+              *
+              "one was not expected.")
         coefs = @view N[i, indepidxs]
         terms = sum(p -> p[1] / scaleby * p[2], zip(coefs, indepspecs))
         eq = depspecs[i] ~ constants[i] - terms

--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -657,16 +657,15 @@ function cache_conservationlaw_eqs!(rn::ReactionSystem, N::AbstractMatrix, col_o
     indepspecs = sts[indepidxs]
     depidxs = col_order[(r + 1):end]
     depspecs = sts[depidxs]
-    constants = MT.unwrap.(MT.scalarize(only(
-        @parameters $(CONSERVED_CONSTANT_SYMBOL)[1:nullity] [conserved = true])))
+    constants = MT.unwrap(only(
+        @parameters $(CONSERVED_CONSTANT_SYMBOL)[1:nullity] [conserved = true]))
 
     conservedeqs = Equation[]
     constantdefs = Equation[]
     for (i, depidx) in enumerate(depidxs)
         scaleby = (N[i, depidx] != 1) ? N[i, depidx] : one(eltype(N))
         (scaleby != 0) || error("Error, found a zero in the conservation law matrix where "
-              *
-              "one was not expected.")
+              * "one was not expected.")
         coefs = @view N[i, indepidxs]
         terms = sum(p -> p[1] / scaleby * p[2], zip(coefs, indepspecs))
         eq = depspecs[i] ~ constants[i] - terms

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -485,11 +485,10 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
         spatial_ivs = nothing, continuous_events = [], discrete_events = [],
         observed = [], kwargs...)
 
-    # Filters away any potential observables from `states` and `spcs`.
+    # Error if any observables have been declared a species or variable
     obs_vars = Set(obs_eq.lhs for obs_eq in observed)
     any(in(obs_vars), us_in) &&
         error("Found an observable in the list of unknowns. This is not allowed.")
-    # us_in = filter(u -> !any(isequal(u, obs_var) for obs_var in obs_vars), us_in)
 
     # Creates a combined iv vector (iv and sivs). This is used later in the function (so that 
     # independent variables can be excluded when encountered quantities are added to `us` and `ps`).

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -487,7 +487,8 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
 
     # Filters away any potential observables from `states` and `spcs`.
     obs_vars = Set(obs_eq.lhs for obs_eq in observed)
-    any(in(obs_vars), us_in) && error("Found an observable in the list of unknowns. This is not allowed.")
+    any(in(obs_vars), us_in) &&
+        error("Found an observable in the list of unknowns. This is not allowed.")
     # us_in = filter(u -> !any(isequal(u, obs_var) for obs_var in obs_vars), us_in)
 
     # Creates a combined iv vector (iv and sivs). This is used later in the function (so that 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -405,11 +405,11 @@ function ReactionSystem(eqs, iv, unknowns, ps;
     sivs′ = if spatial_ivs === nothing
         Vector{typeof(iv′)}()
     else
-        value.(MT.scalarize(spatial_ivs))
+        value.(spatial_ivs)
     end
-    unknowns′ = sort!(value.(MT.scalarize(unknowns)), by = !isspecies)
+    unknowns′ = sort!(value.(unknowns), by = !isspecies)
     spcs = filter(isspecies, unknowns′)
-    ps′ = value.(MT.scalarize(ps))
+    ps′ = value.(ps)
 
     # Checks that no (by Catalyst) forbidden symbols are used.
     allsyms = Iterators.flatten((ps′, unknowns′))
@@ -494,7 +494,7 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
     t = value(iv)
     ivs = Set([t])
     if (spatial_ivs !== nothing)
-        for siv in (MT.scalarize(spatial_ivs))
+        for siv in (spatial_ivs)
             push!(ivs, value(siv))
         end
     end

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -564,7 +564,6 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
             push!(new_ps, p)
         end
     end
-    @show new_ps
     psv = collect(new_ps)
 
     # Passes the processed input into the next `ReactionSystem` call.    

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -503,7 +503,6 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
     # Preallocates the `vars` set, which is used by `findvars!`
     us = OrderedSet{eltype(us_in)}(us_in)
     ps = OrderedSet{eltype(ps_in)}(ps_in)
-    @show eltype(ps_in)
     vars = OrderedSet()
 
     # Extracts the reactions and equations from the combined reactions + equations input vector.

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -502,8 +502,8 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
 
     # Initialises the new unknowns and parameter vectors.
     # Preallocates the `vars` set, which is used by `findvars!`
-    us = OrderedSet{eltype(us_in)}(us_in)
-    ps = OrderedSet{eltype(ps_in)}(ps_in)
+    us = OrderedSet{Any}(us_in)
+    ps = OrderedSet{Any}(ps_in)
     vars = OrderedSet()
 
     # Extracts the reactions and equations from the combined reactions + equations input vector.

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -486,8 +486,9 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
         observed = [], kwargs...)
 
     # Filters away any potential observables from `states` and `spcs`.
-    obs_vars = [obs_eq.lhs for obs_eq in observed]
-    us_in = filter(u -> !any(isequal(u, obs_var) for obs_var in obs_vars), us_in)
+    obs_vars = Set(obs_eq.lhs for obs_eq in observed)
+    any(in(obs_vars), us_in) && error("Found an observable in the list of unknowns. This is not allowed.")
+    # us_in = filter(u -> !any(isequal(u, obs_var) for obs_var in obs_vars), us_in)
 
     # Creates a combined iv vector (iv and sivs). This is used later in the function (so that 
     # independent variables can be excluded when encountered quantities are added to `us` and `ps`).

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -556,7 +556,6 @@ function make_ReactionSystem_internal(rxs_and_eqs::Vector, iv, us_in, ps_in;
             par = arguments(p)[begin]
             if Symbolics.shape(Symbolics.unwrap(par)) !== Symbolics.Unknown() &&
                all(par[i] in ps for i in eachindex(par))
-               @show "here"
                 push!(new_ps, par)
             else
                 push!(new_ps, p)

--- a/test/dsl/dsl_advanced_model_construction.jl
+++ b/test/dsl/dsl_advanced_model_construction.jl
@@ -340,10 +340,23 @@ let
         k[1]*a+k[2], X[1] + V[1]*X[2] --> V[2]*W*Y + B*C
     end
 
-    @parameters k[1:3] a B
+    @parameters k[1:2] a B
     @variables (V(t))[1:2] W(t)
     @species (X(t))[1:2] Y(t) C(t)
     rx = Reaction(k[1]*a+k[2], [X[1], X[2]], [Y, C], [1, V[1]], [V[2] * W, B])
     @named arrtest = ReactionSystem([rx], t)
-    arrtest == rn
+    @test arrtest == rn
+
+    rn = @reaction_network twostate begin
+        @parameters k[1:2]
+        @species (X(t))[1:2]
+        (k[1],k[2]), X[1] <--> X[2]
+    end
+    
+    @parameters k[1:2]
+    @species (X(t))[1:2]
+    rx1 = Reaction(k[1], [X[1]], [X[2]])
+    rx2 = Reaction(k[2], [X[2]], [X[1]])
+    @named twostate = ReactionSystem([rx1, rx2], t)
+    @test twostate == rn
 end

--- a/test/dsl/dsl_options.jl
+++ b/test/dsl/dsl_options.jl
@@ -604,7 +604,7 @@ let
         k, 0 --> X1 + X2
     end
     @test isequal(observed(rn1)[1].rhs, observed(rn2)[1].rhs)
-    @test isequal(observed(rn1)[1].lhs.metadata, observed(rn2)[1].lhs.metadata)
+    @test_broken isequal(observed(rn1)[1].lhs.metadata, observed(rn2)[1].lhs.metadata)
     @test isequal(unknowns(rn1), unknowns(rn2))
 
     # Case with metadata.
@@ -618,7 +618,7 @@ let
         k, 0 --> X1 + X2
     end
     @test isequal(observed(rn3)[1].rhs, observed(rn4)[1].rhs)
-    @test isequal(observed(rn3)[1].lhs.metadata, observed(rn4)[1].lhs.metadata)
+    @test_broken isequal(observed(rn3)[1].lhs.metadata, observed(rn4)[1].lhs.metadata)
     @test isequal(unknowns(rn3), unknowns(rn4))
 end
 
@@ -822,10 +822,7 @@ let
         @variables X(t)
         @equations 2X ~ $c - X
     end)
-
-    u0 = [rn.X => 0.0]
-    ps = []
-    oprob = ODEProblem(rn, u0, (0.0, 100.0), ps; structural_simplify=true)
+    oprob = ODEProblem(rn, [], (0.0, 100.0); structural_simplify=true)
     sol = solve(oprob, Tsit5(); abstol=1e-9, reltol=1e-9)
     @test sol[rn.X][end] ≈ 2.0
 end

--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -343,7 +343,7 @@ end
 let 
     # Prepares the model.
     t = default_t()
-    @species X(t)[1:2]
+    @species (X(t))[1:2]
     @parameters k[1:2]
     rxs = [
         Reaction(k[1], [X[1]], [X[2]]),

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -46,11 +46,12 @@ odesys = complete(convert(ODESystem, rs))
 sdesys = complete(convert(SDESystem, rs))
 
 # Hard coded ODE rhs.
-function oderhs(u, k, t)
+function oderhs(u, kv, t)
     A = u[1]
     B = u[2]
     C = u[3]
     D = u[4]
+    k = kv[1]
     du = zeros(eltype(u), 4)
     du[1] = k[1] - k[3] * A + k[4] * C + 2 * k[5] * C - k[6] * A * B + k[7] * B^2 / 2 -
             k[9] * A * B - k[10] * A^2 - k[11] * A^2 / 2 - k[12] * A * B^3 * C^4 / 144 -
@@ -68,11 +69,12 @@ function oderhs(u, k, t)
 end
 
 # SDE noise coefs.
-function sdenoise(u, k, t)
+function sdenoise(u, kv, t)
     A = u[1]
     B = u[2]
     C = u[3]
     D = u[4]
+    k = kv[1]
     G = zeros(eltype(u), length(k), length(u))
     z = zero(eltype(u))
 
@@ -178,7 +180,7 @@ let
         Reaction(k[19] * t, [D], [E]),                                # D -> E with non constant rate.
         Reaction(k[20] * t * A, [D, E], [F], [2, 1], [2]),                  # 2D + E -> 2F with non constant rate.
     ]
-    @named rs = ReactionSystem(rxs, t, [A, B, C, D, E, F], k)
+    @named rs = ReactionSystem(rxs, t, [A, B, C, D, E, F], [k])
     rs = complete(rs)
     js = complete(convert(JumpSystem, rs))
 
@@ -190,7 +192,7 @@ let
     @test all(map(i -> typeof(equations(js)[i]) <: JumpProcesses.VariableRateJump, vidxs))
 
     p = rand(rng, length(k))
-    pmap = parameters(js) .=> p
+    pmap = [k => p]
     u0 = rand(rng, 2:10, 6)
     u0map = unknowns(js) .=> u0
     ttt = rand(rng)

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -141,7 +141,6 @@ end
 let
     u = rnd_u0(rs, rng)
     p = rnd_ps(rs, rng)
-    @show u,p
     du = oderhs(last.(u), last.(p), 0.0)
     G = sdenoise(last.(u), last.(p), 0.0)
     sdesys = complete(convert(SDESystem, rs))

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -868,11 +868,9 @@ end
 let
     @species (A(t))[1:20]
     using ModelingToolkit: value
-    @test isspecies(value(A))
-    @test isspecies(value(A[2]))
-    Av = value.(ModelingToolkit.scalarize(A))
-    @test isspecies(Av[2])
-    @test isequal(value(Av[2]), value(A[2]))
+    Av = value(A)
+    @test isspecies(Av)
+    @test all(i -> isspecies(Av[i]), 1:length(Av))
 end
 
 # Test mixed models are formulated correctly.

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -391,7 +391,7 @@ end
 # Needs fix for https://github.com/JuliaSymbolics/Symbolics.jl/issues/842.
 let
     @parameters a
-    @species A(t) B(t) C(t)[1:2]
+    @species A(t) B(t) (C(t))[1:2]
     rx1 = Reaction(a, [A, C[1]], [C[2], B], [1, 2], [2, 3])
     io = IOBuffer()
     show(io, rx1)

--- a/test/simulation_and_solving/simulate_SDEs.jl
+++ b/test/simulation_and_solving/simulate_SDEs.jl
@@ -204,9 +204,9 @@ let
         (k1, k2), X1 ↔ X2, ([noise_scaling=η[1]],[noise_scaling=η[2]])
     end
     @unpack k1, k2, η = noise_scaling_network_2
-    sprob_2_1 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η[1] => 2.0, η[2] => 2.0])
-    sprob_2_2 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η[1] => 2.0, η[2] => 0.2])
-    sprob_2_3 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η[1] => 0.2, η[2] => 0.2])
+    sprob_2_1 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η => [2.0, 2.0]])
+    sprob_2_2 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η => [2.0, 0.2]])
+    sprob_2_3 = SDEProblem(noise_scaling_network_2, u0, (0.0, 1000.0), [k1 => 2.0, k2 => 0.66, η => [0.2, 0.2]])
     for repeat in 1:5
         sol_2_1 = solve(sprob_2_1, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))
         sol_2_2 = solve(sprob_2_2, ImplicitEM(); saveat = 1.0, seed = rand(rng, 1:100))

--- a/test/test_functions.jl
+++ b/test/test_functions.jl
@@ -7,22 +7,22 @@ using Random, Test
 
 # Generates a random initial condition (in the form of a map). Each value is a Float64.
 function rnd_u0(sys, rng; factor = 1.0, min = 0.0)
-    return [u => min + factor * rand(rng) for u in unknowns(sys)]
+    return [u => (min .+ factor .* rand(rng, size(u)...)) for u in unknowns(sys)]
 end
 
 # Generates a random initial condition (in the form of a map). Each value is a Int64.
 function rnd_u0_Int64(sys, rng; n = 5, min = 0)
-    return [u => min + rand(rng, 1:n) for u in unknowns(sys)]
+    return [u => (min .+ rand(rng, 1:n, size(u)...)) for u in unknowns(sys)]
 end
 
 # Generates a random parameter set (in the form of a map). Each value is a Float64.
 function rnd_ps(sys, rng; factor = 1.0, min = 0.0)
-    return [p => min + factor * rand(rng) for p in parameters(sys)]
+    return [p => ( min .+ factor .* rand(rng, size(p)...)) for p in parameters(sys)]
 end
 
 # Generates a random parameter set (in the form of a map). Each value is a Float64.
 function rnd_ps_Int64(sys, rng; n = 5, min = 0)
-    return [p => min + rand(rng, 1:n) for p in parameters(sys)]
+    return [p => (min .+ rand(rng, 1:n, size(p)...)) for p in parameters(sys)]
 end
 
 # Used to convert a generated initial condition/parameter set to a vector that can be used for normal

--- a/test/upstream/mtk_problem_inputs.jl
+++ b/test/upstream/mtk_problem_inputs.jl
@@ -180,7 +180,7 @@ end
 begin 
     # Declares the model (with vector species/parameters, with/without default values, and observables).
     t = default_t()
-    @species X(t)[1:2] Y(t)[1:2] = [10.0, 20.0] XY(t)[1:2]
+    @species (X(t))[1:2] (Y(t))[1:2] = [10.0, 20.0] (XY(t))[1:2]
     @parameters p[1:2] d[1:2] = [0.2, 0.5]
     rxs = [
         Reaction(p[1], [], [X[1]]),


### PR DESCRIPTION
Closes https://github.com/SciML/Catalyst.jl/issues/1051

Not handled yet
- [x] parameters are not being left as arrays/vectors when using the two-argument constructor
- [x] scalarizing in the DSL
- [ ] ~scalarizing in spatial code~ I'm not sufficiently familiar with the spatial code, and tests are passing I think, so I will leave this for @TorkelE to handle when he has time. See https://github.com/SciML/Catalyst.jl/issues/1059

WIth this PR the DSL will still scalarize non-parameters, but I believe this is consistent with MTK now.