### PR TITLE
Remove eval in system unpacking

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1183,10 +1183,7 @@ Notes:
   the symbolic variables being defined in the `Main` module.
 """
 macro unpacksys(rn)
-    quote
-        ex = Catalyst.__unpacksys($(esc(rn)))
-        Base.eval($(__module__), ex)
-    end
+    Catalyst.__unpacksys((esc(rn)))
 end
 
 """


### PR DESCRIPTION
This should be at least a partial fix to https://github.com/SciML/Catalyst.jl/issues/1235, but may also need  https://github.com/SciML/RuntimeGeneratedFunctions.jl/pull/96 to fully get pre working
