### PR TITLE
Improve expression parser function

### DIFF
--- a/src/chemistry_functionality.jl
+++ b/src/chemistry_functionality.jl
@@ -99,7 +99,7 @@ function make_compound(expr)
     # - Any ivs attached to it (ivs, e.g. `[]` or `[t,x]`).
     # - The expression which creates the compound (species_expr, e.g. `CO2 = 1.0, [metadata=true]`).
     species_expr = expr.args[2]
-    species_name, ivs, _, _ = find_varinfo_in_declaration(expr.args[2])
+    species_name, ivs, _, _, _ = find_varinfo_in_declaration(expr.args[2])
 
     # If no ivs were given, inserts  an expression which evaluates to the union of the ivs
     # for the species the compound depends on.

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -757,7 +757,7 @@ function read_observables_option(options, all_ivs, us_declared, all_syms; requir
 
         for (idx, obs_eq) in enumerate(obs_eqs.args)
             # Extract the observable, checks for errors.
-            obs_name, ivs, defaults, metadata = find_varinfo_in_declaration(obs_eq.args[2])
+            obs_name, ivs, _, defaults, metadata = find_varinfo_in_declaration(obs_eq.args[2])
 
             # Error checks.
             (requiredec && !in(obs_name, us_declared)) &&

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -734,7 +734,7 @@ end
 # Searches an expression `expr` and returns true if it has any subexpression `D(...)` (where `...` can be anything).
 # Used to determine whether the default differential D has been used in any equation provided to `@equations`.
 function find_D_call(expr)
-    return if Base.isexpr(expr, :call) && expr.args[1] == :D
+    return if Meta.isexpr(expr, :call) && expr.args[1] == :D
         true
     elseif expr isa Expr
         any(find_D_call, expr.args)

--- a/src/expression_utils.jl
+++ b/src/expression_utils.jl
@@ -87,10 +87,13 @@ function find_varinfo_in_declaration(expr::ExprValues)
         ivs = expr.args[2:end]
         expr = expr.args[1]
     end
+    isnothing(ivs) && (ivs = [])
 
+    # If escaped expression, extract symbol. Checks that the expression is a symbol (e.g. `X` in `:(X(t))`).
+    Meta.isexpr(expr, :escape) && (expr = expr.args[1])
     (expr isa Symbol) ||
         error("Erroneous expression encountered in `find_varinfo_in_declaration` (got `$expr` after processing, this should be a symbol).")
-    return (;ivs, idxs, default, metadata)
+    return (;sym = expr, ivs, idxs, default, metadata)
 end
 
 # Converts an expression of the forms:


### PR DESCRIPTION
With v15 aboud to be released I started deleting all my related local branches. Had one I started regarding some observables fix which, while never pushed, did include a big improvement to one of the expression parsing functions (shorter, easier to read, and can extract `[1:2]` from `X(t)[1:2]` expressions, if we ever need it).

Was a shame to just throw it away so figured I'd removed the other stuff and PR it.

has no actual effect on Catalyst. can be merged whenever we feel like it.