### PR TITLE
Fix indexing deprecation warning

### DIFF
--- a/test/simulation_and_solving/hybrid_models.jl
+++ b/test/simulation_and_solving/hybrid_models.jl
@@ -58,13 +58,13 @@ let
     jinputs = JumpInputs(rn, u0map, tspan, pmap; save_positions = (false, false))
     jprob = JumpProblem(jinputs; rng, save_positions = (false, false))
     times = range(0.0, tspan[2], length = 100)
-    Nsims = 4000
+    Nsims = 4000 
     Xv = zeros(length(times))
     Yv = zeros(length(times))
     for n in 1:Nsims
         sol = solve(jprob, Tsit5(); saveat = times, seed)
-        Xv .+= sol(times; idxs = :X)
-        Yv .+= sol(times; idxs = :Y)
+        Xv .+= sol[:X]
+        Yv .+= sol[:Y]
         seed += 1
     end
     Xv ./= Nsims


### PR DESCRIPTION
Hopefully this fixes the timeout for the prerelease hybrid tests.

@ChrisRackauckas should doing stuff like `some_vector .+= sol(times; idxs = :X)` causing the following message:
```julia
┌ Warning: `Base.getindex(A::AbstractDiffEqArray, i::Int)` is deprecated, use `Base.getindex(A, :, i)` instead.
│   caller = _broadcast_getindex at broadcast.jl:652 [inlined]
```
It seems like this is something that should work?