### PR TITLE
Add catalys version to serialisation function

### DIFF
--- a/src/reactionsystem_serialisation/serialise_reactionsystem.jl
+++ b/src/reactionsystem_serialisation/serialise_reactionsystem.jl
@@ -92,7 +92,7 @@ function get_full_system_string(rn::ReactionSystem, annotate::Bool, top_level::B
         has_equations, has_observed, has_defaults, has_continuous_events,
         has_discrete_events, has_systems, has_connection_type)
     annotate || (@string_prepend! "\n" file_text)
-    annotate && @string_prepend! "\n# Serialised using Catalyst version v$(Catalyst.VERSION)." file_text
+    annotate && top_level && @string_prepend! "\n# Serialised using Catalyst version v$(Catalyst.VERSION)." file_text
     @string_prepend! "let" file_text
     @string_append! file_text "\n\n" rs_creation_code "\n\nend"
 

--- a/src/reactionsystem_serialisation/serialise_reactionsystem.jl
+++ b/src/reactionsystem_serialisation/serialise_reactionsystem.jl
@@ -85,13 +85,14 @@ function get_full_system_string(rn::ReactionSystem, annotate::Bool, top_level::B
         top_level, CONNECTION_TYPE_FS)
 
     # Finalise the system. Creates the final `ReactionSystem` call.
-    # Enclose everything in a `let ... end` block.
+    # Enclose everything in a `let ... end` block. Potentially add Catalyst version number.
     rs_creation_code = make_reaction_system_call(
         rn, annotate, top_level, has_sivs, has_species,
         has_variables, has_parameters, has_reactions,
         has_equations, has_observed, has_defaults, has_continuous_events,
         has_discrete_events, has_systems, has_connection_type)
     annotate || (@string_prepend! "\n" file_text)
+    annotate && @string_prepend! "\n# Serialised using Catalyst version v$(Catalyst.VERSION)." file_text
     @string_prepend! "let" file_text
     @string_append! file_text "\n\n" rs_creation_code "\n\nend"
 

--- a/test/miscellaneous_tests/reactionsystem_serialisation.jl
+++ b/test/miscellaneous_tests/reactionsystem_serialisation.jl
@@ -34,6 +34,7 @@ let
     file_string_annotated = read("test_serialisation_annotated.jl", String)
     file_string = read("test_serialisation.jl", String)
     file_string_annotated_real = """let
+    # Serialised using Catalyst version v$(Catalyst.VERSION).
 
     # Independent variable:
     @parameters t


### PR DESCRIPTION
If the `annotate = true` (default) option is used, a string like 
```julia
# Serialised using Catalyst version v1.11.4.
```
will be added to the beginning of the file, telling which version of Catalyst the model was serialised with.