### PR TITLE
Fix 11 typos across multiple files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -56,7 +56,7 @@
   pmap = [k => rand(4)]
   ```
   While one can still manually scalarize a parameter array, it is recommended
-  *not* to do this as it has signifcant performance costs with ModelingToolkit
+  *not* to do this as it has significant performance costs with ModelingToolkit
   v9. Note, scalarized parameter arrays passed to the two-argument
   `ReactionSystem` constructor may become unscalarized.
 - **BREAKING:** We have introduced a restriction on bundling of reactions in the

--- a/docs/src/model_creation/examples/programmatic_generative_linear_pathway.md
+++ b/docs/src/model_creation/examples/programmatic_generative_linear_pathway.md
@@ -134,4 +134,4 @@ plot!(sol_n20; idxs = :Xend, label = "n = 20")
 ## References
 [^1]: [N. Korsbo, H. Jönsson *It’s about time: Analysing simplifying assumptions for modelling multi-step pathways in systems biology*, PLoS Computational Biology (2020).](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1007982)
 [^2]: [J. Metz, O. Diekmann *The Abstract Foundations of Linear Chain Trickery* (1991).](https://ir.cwi.nl/pub/1559/1559D.pdf)
-[^3]: D. Fargue *Reductibilite des systemes hereditaires a des systemes dynamiques (regis par des equations differentielles aux derivees partielles)*, Comptes rendus de l'Académie des Sciences (1973).
+[^3]: D. Fargue *Reductibilite des systems hereditaires a des systems dynamiques (regis par des equations differentielles aux derivees partielles)*, Comptes rendus de l'Académie des Sciences (1973).

--- a/ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl
+++ b/ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl
@@ -81,7 +81,7 @@ end
 """
 assess_identifiability(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, kwargs...)
 
-Applies StructuralIdentifiability.jl's `assess_identifiability` function to a Catalyst `ReactionSystem`. Internally it is converted ot a `ODESystem`, for which structural identifiability is computed.
+Applies StructuralIdentifiability.jl's `assess_identifiability` function to a Catalyst `ReactionSystem`. Internally it is converted to a `ODESystem`, for which structural identifiability is computed.
 
 Arguments:
 - `rs::ReactionSystem`; The reaction system we wish to compute structural identifiability for.
@@ -123,7 +123,7 @@ end
 """
 find_identifiable_functions(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, kwargs...)
 
-Applies StructuralIdentifiability.jl's `find_identifiable_functions` function to a Catalyst `ReactionSystem`. Internally it is converted ot a `ODESystem`, for which structurally identifiable functions are computed.
+Applies StructuralIdentifiability.jl's `find_identifiable_functions` function to a Catalyst `ReactionSystem`. Internally it is converted to a `ODESystem`, for which structurally identifiable functions are computed.
 
 Arguments:
 - `rs::ReactionSystem`; The reaction system we wish to compute structural identifiability for.

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -383,8 +383,8 @@ struct ReactionSystem{V <: NetworkProperties} <:
     end
 end
 
-# Checks if a symbolic expression constains a differential with respect to a species (either directly
-# or somehwere within the differential expression).
+# Checks if a symbolic expression contains a differential with respect to a species (either directly
+# or somewhere within the differential expression).
 function is_species_diff(expr)
     Symbolics.is_derivative(expr) || return false
     return hasnode(ex -> (ex isa Symbolics.BasicSymbolic) && isspecies(ex) && !isbc(ex), expr)

--- a/src/reactionsystem_conversions.jl
+++ b/src/reactionsystem_conversions.jl
@@ -1037,7 +1037,7 @@ function JumpProcesses.JumpProblem(rs::ReactionSystem, prob::SciMLBase.AbstractD
         expand_catalyst_funs = true, checks = false, kwargs...)
     Base.depwarn("JumpProblem(rn::ReactionSystem, prob, ...) is \
         deprecated and will be removed in Catalyst 16. Use \
-        JumpProblem(JumpInputs(rn, ...), ...) insead.", :JumpProblem)
+        JumpProblem(JumpInputs(rn, ...), ...) instead.", :JumpProblem)
     jsys = convert(JumpSystem, rs; name, combinatoric_ratelaws, 
         expand_catalyst_funs, checks)
     jsys = complete(jsys)
@@ -1160,7 +1160,7 @@ symmap_to_varmap(sys, symmap) = symmap
 ### Other Conversion-related Functions ###
 
 # the following function is adapted from SymbolicUtils.jl v.19
-# later on (Spetember 2023) modified by Torkel and Shashi (now assumes input not on polynomial form, which is handled elsewhere, previous version failed in these cases anyway).
+# later on (September 2023) modified by Torkel and Shashi (now assumes input not on polynomial form, which is handled elsewhere, previous version failed in these cases anyway).
 # Copyright (c) 2020: Shashi Gowda, Yingbo Ma, Mason Protter, Julia Computing.
 # MIT license
 """

--- a/src/reactionsystem_serialisation/serialise_fields.jl
+++ b/src/reactionsystem_serialisation/serialise_fields.jl
@@ -539,7 +539,7 @@ end
 
 # Creates an annotation for the system's systems.
 function get_systems_annotation(rn::ReactionSystem)
-    return "Subystems:"
+    return "Subsystems:"
 end
 
 # Combines the 3 systems-related functions in a constant tuple.

--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -337,9 +337,9 @@ end
 
 # Goes through a chain of updating of conservation law constants/species, checking that
 # the values of relevant quantities are correct after each step.
-# Generally, if `Γ` has not been explicitly updated, it will be updated to acomodate new species
+# Generally, if `Γ` has not been explicitly updated, it will be updated to accommodate new species
 # values. If it has been explicitly updated, the corresponding eliminated quantity will have its
-# value updated to acomodate new Γ/species values (however, we have to manually designate this by setting it to `nothing`).
+# value updated to accommodate new Γ/species values (however, we have to manually designate this by setting it to `nothing`).
 # Also checks that quantities are correctly updated in integrators and solutions derived from problems.
 let
     # Prepares the problem inputs and computes the conservation equation.
@@ -399,7 +399,7 @@ let
         # - The conservation law constant will be kept fixed, and secondary updates are made to the
         # eliminated species.
         # Assumes that X3 is the eliminated species. In most updates, designate its as `nothing` (to
-        # ensure that its value is updated to acommodate the new conservation law).
+        # ensure that its value is updated to accommodate the new conservation law).
         # The random Γ is ensured to be large enough not to generate negative values in the eliminated species.
         for _ in 1:3
             # Updates Γ, checks the values of all species and Γ, then resets `prob_old`.
@@ -509,7 +509,7 @@ let
     u0 = [:X1 => 1.0, :X2 => 2.0, :X3 => 3.0]
     ps = [:k1 => 0.1, :k2 => 0.2, :k3 => 0.3, :k4 => 0.4]
     
-    # Checks that the warning si given and can be supressed for the variosu cases.
+    # Checks that the warning si given and can be suppressed for the variosu cases.
     @test_nowarn convert(NonlinearSystem, rn; remove_conserved = true, conseqs_remake_warn = false)
     @test_logs (:warn, r"Note, when constructing*") convert(NonlinearSystem, rn; remove_conserved = true, conseqs_remake_warn = true)
     @test_nowarn NonlinearProblem(rn, u0, ps; remove_conserved = true, conseqs_remake_warn = false)


### PR DESCRIPTION
## Summary\n\nThis PR fixes legitimate typos found by the typos-cli tool.\n\n## Changes\n\nFixed 11 different typos with 14 total corrections:\n\n- `signifcant` → `significant` (1 occurrences)\n- `systemes` → `systems` (2 occurrences)\n- `insead` → `instead` (1 occurrences)\n- `Spetember` → `September` (1 occurrences)\n- `constains` → `contains` (1 occurrences)\n- `somehwere` → `somewhere` (1 occurrences)\n- `Subystems` → `Subsystems` (1 occurrences)\n- `acomodate` → `accommodate` (2 occurrences)\n- `acommodate` → `accommodate` (1 occurrences)\n- `supressed` → `suppressed` (1 occurrences)\n- `ot` → `to` (2 occurrences)\n\n## Files Modified\n\n- HISTORY.md\n- docs/src/model_creation/examples/programmatic_generative_linear_pathway.md\n- ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl\n- src/reactionsystem.jl\n- src/reactionsystem_conversions.jl\n- src/reactionsystem_serialisation/serialise_fields.jl\n- test/network_analysis/conservation_laws.jl\n\n🤖 Generated automatically by typos-cli analysis