### PR TITLE
Add errors for array species/parameters when submitted to `LatticeReactionSystem`s

### DIFF
--- a/src/spatial_reaction_systems/lattice_reaction_systems.jl
+++ b/src/spatial_reaction_systems/lattice_reaction_systems.jl
@@ -153,6 +153,13 @@ struct LatticeReactionSystem{Q, R, S, T} <: MT.AbstractTimeDependentSystem
             sr -> check_spatial_reaction_validity(rs, sr; edge_parameters = edge_parameters),
             spatial_reactions)
 
+        # Additional error checks.
+        if any(haskey(Symbolics.unwrap(symvar).metadata, Symbolics.ArrayShapeCtx)
+                for symvar in [ps; species(rs)])
+            println([ps; species(rs)])
+            throw(ArgumentError("Some species and/or parameters used to create the `LatticeReactionSystem` are array variables ($(filter(symvar -> haskey(Symbolics.unwrap(symvar).metadata, Symbolics.ArrayShapeCtx), [ps; species(rs)]))). This is currently not supported."))
+        end
+
         return new{Q, R, S, T}(
             rs, spatial_reactions, lattice, num_verts, num_edges, num_species,
             spat_species, ps, vertex_parameters, edge_parameters, edge_iterator)

--- a/test/spatial_modelling/lattice_reaction_systems.jl
+++ b/test/spatial_modelling/lattice_reaction_systems.jl
@@ -269,6 +269,25 @@ let
     @test_throws ArgumentError LatticeReactionSystem(rs, [tr], CartesianGrid((2,2)))
 end
 
+# Tests for array parameters/species.
+let
+    tr = @transport_reaction D Y
+
+    rs1 = @reaction_network begin
+        @species X(t)[1:2] Y(t)
+        (k1,k2), X[1] <--> X[2]
+    end
+    @test_throws ArgumentError LatticeReactionSystem(rs1, [tr], CartesianGrid((2,2)))
+
+    rs2 =  @reaction_network begin
+        @species Y(t)
+        @parameters k[1:2,1:2]
+        (k[1,1],k[1,2]), X11 <--> X12
+        (k[2,1],k[2,2]), X21 <--> X22
+    end
+    @test_throws ArgumentError LatticeReactionSystem(rs2, [tr], CartesianGrid((2,2)))
+end
+
 ### Tests Grid Vertex and Edge Number Computation ###
 
 # Tests that the correct numbers are computed for num_edges.


### PR DESCRIPTION
Long-term we should probably support it. However, doing so will be a decent chunk of work, and rather low priority right now.