### PR TITLE
Add compose dispatch and constent handling of scoping to MTK

### DIFF
--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -26,7 +26,7 @@ import Symbolics: BasicSymbolic
 using Symbolics: iscall, sorted_arguments
 using ModelingToolkit: Symbolic, value, get_unknowns, get_ps, get_iv, get_systems,
                        get_eqs, get_defaults, toparam, get_var_to_name, get_observed,
-                       getvar
+                       getvar, has_iv
 
 import ModelingToolkit: get_variables, namespace_expr, namespace_equation, get_variables!,
                         modified_unknowns!, validate, namespace_variables,

--- a/src/reaction.jl
+++ b/src/reaction.jl
@@ -351,20 +351,16 @@ MT.is_alg_equation(rx::Reaction) = false
 # MTK functions for extracting variables within equation type object
 MT.eqtype_supports_collect_vars(rx::Reaction) = true
 function MT.collect_vars!(unknowns, parameters, rx::Reaction, iv; depth = 0,
-        op = MT.Differential)
+        op = MT.Differential)    
+
     MT.collect_vars!(unknowns, parameters, rx.rate, iv; depth, op)
-    for sub in rx.substrates
-        MT.collect_vars!(unknowns, parameters, sub, iv; depth, op)
+
+    for items in (rx.substrates, rx.products, rx.substoich, rx.prodstoich)
+        for item in items
+            MT.collect_vars!(unknowns, parameters, item, iv; depth, op)
+        end
     end
-    for prod in rx.products
-        MT.collect_vars!(unknowns, parameters, prod, iv; depth, op)
-    end
-    for substoich in rx.substoich
-        MT.collect_vars!(unknowns, parameters, substoich, iv; depth, op)
-    end
-    for prodstoich in rx.prodstoich
-        MT.collect_vars!(unknowns, parameters, prodstoich, iv; depth, op)
-    end
+
     if hasnoisescaling(rx)
         ns = getnoisescaling(rx)
         MT.collect_vars!(unknowns, parameters, ns, iv; depth, op)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1403,7 +1403,7 @@ end
 Compose the indicated [`ReactionSystem`](@ref) with one or more `AbstractSystem`s.
 
 """
-function compose(sys::ReactionSystem, systems::AbstractArray; name = nameof(sys))
+function ModelingToolkit.compose(sys::ReactionSystem, systems::AbstractArray; name = nameof(sys))
     nsys = length(systems)
     nsys == 0 && return sys
     @set! sys.name = name

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1402,6 +1402,11 @@ end
 
 Compose the indicated [`ReactionSystem`](@ref) with one or more `AbstractSystem`s.
 
+Notes:
+- The `AbstractSystem` being added in must be an `ODESystem`, `NonlinearSystem`,
+  or `ReactionSystem` currently.
+- Returns a new `ReactionSystem` and does not modify `rs`.
+- By default, the new `ReactionSystem` will have the same name as `sys`.
 """
 function ModelingToolkit.compose(sys::ReactionSystem, systems::AbstractArray; name = nameof(sys))
     nsys = length(systems)

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1415,9 +1415,9 @@ function ModelingToolkit.compose(sys::ReactionSystem, systems::AbstractArray; na
     @set! sys.systems = [get_systems(sys); systems]
     newunknowns = OrderedSet{BasicSymbolic{Real}}()
     newparams = OrderedSet()
-    iv = MT.has_iv(sys) ? MT.get_iv(sys) : nothing
+    iv = has_iv(sys) ? get_iv(sys) : nothing
     for ssys in systems
-        collect_scoped_vars!(newunknowns, newparams, ssys, iv)
+        MT.collect_scoped_vars!(newunknowns, newparams, ssys, iv)
     end
 
     if !isempty(newunknowns) 

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1415,7 +1415,7 @@ function ModelingToolkit.compose(sys::ReactionSystem, systems::AbstractArray; na
     @set! sys.systems = [get_systems(sys); systems]
     newunknowns = OrderedSet{BasicSymbolic{Real}}()
     newparams = OrderedSet()
-    iv = has_iv(sys) ? get_iv(sys) : nothing
+    iv = MT.has_iv(sys) ? MT.get_iv(sys) : nothing
     for ssys in systems
         collect_scoped_vars!(newunknowns, newparams, ssys, iv)
     end


### PR DESCRIPTION
Also switches us to using `ModelingToolkit.collect_vars!` for everything but events (where there is no such functionality).