### PR TITLE
Flip fixed metadata @test_broken to @test

### DIFF
--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -1147,7 +1147,7 @@ let
     @test ModelingToolkitBase.getmetadata(rs1, MiscSystemData, nothing) == "Metadata"
     @test ModelingToolkitBase.getmetadata(rs2, MiscSystemData, nothing) == ones(2, 3)
     @test ModelingToolkitBase.getmetadata(complete(rs1), MiscSystemData, nothing) == "Metadata"
-    @test_broken ModelingToolkitBase.getmetadata(complete(rs2), MiscSystemData, nothing) == ones(2, 3) # Weird and obscure Catalyst bug: https://github.com/SciML/Catalyst.jl/issues/1353.
+    @test ModelingToolkitBase.getmetadata(complete(rs2), MiscSystemData, nothing) == ones(2, 3)
 end
 
 # Tests u0_map and parameter_map system-level metadata.


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

The Catalyst.jl/Modeling downstream job (and Catalyst's own master CI) currently fails with `Unexpected Pass` at `test/reactionsystem_core/reactionsystem.jl:1150`:

```
@test_broken getmetadata(complete(rs2), MiscSystemData, nothing) == ones(2,3)
```

The underlying bug (#1353 — system metadata stored in a `Base.ImmutableDict` where duplicate keys stack, so `complete()` could resurrect a stale entry) was fixed upstream by ModelingToolkitBase's `refreshed_metadata` fix (skips already-seen keys when rebuilding metadata). Verified by pinning: MTKBase 1.42.2 still returns the stale value; MTKBase 1.51.0 returns the updated `ones(2,3)`.

This flips the `@test_broken` to `@test`. Ran the full ReactionSystem Structure test file locally against released deps: **419 pass, 2 broken (unrelated pre-existing), 0 fail**.

Fixes #1353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)