### PR TITLE
Test symbolic jump affects through public API

### DIFF
--- a/test/reactionsystem_core/symbolic_stoichiometry.jl
+++ b/test/reactionsystem_core/symbolic_stoichiometry.jl
@@ -2,7 +2,6 @@
 
 # Fetch packages.
 using Catalyst, JumpProcesses, OrdinaryDiffEq, StochasticDiffEq, Statistics, Test
-using Symbolics: unwrap
 import SymbolicIndexingInterface as SII
 
 # Mock integrator type for testing generated VRJ affect functions.
@@ -218,7 +217,7 @@ let
     rs = @reaction_network begin
         @parameters k
         @variables V(t)
-        k, X --> V*Y
+        k, X --> V * Y
     end
 
     # The jump System should have explicit affects (no equations after mtkcompile)
@@ -231,11 +230,8 @@ let
     @test occursin("Pre(V(t))", affect_str)
 
     # Verify it creates an explicit affect (empty equations after mtkcompile)
-    iv = unwrap(t)
-    aff = ModelingToolkitBase.AffectSystem(js[1].affect!; iv)
-    affsys = ModelingToolkitBase.system(aff)
-    eqs = ModelingToolkitBase.equations(ModelingToolkitBase.unhack_system(affsys))
-    @test isempty(eqs)  # Should be explicit, not implicit
+    compiled_jsys = ModelingToolkitBase.mtkcompile(jsys)
+    @test isempty(ModelingToolkitBase.equations(compiled_jsys))
 end
 
 # Tests symbolic stoichiometries in simulations.


### PR DESCRIPTION
## Summary

- replace a Catalyst test dependency on non-public ModelingToolkitBase AffectSystem internals with public mtkcompile and equations calls
- remove the now-unused Symbolics unwrap import
- keep the assertion that non-species stoichiometry produces a Pre-wrapped explicit affect

## Root cause

ModelingToolkit commit 136462c52d4c983e4ba832893928f270bc399b47 changed the internal AffectSystem constructor to require parent_sys. Catalyst called that non-public constructor directly in symbolic_stoichiometry.jl, so both ModelingToolkit Catalyst Modeling lanes failed with UndefKeywordError.

A behavioral boundary check passed on parent 0b01708ffb4c545b888f859bdcbc505350f723ef, and git bisect identifies 136462c52d4c983e4ba832893928f270bc399b47 as the first bad commit.

## Validation

- exact Julia 1.12.6 clean-base GROUP=Modeling reproduction: Symbolic Stoichiometry 20 passed, 1 errored before the fix
- focused parent-boundary block: passed on 0b01708ffb
- focused public-API regression block after the fix: passed
- full test/reactionsystem_core/symbolic_stoichiometry.jl after the fix: exited 0, including its 10,000-trajectory simulation tail
- Runic 1.7.0 check on touched ranges 1:6 and 210:239: passed
- git diff --check: passed

The repository-wide Runic 1.7.0 check still exits 1 on pre-existing formatting in this test file outside the touched ranges; this PR does not mix that broad formatting cleanup into the regression fix.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.