### PR TITLE
Test symbolic stoichiometry through public API

### DIFF
--- a/test/reactionsystem_core/symbolic_stoichiometry.jl
+++ b/test/reactionsystem_core/symbolic_stoichiometry.jl
@@ -2,7 +2,6 @@
 
 # Fetch packages.
 using Catalyst, JumpProcesses, OrdinaryDiffEq, StochasticDiffEq, Statistics, Test
-using Symbolics: unwrap
 import SymbolicIndexingInterface as SII
 
 # Mock integrator type for testing generated VRJ affect functions.
@@ -207,35 +206,26 @@ let
     end
 end
 
-# Tests that non-species unknowns (regular variables) in stoichiometry are properly wrapped in Pre().
-# This ensures MTKBase generates explicit affects rather than implicit ones.
+# Tests jump simulation with a non-species unknown in symbolic stoichiometry.
 let
     @parameters k
     @variables V(t)
     @species X(t) Y(t)
 
-    # Reaction where V (a non-species variable) appears in the stoichiometry
     rs = @reaction_network begin
         @parameters k
         @variables V(t)
-        k, X --> V*Y
+        k, X --> V * Y
     end
 
-    # The jump System should have explicit affects (no equations after mtkcompile)
-    jsys = jump_model(rs)
-    js = ModelingToolkitBase.jumps(jsys)
-    @test length(js) == 1
-
-    # Check that V appears as Pre(V(t)) in the affect equations
-    affect_str = string(js[1].affect!)
-    @test occursin("Pre(V(t))", affect_str)
-
-    # Verify it creates an explicit affect (empty equations after mtkcompile)
-    iv = unwrap(t)
-    aff = ModelingToolkitBase.AffectSystem(js[1].affect!; iv)
-    affsys = ModelingToolkitBase.system(aff)
-    eqs = ModelingToolkitBase.equations(ModelingToolkitBase.unhack_system(affsys))
-    @test isempty(eqs)  # Should be explicit, not implicit
+    jprob = JumpProblem(
+        rs, [X => 1, Y => 0, V => 2], (0.0, 1.0), [k => 100.0];
+        rng = StableRNG(12345)
+    )
+    sol = solve(jprob, SSAStepper())
+    @test sol[X][end] == 0
+    @test sol[Y][end] == 2
+    @test sol[V][end] == 2
 end
 
 # Tests symbolic stoichiometries in simulations.

--- a/test/reactionsystem_core/symbolic_stoichiometry.jl
+++ b/test/reactionsystem_core/symbolic_stoichiometry.jl
@@ -206,26 +206,32 @@ let
     end
 end
 
-# Tests jump simulation with a non-species unknown in symbolic stoichiometry.
+# Tests that non-species unknowns (regular variables) in stoichiometry are properly wrapped in Pre().
+# This ensures MTKBase generates explicit affects rather than implicit ones.
 let
     @parameters k
     @variables V(t)
     @species X(t) Y(t)
 
+    # Reaction where V (a non-species variable) appears in the stoichiometry
     rs = @reaction_network begin
         @parameters k
         @variables V(t)
         k, X --> V * Y
     end
 
-    jprob = JumpProblem(
-        rs, [X => 1, Y => 0, V => 2], (0.0, 1.0), [k => 100.0];
-        rng = StableRNG(12345)
-    )
-    sol = solve(jprob, SSAStepper())
-    @test sol[X][end] == 0
-    @test sol[Y][end] == 2
-    @test sol[V][end] == 2
+    # The jump System should have explicit affects (no equations after mtkcompile)
+    jsys = jump_model(rs)
+    js = ModelingToolkitBase.jumps(jsys)
+    @test length(js) == 1
+
+    # Check that V appears as Pre(V(t)) in the affect equations
+    affect_str = string(js[1].affect!)
+    @test occursin("Pre(V(t))", affect_str)
+
+    # Verify it creates an explicit affect (empty equations after mtkcompile)
+    compiled_jsys = ModelingToolkitBase.mtkcompile(jsys)
+    @test isempty(ModelingToolkitBase.equations(compiled_jsys))
 end
 
 # Tests symbolic stoichiometries in simulations.


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Replace the symbolic-stoichiometry test's construction of private ModelingToolkitBase affect internals with the documented public compilation path:

```julia
compiled_jsys = ModelingToolkitBase.mtkcompile(jsys)
@test isempty(ModelingToolkitBase.equations(compiled_jsys))
```

The test still inspects the generated symbolic jump system, verifies that it contains one jump, and checks that its symbolic affect contains `Pre(V(t))`. This addresses the review request to retain assertions about the generated symbolic jump and its equations.

## Root cause

The failure bisects to ModelingToolkit commit `136462c52d4c983e4ba832893928f270bc399b47` (`refactor: do not rely on metadata when constructing AffectSystem`), whose direct parent `0b01708ffb4c545b888f859bdcbc505350f723ef` passes the test. That refactor made the private `AffectSystem(...; parent_sys)` keyword mandatory, so Catalyst's test errored while reconstructing private internals rather than testing Catalyst behavior.

`ModelingToolkitBase.mtkcompile`, `jumps`, and `equations` are exported by their declaring module; `mtkcompile` has its own docstring and a rendered API-docs entry.

## Local verification

The exact downstream test command used Julia 1.12.6, current ModelingToolkit master `77941f873102904935c798fdb3dcd2bbfbfe8d3a`, and coverage:

```sh
GROUP=Modeling julia +1.12 --project=<downstream-env> --startup-file=no \
  -e 'using Pkg; Pkg.test("Catalyst"; coverage=true)'
```

- Clean Catalyst master: Symbolic Stoichiometry reached 20 passes, then errored with `UndefKeywordError: keyword argument parent_sys not assigned`.
- This PR: Symbolic Stoichiometry passed 30/30.
- The patched full group continued successfully through Reaction Balancing. It then stopped at the independent Conservation Laws baseline issue: 242 passed, 7 pre-existing `@test_broken` assertions unexpectedly passed, and 17 remained broken. That separate issue is tracked by draft PR #1512; this PR does not alter those markers.
- `git diff --check` passed.
- Julia 1.10 and 1.12 parsing passed.
- Runic passed on the changed executable `let` block. The whole-repository Runic check remains nonzero on pre-existing formatting outside this focused diff.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.
