### PR TITLE
Fix awkward line splits from JuliaFormatter

### DIFF
--- a/ext/CatalystCairoMakieExtension/cairo_makie_extension_spatial_modelling.jl
+++ b/ext/CatalystCairoMakieExtension/cairo_makie_extension_spatial_modelling.jl
@@ -24,8 +24,7 @@ function lattice_animation(
     vals, plot_min, plot_max = Catalyst.extract_vals(sol, sp, lrs, plot_min, plot_max, t)
 
     # Creates the base figure (which is modified in the animation).
-    fig, ax,
-    plt = scatterlines(vals[1];
+    fig, ax, plt = scatterlines(vals[1];
         axis = (xlabel = "Compartment", ylabel = "$(sp)",
             limits = (nothing, nothing, plot_min, plot_max)),
         markersize = markersize, kwargs...)
@@ -101,8 +100,7 @@ function lattice_animation(
     x_vals, y_vals = Catalyst.extract_grid_axes(lrs)
 
     # Creates the base figure (which is modified in the animation).
-    fig, ax,
-    hm = heatmap(x_vals, y_vals, vals[1];
+    fig, ax, hm = heatmap(x_vals, y_vals, vals[1];
         axis = (xgridvisible = false, ygridvisible = false,
             xlabel = "Compartment", ylabel = "Compartment"),
         colormap, colorrange = (plot_min, plot_max),

--- a/ext/CatalystGraphMakieExtension/graph_makie_extension_spatial_modelling.jl
+++ b/ext/CatalystGraphMakieExtension/graph_makie_extension_spatial_modelling.jl
@@ -27,10 +27,8 @@ function lattice_animation(
     vals, plot_min, plot_max = Catalyst.extract_vals(sol, sp, lrs, plot_min, plot_max, t)
 
     # Creates the base figure (which is modified in the animation).
-    fig, ax,
-    plt = graphplot(plot_graph; node_color = vals[1],
-        node_attr = (colorrange = (plot_min, plot_max), colormap), node_size, kwargs...
-    )
+    fig, ax, plt = graphplot(plot_graph; node_color = vals[1],
+        node_attr = (colorrange = (plot_min, plot_max), colormap), node_size, kwargs...)
     ttitle && (ax.title = "Time: $(round(t[1]; sigdigits = 3))")
 
     # Creates the animation.

--- a/src/chemistry_functionality.jl
+++ b/src/chemistry_functionality.jl
@@ -275,8 +275,7 @@ function balance_reaction(reaction::Reaction)
     end
 
     isempty(balancedrxs) && (@warn "Unable to balance reaction.")
-    (length(balancedrxs) > 1) &&
-        (@warn "The space of possible balanced versions of the reaction ($reaction) is greater than one-dimension. This prevents the selection of a single appropriate balanced reaction. Instead, a basis for balanced reactions is returned. Note that we do not check if they preserve the set of substrates and products from the original reaction.")
+    (length(balancedrxs) > 1) && (@warn "The space of possible balanced versions of the reaction ($reaction) is greater than one-dimension. This prevents the selection of a single appropriate balanced reaction. Instead, a basis for balanced reactions is returned. Note that we do not check if they preserve the set of substrates and products from the original reaction.")
     return balancedrxs
 end
 

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -3,15 +3,14 @@
 # Declare various arrow types symbols used for the empty set (also 0).
 const empty_set = Set{Symbol}([:∅, :Ø])
 const fwd_arrows = Set{Symbol}([:>, :(=>), :→, :↣, :↦, :⇾, :⟶, :⟼, :⥟, :⥟, :⇀, :⇁, :⇒, :⟾])
-const bwd_arrows = Set{Symbol}([:<, :(<=), :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :↼, :↽, :⇐, :⟽,
-    Symbol("<--")])
+const bwd_arrows = Set{Symbol}([:<, :(<=), :←, :↢, :↤, :⇽, :⟵, :⟻, :⥚, :⥞, :↼, :↽, :⇐, :⟽, Symbol("<--")])
 const double_arrows = Set{Symbol}([:↔, :⟷, :⇄, :⇆, :⇌, :⇋, :⇔, :⟺, Symbol("<-->")])
 const pure_rate_arrows = Set{Symbol}([:(=>), :(<=), :⇐, :⟽, :⇒, :⟾, :⇔, :⟺])
 
 # Declares the keys used for various options.
 const option_keys = (:species, :parameters, :variables, :ivs, :compounds, :observables,
-    :default_noise_scaling, :differentials, :equations,
-    :continuous_events, :discrete_events, :combinatoric_ratelaws, :require_declaration)
+    :default_noise_scaling, :differentials, :equations, :continuous_events, :discrete_events,
+    :combinatoric_ratelaws, :require_declaration)
 
 ### `@species` Macro ###
 
@@ -298,14 +297,12 @@ function make_reaction_system(ex::Expr, name)
     requiredec = haskey(options, :require_declaration)
     reactions = get_reactions(reaction_lines)
     sps_inferred, ps_pre_inferred = extract_sps_and_ps(reactions, syms_declared; requiredec)
-    vs_inferred, diffs_inferred,
-    equations = read_equations_option!(diffsexpr, options,
+    vs_inferred, diffs_inferred, equations = read_equations_option!(diffsexpr, options,
         union(syms_declared, sps_inferred), tiv; requiredec)
     ps_inferred = setdiff(ps_pre_inferred, vs_inferred, diffs_inferred)
     syms_inferred = union(sps_inferred, ps_inferred, vs_inferred, diffs_inferred)
     all_syms = union(syms_declared, syms_inferred)
-    obsexpr, obs_eqs,
-    obs_syms = read_observables_option(options, ivs,
+    obsexpr, obs_eqs, obs_syms = read_observables_option(options, ivs,
         union(sps_declared, vs_declared), all_syms; requiredec)
 
     # Read options not related to the declaration or inference of symbols.

--- a/src/reaction.jl
+++ b/src/reaction.jl
@@ -702,8 +702,7 @@ Notes: The following values are possible:
 end
 
 const JUMP_SCALES = (PhysicalScale.Jump, PhysicalScale.VariableRateJump)
-const NON_CONSTANT_JUMP_SCALES = (
-    PhysicalScale.ODE, PhysicalScale.SDE, PhysicalScale.VariableRateJump)
+const NON_CONSTANT_JUMP_SCALES = (PhysicalScale.ODE, PhysicalScale.SDE, PhysicalScale.VariableRateJump)
 
 """
     has_physical_scale(rx::Reaction)

--- a/src/reactionsystem_serialisation/serialise_fields.jl
+++ b/src/reactionsystem_serialisation/serialise_fields.jl
@@ -102,12 +102,9 @@ function handle_us_n_ps(file_text::String, rn::ReactionSystem, annotate::Bool,
         while !(isempty(remaining_ps) && isempty(remaining_sps) && isempty(remaining_vars))
             # Checks which parameters/species/variables can be written. The `dependency_split`
             # function updates the `remaining_` input.
-            writable_ps = dependency_split!(remaining_ps,
-                [remaining_ps; remaining_sps; remaining_vars])
-            writable_sps = dependency_split!(remaining_sps,
-                [remaining_ps; remaining_sps; remaining_vars])
-            writable_vars = dependency_split!(remaining_vars,
-                [remaining_ps; remaining_sps; remaining_vars])
+            writable_ps = dependency_split!(remaining_ps, [remaining_ps; remaining_sps; remaining_vars])
+            writable_sps = dependency_split!(remaining_sps, [remaining_ps; remaining_sps; remaining_vars])
+            writable_vars = dependency_split!(remaining_vars, [remaining_ps; remaining_sps; remaining_vars])
 
             # Writes those that can be written.
             isempty(writable_ps) ||
@@ -430,8 +427,7 @@ function get_continuous_events_annotation(rn::ReactionSystem)
 end
 
 # Combines the 3 -related functions in a constant tuple.
-CONTINUOUS_EVENTS_FS = (seri_has_continuous_events, get_continuous_events_string,
-    get_continuous_events_annotation)
+CONTINUOUS_EVENTS_FS = (seri_has_continuous_events, get_continuous_events_string, get_continuous_events_annotation)
 
 ### Handles Discrete Events ###
 
@@ -487,8 +483,7 @@ function get_discrete_events_annotation(rn::ReactionSystem)
 end
 
 # Combines the 3 -related functions in a constant tuple.
-DISCRETE_EVENTS_FS = (seri_has_discrete_events, get_discrete_events_string,
-    get_discrete_events_annotation)
+DISCRETE_EVENTS_FS = (seri_has_discrete_events, get_discrete_events_string, get_discrete_events_annotation)
 
 ### Handles Systems ###
 
@@ -563,5 +558,4 @@ function get_connection_type_annotation(rn::ReactionSystem)
 end
 
 # Combines the 3 connection types-related functions in a constant tuple.
-CONNECTION_TYPE_FS = (
-    seri_has_connection_type, get_connection_type_string, get_connection_type_annotation)
+CONNECTION_TYPE_FS = (seri_has_connection_type, get_connection_type_string, get_connection_type_annotation)


### PR DESCRIPTION
## Summary

This PR fixes awkward line splits that were introduced by JuliaFormatter, making the code more readable by keeping logical units together.

## Changes Made

### 1. Fixed tuple assignments in plotting functions
- `fig, ax, plt = ...` and `fig, ax, hm = ...` now stay on single lines
- Files affected:
  - `ext/CatalystCairoMakieExtension/cairo_makie_extension_spatial_modelling.jl`
  - `ext/CatalystGraphMakieExtension/graph_makie_extension_spatial_modelling.jl`

### 2. Fixed constant definitions
- Tuples defining constants now stay on single lines when reasonable
- Files affected:
  - `src/reactionsystem_serialisation/serialise_fields.jl` (CONTINUOUS_EVENTS_FS, DISCRETE_EVENTS_FS, CONNECTION_TYPE_FS)
  - `src/reaction.jl` (NON_CONSTANT_JUMP_SCALES)

### 3. Fixed split function calls
- Function calls with their arguments stay together
- Files affected:
  - `src/reactionsystem_serialisation/serialise_fields.jl` (dependency_split\! calls)
  - `src/dsl.jl` (read_equations_option\!, read_observables_option)

### 4. Improved readability of long lines
- Binary operations with warnings kept more readable
- Arrays and sets formatted more sensibly
- Files affected:
  - `src/chemistry_functionality.jl`
  - `src/dsl.jl` (bwd_arrows, option_keys)

## Verification

These changes have been tested with an updated version of JuliaFormatter (PR pending) to ensure they won't be reverted. The updated formatter is more conservative about breaking lines, especially for:
- Tuple assignments on the LHS of `=`
- Function calls that are only slightly over the margin
- Constant definitions

## Related Issues

This addresses formatting issues similar to those seen in:
- SciML/JumpProcesses.jl#504
- Other SciML packages affected by aggressive line breaking

🤖 Generated with [Claude Code](https://claude.ai/code)