### PR TITLE
Use SciMLTesting v1.1.0 run_tests harness

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -76,6 +76,7 @@ Reexport = "1.0"
 RuntimeGeneratedFunctions = "0.5.12"
 SciMLBase = "2.84, 3"
 SciMLPublic = "1"
+SciMLTesting = "1.1"
 Setfield = "1"
 SparseArrays = "1.10"
 StochasticDiffEq = "6.101, 7"
@@ -99,10 +100,10 @@ OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -114,5 +115,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["DataInterpolations", "DiffEqCallbacks", "DiffEqNoiseProcess", "DomainSets",
     "Logging", "NonlinearSolve", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqDefault",
     "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner",
-    "Pkg", "Plots", "Random", "SafeTestsets", "StableRNGs",
+    "Plots", "Random", "SafeTestsets", "SciMLTesting", "StableRNGs",
     "StaticArrays", "Statistics", "SteadyStateDiffEq", "StochasticDiffEq", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,104 +1,84 @@
 ### Preparations ###
 
 # Required for `@safetestset` and `@testset`, respectively.
-using SafeTestsets, Test, Pkg
-
-# Required for running parallel test groups (copied from ModelingToolkit).
-const GROUP = get(ENV, "GROUP", "All")
-
-function activate_extensions_env()
-    Pkg.activate("extensions")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    Pkg.instantiate()
-end
-
-function activate_qa_env()
-    Pkg.activate("qa")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    Pkg.instantiate()
-end
+using SafeTestsets, Test, SciMLTesting
 
 ### Run Tests ###
 @time begin
-    if GROUP == "All" || GROUP == "Modeling"
-        # Tests the `ReactionSystem` structure and its properties.
-        @time @safetestset "Reaction Structure" begin include("reactionsystem_core/reaction.jl") end
-        @time @safetestset "ReactionSystem Structure" begin include("reactionsystem_core/reactionsystem.jl") end
-        @time @safetestset "Higher Order Reactions" begin include("reactionsystem_core/higher_order_reactions.jl") end
-        @time @safetestset "Symbolic Stoichiometry" begin include("reactionsystem_core/symbolic_stoichiometry.jl") end
-        @time @safetestset "Parameter Type Designation" begin include("reactionsystem_core/parameter_type_designation.jl") end
-        @time @safetestset "Custom CRN Functions" begin include("reactionsystem_core/custom_crn_functions.jl") end
-        @time @safetestset "Coupled CRN/Equation Systems" begin include("reactionsystem_core/coupled_equation_crn_systems.jl") end
-        @time @safetestset "Events" begin include("reactionsystem_core/events.jl") end
-        @time @safetestset "Functional Parameters" begin include("reactionsystem_core/functional_parameters.jl") end
+    run_tests(;
+        core = () -> nothing,
+        groups = Dict(
+            "Modeling" => () -> begin
+                # Tests the `ReactionSystem` structure and its properties.
+                @time @safetestset "Reaction Structure" begin include(joinpath(@__DIR__, "reactionsystem_core", "reaction.jl")) end
+                @time @safetestset "ReactionSystem Structure" begin include(joinpath(@__DIR__, "reactionsystem_core", "reactionsystem.jl")) end
+                @time @safetestset "Higher Order Reactions" begin include(joinpath(@__DIR__, "reactionsystem_core", "higher_order_reactions.jl")) end
+                @time @safetestset "Symbolic Stoichiometry" begin include(joinpath(@__DIR__, "reactionsystem_core", "symbolic_stoichiometry.jl")) end
+                @time @safetestset "Parameter Type Designation" begin include(joinpath(@__DIR__, "reactionsystem_core", "parameter_type_designation.jl")) end
+                @time @safetestset "Custom CRN Functions" begin include(joinpath(@__DIR__, "reactionsystem_core", "custom_crn_functions.jl")) end
+                @time @safetestset "Coupled CRN/Equation Systems" begin include(joinpath(@__DIR__, "reactionsystem_core", "coupled_equation_crn_systems.jl")) end
+                @time @safetestset "Events" begin include(joinpath(@__DIR__, "reactionsystem_core", "events.jl")) end
+                @time @safetestset "Functional Parameters" begin include(joinpath(@__DIR__, "reactionsystem_core", "functional_parameters.jl")) end
 
-        # Tests model creation via the @reaction_network DSL.
-        @time @safetestset "DSL Basic Model Construction" begin include("dsl/dsl_basic_model_construction.jl") end
-        @time @safetestset "DSL Advanced Model Construction" begin include("dsl/dsl_advanced_model_construction.jl") end
-        @time @safetestset "DSL Options" begin include("dsl/dsl_options.jl") end
+                # Tests model creation via the @reaction_network DSL.
+                @time @safetestset "DSL Basic Model Construction" begin include(joinpath(@__DIR__, "dsl", "dsl_basic_model_construction.jl")) end
+                @time @safetestset "DSL Advanced Model Construction" begin include(joinpath(@__DIR__, "dsl", "dsl_advanced_model_construction.jl")) end
+                @time @safetestset "DSL Options" begin include(joinpath(@__DIR__, "dsl", "dsl_options.jl")) end
 
-        # Tests compositional and hierarchical modelling.
-        @time @safetestset "ReactionSystem Components Based Creation" begin include("compositional_modelling/component_based_model_creation.jl") end # hierarchical modelling broken due to https://github.com/SciML/ModelingToolkit.jl/pull/4101
-        @time @safetestset "Brownians, Jumps, and Poissonians Composition" begin include("compositional_modelling/brownians_and_jumps_composition.jl") end
+                # Tests compositional and hierarchical modelling.
+                @time @safetestset "ReactionSystem Components Based Creation" begin include(joinpath(@__DIR__, "compositional_modelling", "component_based_model_creation.jl")) end # hierarchical modelling broken due to https://github.com/SciML/ModelingToolkit.jl/pull/4101
+                @time @safetestset "Brownians, Jumps, and Poissonians Composition" begin include(joinpath(@__DIR__, "compositional_modelling", "brownians_and_jumps_composition.jl")) end
 
-        # Tests various miscellaneous features.
-        @time @safetestset "API" begin include("miscellaneous_tests/api.jl") end
-        @time @safetestset "Units" begin include("miscellaneous_tests/units.jl") end # `_validate` currently no longer avaiable, awaiting advice.
-        @time @safetestset "Compound Species" begin include("miscellaneous_tests/compound_macro.jl") end
-        @time @safetestset "Reaction Balancing" begin include("miscellaneous_tests/reaction_balancing.jl") end
+                # Tests various miscellaneous features.
+                @time @safetestset "API" begin include(joinpath(@__DIR__, "miscellaneous_tests", "api.jl")) end
+                @time @safetestset "Units" begin include(joinpath(@__DIR__, "miscellaneous_tests", "units.jl")) end # `_validate` currently no longer avaiable, awaiting advice.
+                @time @safetestset "Compound Species" begin include(joinpath(@__DIR__, "miscellaneous_tests", "compound_macro.jl")) end
+                @time @safetestset "Reaction Balancing" begin include(joinpath(@__DIR__, "miscellaneous_tests", "reaction_balancing.jl")) end
 
-        # Tests reaction network analysis features.
-        @time @safetestset "Conservation Laws" begin include("network_analysis/conservation_laws.jl") end # Multiple issues. https://github.com/SciML/ModelingToolkit.jl/issues/4102 required to start debugging.
-        @time @safetestset "Network Properties" begin include("network_analysis/network_properties.jl") end
-        @time @safetestset "CRN Theory" begin include("network_analysis/crn_theory.jl") end
-    end
+                # Tests reaction network analysis features.
+                @time @safetestset "Conservation Laws" begin include(joinpath(@__DIR__, "network_analysis", "conservation_laws.jl")) end # Multiple issues. https://github.com/SciML/ModelingToolkit.jl/issues/4102 required to start debugging.
+                @time @safetestset "Network Properties" begin include(joinpath(@__DIR__, "network_analysis", "network_properties.jl")) end
+                @time @safetestset "CRN Theory" begin include(joinpath(@__DIR__, "network_analysis", "crn_theory.jl")) end
+            end,
+            "Simulation" => () -> begin
+                # Tests ODE, SDE, jump simulations, nonlinear solving, and steady state simulations.
+                @time @safetestset "ODE System Simulations" begin include(joinpath(@__DIR__, "simulation_and_solving", "simulate_ODEs.jl")) end
+                @time @safetestset "Automatic Jacobian Construction" begin include(joinpath(@__DIR__, "simulation_and_solving", "jacobian_construction.jl")) end
+                @time @safetestset "SDE System Simulations" begin include(joinpath(@__DIR__, "simulation_and_solving", "simulate_SDEs.jl")) end
+                @time @safetestset "Jump System Simulations" begin include(joinpath(@__DIR__, "simulation_and_solving", "simulate_jumps.jl")) end
+                @time @safetestset "Nonlinear and SteadyState System Solving" begin include(joinpath(@__DIR__, "simulation_and_solving", "solve_nonlinear.jl")) end
 
-    if GROUP == "All" || GROUP == "Simulation"
-        # Tests ODE, SDE, jump simulations, nonlinear solving, and steady state simulations.
-        @time @safetestset "ODE System Simulations" begin include("simulation_and_solving/simulate_ODEs.jl") end
-        @time @safetestset "Automatic Jacobian Construction" begin include("simulation_and_solving/jacobian_construction.jl") end
-        @time @safetestset "SDE System Simulations" begin include("simulation_and_solving/simulate_SDEs.jl") end
-        @time @safetestset "Jump System Simulations" begin include("simulation_and_solving/simulate_jumps.jl") end
-        @time @safetestset "Nonlinear and SteadyState System Solving" begin include("simulation_and_solving/solve_nonlinear.jl") end
-
-        # Tests upstream SciML and DiffEq stuff.
-        @time @safetestset "MTK Structure Indexing" begin include("upstream/mtk_structure_indexing.jl") end
-        @time @safetestset "MTK Problem Inputs" begin include("upstream/mtk_problem_inputs.jl") end # Required to fix lots of these: https://github.com/SciML/ModelingToolkit.jl/issues/4098
-    end
-
-    if GROUP == "All" || GROUP == "Hybrid"
-        @time @safetestset "ReactionSystem Hybrid Solvers" begin include("simulation_and_solving/hybrid_models.jl") end
-    end
-
-    if GROUP == "All" || GROUP == "Misc"
-        @time @safetestset "ReactionSystem Serialisation" begin include("miscellaneous_tests/reactionsystem_serialisation.jl") end
-        # BROKEN
-        #@time @safetestset "Latexify" begin include("visualisation/latexify.jl") end # https://github.com/SciML/Catalyst.jl/issues/1352
-    end
-
-    # Quality assurance (Aqua, JET, ExplicitImports) via the SciMLTesting harness.
-    # Runs in its own `test/qa` sub-environment so the heavier QA tooling does not
-    # constrain the main test environment's resolution.
-    if GROUP == "QA"
-        activate_qa_env()
-        include("qa/qa.jl")
-    end
-
-    if GROUP == "All" || GROUP == "Spatial"
-        # Tests spatial modelling and simulations.
-        @time @safetestset "PDE Systems Simulations" begin include("spatial_modelling/simulate_PDEs.jl") end
-        @time @safetestset "Spatial Reactions" begin include("spatial_modelling/spatial_reactions.jl") end
-        @time @safetestset "Discrete Space Reaction Systems" begin include("spatial_modelling/dspace_reaction_systems.jl") end
-        @time @safetestset "Spatial Discrete Space Variants" begin include("spatial_modelling/dspace_reaction_systems_space_types.jl") end
-        @time @safetestset "ODE Discrete Space Systems Simulations" begin include("spatial_modelling/dspace_reaction_systems_ODEs.jl") end
-        @time @safetestset "Jump Discrete Space Systems Simulations" begin include("spatial_modelling/dspace_reaction_systems_jumps.jl") end
-        @time @safetestset "Discrete Space Simulation Structure Interfacing" begin include("spatial_modelling/dspace_simulation_struct_interfacing.jl") end
-    end
-
-    # Tests extensions.
-    if GROUP == "All" || GROUP == "Extensions"
-        activate_extensions_env()
-        include("runtests_extensions.jl")
-    end
-
+                # Tests upstream SciML and DiffEq stuff.
+                @time @safetestset "MTK Structure Indexing" begin include(joinpath(@__DIR__, "upstream", "mtk_structure_indexing.jl")) end
+                @time @safetestset "MTK Problem Inputs" begin include(joinpath(@__DIR__, "upstream", "mtk_problem_inputs.jl")) end # Required to fix lots of these: https://github.com/SciML/ModelingToolkit.jl/issues/4098
+            end,
+            "Hybrid" => () -> begin
+                @time @safetestset "ReactionSystem Hybrid Solvers" begin include(joinpath(@__DIR__, "simulation_and_solving", "hybrid_models.jl")) end
+            end,
+            "Misc" => () -> begin
+                @time @safetestset "ReactionSystem Serialisation" begin include(joinpath(@__DIR__, "miscellaneous_tests", "reactionsystem_serialisation.jl")) end
+                # BROKEN
+                #@time @safetestset "Latexify" begin include(joinpath(@__DIR__, "visualisation", "latexify.jl")) end # https://github.com/SciML/Catalyst.jl/issues/1352
+            end,
+            "Spatial" => () -> begin
+                # Tests spatial modelling and simulations.
+                @time @safetestset "PDE Systems Simulations" begin include(joinpath(@__DIR__, "spatial_modelling", "simulate_PDEs.jl")) end
+                @time @safetestset "Spatial Reactions" begin include(joinpath(@__DIR__, "spatial_modelling", "spatial_reactions.jl")) end
+                @time @safetestset "Discrete Space Reaction Systems" begin include(joinpath(@__DIR__, "spatial_modelling", "dspace_reaction_systems.jl")) end
+                @time @safetestset "Spatial Discrete Space Variants" begin include(joinpath(@__DIR__, "spatial_modelling", "dspace_reaction_systems_space_types.jl")) end
+                @time @safetestset "ODE Discrete Space Systems Simulations" begin include(joinpath(@__DIR__, "spatial_modelling", "dspace_reaction_systems_ODEs.jl")) end
+                @time @safetestset "Jump Discrete Space Systems Simulations" begin include(joinpath(@__DIR__, "spatial_modelling", "dspace_reaction_systems_jumps.jl")) end
+                @time @safetestset "Discrete Space Simulation Structure Interfacing" begin include(joinpath(@__DIR__, "spatial_modelling", "dspace_simulation_struct_interfacing.jl")) end
+            end,
+            "Extensions" => (; env = joinpath(@__DIR__, "extensions"),
+                body = joinpath(@__DIR__, "runtests_extensions.jl")),
+        ),
+        # Quality assurance (Aqua, JET, ExplicitImports) via the SciMLTesting harness.
+        # Runs only under `GROUP=QA` (never as part of `All`), in its own `test/qa`
+        # sub-environment so the heavier QA tooling does not constrain the main test
+        # environment's resolution.
+        qa = (; env = joinpath(@__DIR__, "qa"),
+            body = joinpath(@__DIR__, "qa", "qa.jl")),
+        all = ["Modeling", "Simulation", "Hybrid", "Misc", "Spatial", "Extensions"],
+    )
 end # @time


### PR DESCRIPTION
Replaces the hand-written `GROUP` if-ladder in `test/runtests.jl` with a single declarative `run_tests` call from [SciMLTesting](https://github.com/SciML/SciMLTesting.jl) v1.1.0.

## What changed
- The six functional groups (`Modeling`, `Simulation`, `Hybrid`, `Misc`, `Spatial`, `Extensions`) are passed as `groups` entries.
- A curated `all = ["Modeling", "Simulation", "Hybrid", "Misc", "Spatial", "Extensions"]` reproduces the original `All` membership **exactly**: bare/`All` runs all six groups in the original order. This repo has no QA group.
- The `Extensions` group keeps its isolated `test/extensions` environment via the `env` kwarg, which performs the same `Pkg.activate` / `Pkg.develop(repo root)` / `Pkg.instantiate` that the old `activate_extensions_env()` helper did.

## Behavior equivalence
This is a behavior-equivalent refactor — no test assertions or logic changed, and the set of testsets run under each `GROUP` value (including bare/`All`) is identical before and after. Verified with a dispatch dry-run:

| GROUP | groups run |
|---|---|
| `All` | Modeling, Simulation, Hybrid, Misc, Spatial, Extensions |
| `Modeling` / `Simulation` / `Hybrid` / `Misc` / `Spatial` / `Extensions` | the named group only |

## Project.toml
- Added `SciMLTesting` (`09d9d899-5365-40a9-917a-5f67fddea283`) to `[extras]`, `[compat] SciMLTesting = "1"`, and the test target.
- Dropped `Pkg` from the test deps — only the old harness used it; `run_tests` bundles `Pkg`.

---
Ignore until reviewed by @ChrisRackauckas.