### PR TITLE
Initialize conserved constants in ODE and SDE systems

### DIFF
--- a/src/reactionsystem_conversions.jl
+++ b/src/reactionsystem_conversions.jl
@@ -715,8 +715,12 @@ function hybrid_model(rs::ReactionSystem;
     jumps = vcat(rxn_jumps, user_jumps)
 
     # --- Add constraints (BC species, constraint equations, conserved species) ---
+    initeqs = Equation[]
     if has_continuous
-        eqs, us, ps, obs, ics = addconstraints!(eqs, flatrs, ists, ispcs; remove_conserved)
+        eqs, us, ps, obs, ics, initeqs = addconstraints!(
+            eqs, flatrs, ists, ispcs;
+            remove_conserved, compute_cl_initeqs = remove_conserved
+        )
     else
         # Pure jump case.
         any(isbc, get_unknowns(flatrs)) &&
@@ -729,10 +733,12 @@ function hybrid_model(rs::ReactionSystem;
 
     # --- Construct unified System ---
     # Note: brownians is a positional arg (5th) in the System constructor.
-    MT.System(eqs, get_iv(flatrs), us, ps, brownian_vars;
+    return MT.System(
+        eqs, get_iv(flatrs), us, ps, brownian_vars;
         poissonians = user_poissonians,
         jumps,
         observed = obs,
+        initialization_eqs = initeqs,
         name,
         bindings = MT.get_bindings(flatrs),
         initial_conditions = merge(initial_conditions, ics),
@@ -1022,15 +1028,24 @@ function sde_model(rs::ReactionSystem;
         remove_conserved && conservationlaws(flatrs)
         ists, ispcs = get_indep_sts(flatrs, remove_conserved)
 
-        eqs = assemble_drift(flatrs, ispcs; combinatoric_ratelaws, include_zero_odes,
-            remove_conserved, expand_catalyst_funs, use_jump_ratelaws)
-        noiseeqs = assemble_diffusion(flatrs, ists, ispcs; combinatoric_ratelaws,
-            remove_conserved, expand_catalyst_funs, use_jump_ratelaws)
-        eqs, us, ps, obs, ics = addconstraints!(eqs, flatrs, ists, ispcs; remove_conserved)
+        eqs = assemble_drift(
+            flatrs, ispcs; combinatoric_ratelaws, include_zero_odes,
+            remove_conserved, expand_catalyst_funs, use_jump_ratelaws
+        )
+        noiseeqs = assemble_diffusion(
+            flatrs, ists, ispcs; combinatoric_ratelaws,
+            remove_conserved, expand_catalyst_funs, use_jump_ratelaws
+        )
+        eqs, us, ps, obs, ics, initeqs = addconstraints!(
+            eqs, flatrs, ists, ispcs;
+            remove_conserved, compute_cl_initeqs = remove_conserved
+        )
 
-        return MT.System(eqs, get_iv(flatrs), us, ps;
+        return MT.System(
+            eqs, get_iv(flatrs), us, ps;
             noise_eqs = noiseeqs,
             observed = obs,
+            initialization_eqs = initeqs,
             name,
             initial_conditions = merge(initial_conditions, ics),
             checks,

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -1147,7 +1147,7 @@ let
     @test ModelingToolkitBase.getmetadata(rs1, MiscSystemData, nothing) == "Metadata"
     @test ModelingToolkitBase.getmetadata(rs2, MiscSystemData, nothing) == ones(2, 3)
     @test ModelingToolkitBase.getmetadata(complete(rs1), MiscSystemData, nothing) == "Metadata"
-    @test_broken ModelingToolkitBase.getmetadata(complete(rs2), MiscSystemData, nothing) == ones(2, 3) # Weird and obscure Catalyst bug: https://github.com/SciML/Catalyst.jl/issues/1353.
+    @test ModelingToolkitBase.getmetadata(complete(rs2), MiscSystemData, nothing) == ones(2, 3)
 end
 
 # Tests u0_map and parameter_map system-level metadata.


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Pass conservation-law initialization equations through ODE/SDE/hybrid system construction when conserved species are eliminated.
- Promote the recovered complete-system matrix metadata assertion from `@test_broken` to `@test`.

## Root Cause
With the current post-yank resolver (`SciMLBase v3.33.1`, `ModelingToolkitBase v1.51.0`), conserved constants such as `Γ` were left at default values in ODE/SDE systems with `remove_conserved=true`. The steady-state conversion path already supplied these initialization equations; the ODE/SDE paths did not.

## Validation
- `git diff --check`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_165240_11300/julia_depot_catalyst_clean_modeling GROUP=Modeling JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.11 --startup-file=no --color=yes -e 'using Pkg; Pkg.activate(temp=true); if isempty(Pkg.Registry.reachable_registries()); Pkg.Registry.add(Pkg.RegistrySpec(path="/home/crackauc/sandbox/tmp_20260708_165240_11300/General_pre_retrocap_registry")); end; Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.test("Catalyst"; coverage=false)'`
  - Result: `Catalyst tests passed`; `Conservation Laws | 250 pass, 17 broken, 267 total`; `ReactionSystem Structure | 419 pass, 2 broken, 421 total`.
- Runic was attempted. Full-file checks are not clean on the current repo state and would require broad unrelated rewrites, so this PR keeps formatting changes scoped to the touched lines.