### PR TITLE
refactor: ignore certain system metadata during serialization

### DIFF
--- a/src/reactionsystem_serialisation/serialisation_support.jl
+++ b/src/reactionsystem_serialisation/serialisation_support.jl
@@ -245,6 +245,25 @@ const SKIPPED_METADATA = [
     Symbolics.VariableDefaultValue,
     Symbolics.VariableSource]
 
+# List of metadata keys in an `AbstractSystem` which shouldn't be serialized.
+const SKIPPED_SYSTEM_METADATA = [MT.MutableCacheKey]
+
+function system_has_serializable_metadata(sys::MT.AbstractSystem)
+    any(!in(SKIPPED_SYSTEM_METADATA), keys(MT.get_metadata(sys)))
+end
+
+function system_metadata_to_string(meta::Base.ImmutableDict)
+    output = "Dict(["
+    saved_keys = 0
+    for key in keys(meta)
+        key in SKIPPED_SYSTEM_METADATA && continue
+        saved_keys += 1
+        @string_append! output x_2_string(key) " => " x_2_string(meta[key]) ", "
+    end
+    output = iszero(saved_keys) ? output : Catalyst.get_substring_end(output, 1, -2)
+    return output * "])"
+end
+
 ### Generic Expression Handling ###
 
 # Potentially strips the call for a symbolics. E.g. X(t) becomes X (but p remains p). This is used

--- a/src/reactionsystem_serialisation/serialise_reactionsystem.jl
+++ b/src/reactionsystem_serialisation/serialise_reactionsystem.jl
@@ -177,10 +177,9 @@ function make_reaction_system_call(rs::ReactionSystem, annotate, top_level, has_
     end
 
     # Potentially appends `ReactionSystem` metadata value(s).
-    if ModelingToolkitBase.get_metadata(rs) != Base.ImmutableDict(ModelingToolkitBase.MutableCacheKey => Dict{DataType, Any}())
-        md_string = ", metadata = $(x_2_string(MT.get_metadata(rs)))"
-        md_string = replace(md_string, "ModelingToolkitBase.MutableCacheKey => Dict([]), " => "") # These are added internally by MTK. Unnecessary and makes code less readable.
-        md_string = replace(md_string, ", ModelingToolkitBase.MutableCacheKey => Dict([])" => "")
+
+    if system_has_serializable_metadata(rs)
+        md_string = ", metadata = " * system_metadata_to_string(MT.get_metadata(rs))
         @string_append! reaction_system_string md_string
     end
 


### PR DESCRIPTION
This refactors system metadata serialization to more robustly ignore `MutableCacheKey`