### PR TITLE
fix: turn off parameter splitting for `BifurcationProblem`

### DIFF
--- a/ext/CatalystBifurcationKitExtension/bifurcation_kit_extension.jl
+++ b/ext/CatalystBifurcationKitExtension/bifurcation_kit_extension.jl
@@ -24,7 +24,7 @@ function BK.BifurcationProblem(rs::ReactionSystem, u0_bif, ps, bif_par, args...;
     Catalyst.conservationlaw_errorcheck(rs, vcat(ps, u0))
     nsys = convert(NonlinearSystem, rs; defaults = Dict(u0),
         remove_conserved = true, remove_conserved_warn = false)
-    nsys = complete(nsys)
+    nsys = complete(nsys; split = false)
 
     # Makes BifurcationProblem (this call goes through the ModelingToolkit-based BifurcationKit extension).
     return BK.BifurcationProblem(nsys, u0_bif, ps, bif_par, args...; plot_var,


### PR DESCRIPTION
`BifurcationProblem` does not support symbolic indexing and as a result, MTK (somewhat hackily) just removes `sys.index_cache` in the `BifurcationProblem` constructor to force `split = false` behavior. However, with `complete` now reordering parameters, this breaks assumptions and makes analysis of these problems difficult.

In hindsight, `BifurcationProblem` should have just errored if the system was created with `split=true`, but changing that behavior is breaking. I will add a warning in MTK. For now, this should fix CI

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
