### PR TITLE
drop unneeded accessor

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -425,8 +425,9 @@ function ReactionSystem(eqs, iv, unknowns, ps, brownians = SymbolicT[];
     # Process initial_conditions to unwrap Num wrappers.
     initial_conditions = SymmapT(value(entry[1]) => value(entry[2]) for entry in initial_conditions)
 
-    # handles "bindings". Recently introduced in MTK/Symbolics, explicit Catalyst support need to be
-    # implemented. Left empty for now.
+    # Bindings are auto-discovered by MTKBase from variable metadata when Systems are created.
+    # The 5-argument System constructor calls process_variables! which extracts bindings from
+    # variables with symbolic default values. No explicit Catalyst handling is needed.
     bindings = MT.SymmapT()
 
     # Extracts independent variables (iv and sivs), dependent variables (species and variables)


### PR DESCRIPTION
This should already be defined in MTK, but let's run CI to double check that.