### PR TITLE
Consider the Danish/Norwegian letter ∅ as the empty set symbol (Ø)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -81,6 +81,7 @@
   end
   plot_network(brusselator)
   ```
+- The letter Ø (used in Danish/Norweigan alphabet) is now conisdred the same as ∅ (empty set). It can no longer be used as a species/parameter.
  
 ## Catalyst 14.4.1
 - Support for user-defined functions on the RHS when providing coupled equations 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -81,7 +81,7 @@
   end
   plot_network(brusselator)
   ```
-- The letter Ø (used in Danish/Norweigan alphabet) is now conisdred the same as ∅ (empty set). It can no longer be used as a species/parameter.
+- The letter Ø (used in Danish/Norwegian alphabet) is now conisdred the same as ∅ (empty set). It can no longer be used as a species/parameter.
  
 ## Catalyst 14.4.1
 - Support for user-defined functions on the RHS when providing coupled equations 

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -69,7 +69,7 @@ const ExprValues = Union{Expr, Symbol, Float64, Int, Bool}
 const CONSERVED_CONSTANT_SYMBOL = :Γ
 
 # Declares symbols which may neither be used as parameters nor unknowns.
-const forbidden_symbols_skip = Set([:ℯ, :pi, :π, :t, :∅])
+const forbidden_symbols_skip = Set([:ℯ, :pi, :π, :t, :∅, :Ø])
 const forbidden_symbols_error = union(Set([:im, :nothing, CONSERVED_CONSTANT_SYMBOL]),
     forbidden_symbols_skip)
 

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -1,7 +1,7 @@
 ### Constants Declarations ###
 
 # Declare various arrow types symbols used for the empty set (also 0).
-const empty_set = Set{Symbol}([:∅])
+const empty_set = Set{Symbol}([:∅, :Ø])
 const fwd_arrows = Set{Symbol}([:>, :(=>), :→, :↣, :↦, :⇾, :⟶, :⟼, :⥟, :⥟, :⇀, :⇁, :⇒, :⟾])
 const bwd_arrows = Set{Symbol}([:<, :(<=), :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :↼, :↽, :⇐, :⟽,
     Symbol("<--")])

--- a/src/spatial_reaction_systems/spatial_reactions.jl
+++ b/src/spatial_reaction_systems/spatial_reactions.jl
@@ -155,7 +155,7 @@ end
 # Loops through a rate and extracts all parameters.
 function find_parameters_in_rate!(parameters, rateex::ExprValues)
     if rateex isa Symbol
-        if rateex in [:t, :∅, :im, :nothing, CONSERVED_CONSTANT_SYMBOL]
+        if rateex in [:t, :∅, :Ø, :im, :nothing, CONSERVED_CONSTANT_SYMBOL]
             error("Forbidden term $(rateex) used in transport reaction rate.")
         elseif !(rateex in [:ℯ, :pi, :π])
             push!(parameters, rateex)

--- a/test/dsl/dsl_basic_model_construction.jl
+++ b/test/dsl/dsl_basic_model_construction.jl
@@ -444,7 +444,7 @@ let
     @test any(isequal(I), unknowns(rn))
 end
 
-# Test that Ø (Danish/Noerweigan letter), ∅ (empty set), and 0 (zero) are equivalent.
+# Test that Ø (Danish/Norwegian letter), ∅ (empty set), and 0 (zero) are equivalent.
 let
     rn1 = @reaction_network rn begin
         p, Ø --> X
@@ -462,7 +462,15 @@ let
         p, Ø --> X
         d, X --> ∅
     end
-    @test rn1 == rn2 == rn3 == rn4
+    rn5 = @reaction_network rn begin
+        p, Ø --> X
+        d, X --> 0
+    end
+    rn6 = @reaction_network rn begin
+        p, ∅ --> X
+        d, X --> 0
+    end
+    @test rn1 == rn2 == rn3 == rn4 == rn5 == rn6
 end
 
 # Tests backwards and bi-directional arrows.

--- a/test/dsl/dsl_basic_model_construction.jl
+++ b/test/dsl/dsl_basic_model_construction.jl
@@ -444,6 +444,27 @@ let
     @test any(isequal(I), unknowns(rn))
 end
 
+# Test that Ø (Danish/Noerweigan letter), ∅ (empty set), and 0 (zero) are equivalent.
+let
+    rn1 = @reaction_network rn begin
+        p, Ø --> X
+        d, X --> Ø
+    end
+    rn2 = @reaction_network rn begin
+        p, ∅ --> X
+        d, X --> ∅
+    end
+    rn3 = @reaction_network rn begin
+        p, 0 --> X
+        d, X --> 0
+    end
+    rn4 = @reaction_network rn begin
+        p, Ø --> X
+        d, X --> ∅
+    end
+    @test rn1 == rn2 == rn3 == rn4
+end
+
 # Tests backwards and bi-directional arrows.
 let
     rn1 = @reaction_network arrowtest begin
@@ -472,7 +493,7 @@ let
 end
 
 # Test that symbols with special meanings are handled properly.
-let 
+let
     test_network = @reaction_network begin t * k, X --> ∅ end
     @test length(species(test_network)) == 1
     @test length(parameters(test_network)) == 1
@@ -532,7 +553,7 @@ let
     @test_throws Exception @eval @reaction nothing, 0 --> X
     @test_throws Exception @eval @reaction Γ, 0 --> X
     @test_throws Exception @eval @reaction ∅, 0 --> X
-    
+
     # @reaction macro, symbols that cannot be a reactant.
     @test_throws Exception @eval @reaction 1, 0 --> im
     @test_throws Exception @eval @reaction 1, 0 --> nothing
@@ -541,13 +562,13 @@ let
     @test_throws Exception @eval @reaction 1, 0 --> pi
     @test_throws Exception @eval @reaction 1, 0 --> π
     @test_throws Exception @eval @reaction 1, 0 --> t
-    
+
     # @reaction_network macro, symbols that cannot be in the rate.
     @test_throws Exception @eval @reaction_network begin im, 0 --> X end
     @test_throws Exception @eval @reaction_network begin nothing, 0 --> X end
     @test_throws Exception @eval @reaction_network begin Γ, 0 --> X end
     @test_throws Exception @eval @reaction_network begin ∅, 0 --> X end
-    
+
     # @reaction_network macro, symbols that cannot be a reactant.
     @test_throws Exception @eval @reaction_network begin 1, 0 --> im end
     @test_throws Exception @eval @reaction_network begin 1, 0 --> nothing end


### PR DESCRIPTION
Currently this:
```julia
@reaction_network begin
    (p,d), Ø <--> X
end
```
is interpreted as transformation between species Ø and X, as the unicode for the letter Ø is used instead of the empty set ∅.