### PR TITLE
Bump version to 16.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "16.2.0"
+version = "16.2.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
Automated patch version bump (16.2.0 -> 16.2.1) to release unreleased commits on `master` via JuliaRegistrator.