### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/FormatSuggestions.yml
+++ b/.github/workflows/FormatSuggestions.yml
@@ -1,9 +1,0 @@
-name: "Format Suggestions"
-on: pull_request
-permissions:
-  contents: read
-  pull-requests: write
-jobs:
-  format-suggestions:
-    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
-    secrets: "inherit"

--- a/.github/workflows/FormatSuggestions.yml
+++ b/.github/workflows/FormatSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Format Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  format-suggestions:
+    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Adds the missing standard SciML centralized caller workflows to this repo.

**Added in this PR:**
- `FormatSuggestions.yml` — auto-format suggestions on PR (JuliaFormatter-based, uses `format-suggestions-on-pr.yml@v1`). This repo's format check uses JuliaFormatter.
- `DependabotAutoMerge.yml` — Dependabot auto-merge (uses `dependabot-automerge.yml@v1`).

**Not added (already present):**
- Doc preview cleanup is already provided by the existing `DocsCleanup.yml`.

These are static caller files referencing reusable workflows in `SciML/.github`; no existing files, code, or `Project.toml` were touched.

---

**Ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)