### PR TITLE
Remove last OrdinaryDiffEq mention

### DIFF
--- a/src/reactionsystem_conversions.jl
+++ b/src/reactionsystem_conversions.jl
@@ -795,7 +795,7 @@ end
 
 Example:
 ```julia
-using Catalyst, OrdinaryDiffEq, JumpProcesses, Plots
+using Catalyst, OrdinaryDiffEqTsit5, JumpProcesses, Plots
 rn = @reaction_network begin
     k*(1 + sin(t)), 0 --> A
 end

--- a/src/spatial_reaction_systems/lattice_reaction_systems.jl
+++ b/src/spatial_reaction_systems/lattice_reaction_systems.jl
@@ -27,7 +27,7 @@ are possible.
 Example:
 ```julia
 # Fetch packages.
-using Catalyst, OrdinaryDiffEq
+using Catalyst, OrdinaryDiffEqDefault
 import CairoMakie
 
 # Creates the `LatticeReactionSystem` model.

--- a/src/spatial_reaction_systems/lattice_reaction_systems.jl
+++ b/src/spatial_reaction_systems/lattice_reaction_systems.jl
@@ -27,7 +27,7 @@ are possible.
 Example:
 ```julia
 # Fetch packages.
-using Catalyst, OrdinaryDiffEqTsit5
+using Catalyst, OrdinaryDiffEqDefault
 import CairoMakie
 
 # Creates the `LatticeReactionSystem` model.
@@ -43,7 +43,7 @@ u0 = [:X => rand(5,5)]
 tspan = (0.0, 1.0)
 ps = [:p => 1.0, :d => 0.5, :D => 0.1]
 oprob = ODEProblem(lrs, u0, tspan, ps)
-osol = solve(oprob, Tsit5())
+osol = solve(oprob)
 
 # Saves an animation of the solution to the file "lattice_animation.mp4".
 lattice_animation(osol, :X, lrs, "lattice_animation.mp4")

--- a/src/spatial_reaction_systems/lattice_reaction_systems.jl
+++ b/src/spatial_reaction_systems/lattice_reaction_systems.jl
@@ -27,7 +27,7 @@ are possible.
 Example:
 ```julia
 # Fetch packages.
-using Catalyst, OrdinaryDiffEqDefault
+using Catalyst, OrdinaryDiffEqTsit5
 import CairoMakie
 
 # Creates the `LatticeReactionSystem` model.
@@ -43,7 +43,7 @@ u0 = [:X => rand(5,5)]
 tspan = (0.0, 1.0)
 ps = [:p => 1.0, :d => 0.5, :D => 0.1]
 oprob = ODEProblem(lrs, u0, tspan, ps)
-osol = solve(oprob)
+osol = solve(oprob, Tsit5())
 
 # Saves an animation of the solution to the file "lattice_animation.mp4".
 lattice_animation(osol, :X, lrs, "lattice_animation.mp4")

--- a/src/spatial_reaction_systems/lattice_sim_struct_interfacing.jl
+++ b/src/spatial_reaction_systems/lattice_sim_struct_interfacing.jl
@@ -307,7 +307,7 @@ Notes:
 
 Example:
 ```julia
-using Catalyst, OrdinaryDiffEqTsit5
+using Catalyst, OrdinaryDiffEqDefault
 
 # Prepare `LatticeReactionSystem`s.
 rs = @reaction_network begin
@@ -322,7 +322,7 @@ tspan = (0.0, 10.0)
 ps = [:k1 => 1, :k2 => 2.0, :D => 0.1]
 
 oprob = ODEProblem(lrs1, u0, tspan, ps)
-osol = solve(oprob1, Tsit5())
+osol = solve(oprob)
 lat_getu(osol, :X1, lrs) # Returns the value of X1 at each time step.
 lat_getu(osol, :X1, lrs; t = 0.0:10.0) # Returns the value of X1 at times 0.0, 1.0, ..., 10.0
 ```

--- a/src/spatial_reaction_systems/lattice_sim_struct_interfacing.jl
+++ b/src/spatial_reaction_systems/lattice_sim_struct_interfacing.jl
@@ -4,7 +4,7 @@
     lat_setp!(sim_struct, p, lrs::LatticeReactionSystem, p_val)
 
 For a problem or integrators, update its `p` vector with the input `p_val`. For non-lattice models,
-this is can be done through direct interfacing (e.g. `prob[p] = 1.0`). However, for 
+this is can be done through direct interfacing (e.g. `prob[p] = 1.0`). However, for
 `LatticeReactionSystem`-based problems and integrators, this function must be used instead.
 
 Arguments:
@@ -82,7 +82,7 @@ end
     lat_getp(sim_struct, p, lrs::LatticeReactionSystem)
 
 For a problem or integrators, retrieves its `p` values. For non-lattice models,
-this is can be done through direct interfacing (e.g. `prob[p]`). However, for 
+this is can be done through direct interfacing (e.g. `prob[p]`). However, for
 `LatticeReactionSystem`-based problems and integrators, this function must be used instead. The
 output format depends on the lattice (a dense array for cartesian grid lattices, a sparse array for
 masked grid lattices, and a vector for graph lattices). This format is similar to what is used to
@@ -95,7 +95,7 @@ Arguments:
 - `lrs`: The `LatticeReactionSystem` which was used to generate the structure we wish to modify.
 
 Notes:
-- Even if the parameter is spatially uniform, a full array with its values across all vertices will be retrieved. 
+- Even if the parameter is spatially uniform, a full array with its values across all vertices will be retrieved.
 
 Example:
 ```julia
@@ -145,7 +145,7 @@ end
     lat_setu!(sim_struct, sp, lrs::LatticeReactionSystem, u)
 
 For a problem or integrators, update its `u` vector with the input `u`. For non-lattice models,
-this is can be done through direct interfacing (e.g. `prob[X] = 1.0`). However, for 
+this is can be done through direct interfacing (e.g. `prob[X] = 1.0`). However, for
 `LatticeReactionSystem`-based problems and integrators, this function must be used instead.
 
 Arguments:
@@ -224,7 +224,7 @@ end
     lat_getu(sim_struct, sp, lrs::LatticeReactionSystem)
 
 For a problem or integrators, retrieves its `u` values. For non-lattice models,
-this is can be done through direct interfacing (e.g. `prob[X]`). However, for 
+this is can be done through direct interfacing (e.g. `prob[X]`). However, for
 `LatticeReactionSystem`-based problems and integrators, this function must be used instead. The
 output format depends on the lattice (a dense array for cartesian grid lattices, a sparse array for
 masked grid lattices, and a vector for graph lattices). This format is similar to which is used to
@@ -236,7 +236,7 @@ Arguments:
 - `lrs`: The `LatticeReactionSystem` which was used to generate the structure we wish to modify.
 
 Notes:
-- Even if the species is spatially uniform, a full array with its values across all vertices will be retrieved. 
+- Even if the species is spatially uniform, a full array with its values across all vertices will be retrieved.
 
 Example:
 ```julia
@@ -277,15 +277,15 @@ function lat_getu(jint::JumpProcesses.SSAIntegrator, sp_idx, sp_tot, lattice)
     return reshape_vals(jint.u[sp_idx, :], lattice)
 end
 
-# A single function, `lat_getu`, which contains all interfacing functionality. However, 
-# long-term it should be replaced with a sleeker interface. Ideally as MTK-wide support for 
+# A single function, `lat_getu`, which contains all interfacing functionality. However,
+# long-term it should be replaced with a sleeker interface. Ideally as MTK-wide support for
 # lattice problems and solutions is introduced. Note that SciML considers jump simulation solutions
 # as `ODESolution`, hence that type is specified.
 """
     lat_getu(sol, sp, lrs::LatticeReactionSystem; t = nothing)
 
 A function for retrieving the solution of a `LatticeReactionSystem`-based simulation on various
-desired forms. Generally, for `LatticeReactionSystem`s, the values in `sol` is ordered in a 
+desired forms. Generally, for `LatticeReactionSystem`s, the values in `sol` is ordered in a
 way which is not directly interpretable by the user. Furthermore, the normal Catalyst interface
 for solutions (e.g. `sol[:X]`) does not work for these solutions. Hence this function is used instead.
 
@@ -307,13 +307,13 @@ Notes:
 
 Example:
 ```julia
-using Catalyst, OrdinaryDiffEq
+using Catalyst, OrdinaryDiffEqTsit5
 
 # Prepare `LatticeReactionSystem`s.
 rs = @reaction_network begin
     (k1,k2), X1 <--> X2
 end
-tr = @transport_reaction D X1 
+tr = @transport_reaction D X1
 lrs = LatticeReactionSystem(rs, [tr], CartesianGrid((2,2)))
 
 # Create problems.
@@ -348,7 +348,7 @@ function lat_getu(sol::ODESolution, lattice, t::Nothing, sp_idx::Int64, sp_tot::
     end
 end
 
-# Function which handles the input in the case where `t` is a range of values (i.e. return `sp`s 
+# Function which handles the input in the case where `t` is a range of values (i.e. return `sp`s
 # value at all designated time points.
 function lat_getu(sol::ODESolution, lattice, t::AbstractVector{T}, sp_idx::Int64,
         sp_tot::Int64) where {T <: Number}
@@ -374,8 +374,8 @@ end
 """
     rebuild_lat_internals!(sciml_struct)
 
-Rebuilds the internal functions for simulating a LatticeReactionSystem. Whenever a problem or 
-integrator has had its parameter values updated, this function should be called for the update to 
+Rebuilds the internal functions for simulating a LatticeReactionSystem. Whenever a problem or
+integrator has had its parameter values updated, this function should be called for the update to
 be taken into account. For ODE simulations, `rebuild_lat_internals!` needs only to be called when
 - An edge parameter has been updated.
 - When a parameter with spatially homogeneous values has been given spatially heterogeneous values (or vice versa).
@@ -393,7 +393,7 @@ Example:
 rs = @reaction_network begin
     (k1,k2), X1 <--> X2
 end
-tr = @transport_reaction D X1 
+tr = @transport_reaction D X1
 grid = CartesianGrid((2,2))
 lrs = LatticeReactionSystem(rs, [tr], grid)
 

--- a/test/extensions/lattice_simulation_plotting.jl
+++ b/test/extensions/lattice_simulation_plotting.jl
@@ -2,7 +2,7 @@
 
 # Fetch packages.
 using Catalyst, CairoMakie, GraphMakie, Graphs
-using JumpProcesses, OrdinaryDiffEqDefault, OrdinaryDiffEqTsit5, Test
+using JumpProcesses, OrdinaryDiffEqTsit5, Test
 
 
 ### Checks Basic Plot Cases ###
@@ -19,7 +19,7 @@ let
     diffusion_rx = @transport_reaction D X
     for lattice in [CartesianGrid(3), [true, true, false]]
         lrs = LatticeReactionSystem(rs, [diffusion_rx], lattice)
-        
+
         # Simulates the model (using ODE and jumps).
         u0 = [:X => [1, 2, 3]]
         tspan = (0.0, 1.0)
@@ -34,7 +34,7 @@ let
             # Plots the simulation and checks that a stored value is correct.
             fig, ax, plt = lattice_plot(sol, :X, lrs; t = 1.0)
             @test plt[1].val[1][2] ≈ sol.u[end][1]
-            
+
             # Attempts to animate the simulation (using various arguments). Deletes the saved file.
             lattice_animation(sol, :X, lrs, "animation_tmp.mp4"; nframes = 10, framerate = 10, colormap = :BuGn_6)
             @test isfile("animation_tmp.mp4")
@@ -59,7 +59,7 @@ let
     diffusion_rx = @transport_reaction D X
     for lattice in [CartesianGrid((2,2)), [true true; false true]]
         lrs = LatticeReactionSystem(rs, [diffusion_rx], lattice)
-        
+
         # Simulates the model (using ODE and jumps).
         u0 = [:X => [1 2; 3 4]]
         tspan = (0.0, 1.0)
@@ -74,7 +74,7 @@ let
             # Plots the simulation and checks that a stored value is correct.
             fig, ax, hm = lattice_plot(sol, :X, lrs; t = 1.0)
             @test hm[3].val[1] ≈ sol.u[end][1]
-                    
+
             # Attempts to animate the simulation (using various arguments). Deletes the saved file.
             lattice_animation(sol, :X, lrs, "animation_tmp.mp4"; nframes = 10, framerate = 10, colormap = :BuGn_6)
             @test isfile("animation_tmp.mp4")
@@ -92,7 +92,7 @@ let
     lattice = CartesianGrid((2,2,2))
     lrs = LatticeReactionSystem(rs, [diffusion_rx], lattice)
     oprob = ODEProblem(lrs, [:X => 1.0], 1.0, [:d => 1.0, :D => 0.2])
-    osol = solve(oprob)
+    osol = solve(oprob, Tsit5())
 
     @test_throws ArgumentError lattice_plot(osol, :X, lrs)
     @test_throws ArgumentError lattice_animation(osol, :X, lrs, "animation_tmp.mp4")
@@ -110,7 +110,7 @@ let
     diffusion_rx = @transport_reaction D X
     lattice = Graphs.SimpleGraphs.cycle_graph(4)
     lrs = LatticeReactionSystem(rs, [diffusion_rx], lattice)
-    
+
     # Simulates the model (using ODE and jumps).
     u0 = [:X => [1, 2, 3, 4]]
     tspan = (0.0, 1.0)
@@ -125,7 +125,7 @@ let
         # Plots the simulation and checks that a stored value is correct.
         fig, ax, plt = lattice_plot(sol, :X, lrs; t = 0.0)
         @test plt.node_color[] == osol.u[1]
-        
+
         # Attempts to animate the simulation (using various arguments). Deletes the saved file.
         lattice_animation(sol, :X, lrs, "animation_tmp.mp4"; nframes = 10, framerate = 10, colormap = :BuGn_6)
         @test isfile("animation_tmp.mp4")


### PR DESCRIPTION
Was going to finish this one off https://github.com/SciML/Catalyst.jl/issues/1096, but @vyudu already did. Did the one case remaining in a docstring though. Also, there is this from the `JumpInputs` docstring:
```julia
using Catalyst, OrdinaryDiffEq, JumpProcesses, Plots
rn = @reaction_network begin
    k*(1 + sin(t)), 0 --> A
end
jinput = JumpInputs(rn, [:A => 0], (0.0, 10.0), [:k => .5])
@assert jinput.prob isa ODEProblem
jprob = JumpProblem(jinput)
sol = solve(jprob, Tsit5())
plot(sol, idxs = :A)

rn = @reaction_network begin
    k, 0 --> A
end
jinput = JumpInputs(rn, [:A => 0], (0.0, 10.0), [:k => .5])
@assert jinput.prob isa DiscreteProblem
jprob = JumpProblem(jinput)
sol = solve(jprob)
plot(sol, idxs = :A)
```
Could this be changed from `OrdinaryDiffEq` to `OrdinaryDiffEqTsit5` @isaacsas?
