### PR TITLE
Release prep: bump version to 16.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "16.2.1"
+version = "16.2.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
## Summary

Bumps `version` in Project.toml from 16.2.1 to 16.2.2 to register the commits accumulated on `master` since the last release (16.2.1, commit deb00ddd).

## What changed since 16.2.1

Diffed `deb00ddd..HEAD` (72 files changed, no changes under `src/`):

- **Docs**: many tutorial/docs pages updated for compatibility with newer versions of downstream packages (BifurcationKit, OrdinaryDiffEq, Optimization, Turing, etc.) — wording/example fixes, no package behavior change.
- **Tests**: assorted test fixes/updates (marking previously-broken tests as passing, adapting to new `prob_func` syntax in upstream solvers, etc.).
- **Project.toml**:
  - Test-only dependency refactor: removed `OrdinaryDiffEqBDF`/`OrdinaryDiffEqDefault`/`OrdinaryDiffEqRosenbrock`/`OrdinaryDiffEqTsit5`/`OrdinaryDiffEqVerner` from `[extras]`/`[targets]`/`[compat]`, replaced with the umbrella `OrdinaryDiffEq = "6, 7"` (test-only, no `[deps]` impact).
  - Runtime compat bump (already present in the diff, commit 0b8392da): `ModelingToolkitBase` lower bound raised from `"1.17"` to `"1.46"`.
  - `README.md` badge link fix.

No `src/` files changed, no new exported API, no behavior change to the package itself.

## Bump type: PATCH (16.2.1 → 16.2.2)

All source-code-relevant changes are docs/tests/CI/compat-housekeeping only. No new features or breaking changes were introduced, so this follows SemVer PATCH conventions (and would still be PATCH-equivalent even under the pre-1.0 "breaking-as-minor" convention, since Catalyst is post-1.0 at 16.x and nothing here is breaking).

🤖 Generated with automated release-prep tooling.