### PR TITLE
Add tutorial set-up code

### DIFF
--- a/docs/src/model_creation/examples/basic_CRN_library.md
+++ b/docs/src/model_creation/examples/basic_CRN_library.md
@@ -1,8 +1,8 @@
 # [Library of Basic Chemical Reaction Network Models](@id basic_CRN_library)
 ```@raw html
-<details><summary><strong>Tutorial environment set-up</strong></summary>
+<details><summary><strong>Environment setup and package installation</strong></summary>
 ```
-The following code sets up an environment for running the following examples.
+The following code sets up an environment for running the code on this page.
 ```julia
 using Pkg
 Pkg.activate(".")

--- a/docs/src/model_creation/examples/basic_CRN_library.md
+++ b/docs/src/model_creation/examples/basic_CRN_library.md
@@ -2,7 +2,7 @@
 ```@raw html
 <details><summary><strong>Tutorial environment set-up</strong></summary>
 ```
-The following code sets up an environment for running this tutorial.
+The following code sets up an environment for running the following examples.
 ```julia
 using Pkg
 Pkg.activate(".")

--- a/docs/src/model_creation/examples/basic_CRN_library.md
+++ b/docs/src/model_creation/examples/basic_CRN_library.md
@@ -1,4 +1,22 @@
 # [Library of Basic Chemical Reaction Network Models](@id basic_CRN_library)
+```@raw html
+<details><summary><strong>Tutorial environment set-up</strong></summary>
+```
+The following code sets up an environment for running this tutorial.
+```julia
+using Pkg
+Pkg.activate(".")
+Pkg.add("Catalyst")
+Pkg.add("OrdinaryDiffEqDefault")
+Pkg.add("StochasticDiffEq")
+Pkg.add("JumpProcesses")
+Pkg.add("Plots")
+```
+```@raw html
+</details>
+```
+  \
+  
 Below we will present various simple and established chemical reaction network (CRN) models. Each model is given some brief background, implemented using the `@reaction_network` DSL, and basic simulations are performed.
 
 ## [Birth-death process](@id basic_CRN_library_bd)


### PR DESCRIPTION
Should solve https://github.com/SciML/Catalyst.jl/issues/1105

Right now I just add a simple example for the CRN library example. If we are happy with text and approach we can copy across all (or some?) of the doc pages.

This is how it looks like by default:
![image](https://github.com/user-attachments/assets/f3211330-bf67-4fb7-b85c-e93fd92c9a5e)
And this when you click to expand the menu
![image](https://github.com/user-attachments/assets/7797098e-3f64-44a8-b0ab-932bb3382ad9)
