### PR TITLE
Activate corrected conservation-law tests

### DIFF
--- a/test/network_analysis/conservation_laws.jl
+++ b/test/network_analysis/conservation_laws.jl
@@ -147,9 +147,9 @@ let
         @test nsol1[sps] ≈ nsol1b[sps]
         @test nsol1[sps] ≈ nsol2[sps]
         @test nsol1[sps] ≈ nsol2b[sps]
-        @test_broken nsol1[sps] ≈ sssol1[sps]
+        @test nsol1[sps] ≈ sssol1[sps]
         @test nsol1[sps] ≈ sssol2[sps]
-        @test_broken nsol1[sps] ≈ sssol3[sps]
+        @test nsol1[sps] ≈ sssol3[sps]
     end
 
     # Creates SDEProblems using various approaches.
@@ -176,11 +176,11 @@ let
     sprob1.f(du1, sprob1.u0, sprob1.p, 1.0)
     sprob2.f(du2, sprob2.u0, sprob2.p, 1.0)
     sprob3.f(du3, sprob3.u0, sprob3.p, 1.0)
-    @test_broken du1 ≈ du2[ind_uidxs] ≈ du3
+    @test du1 ≈ du2[ind_uidxs] ≈ du3
     sprob1.g(g1, sprob1.u0, sprob1.p, 1.0)
     sprob2.g(g2, sprob2.u0, sprob2.p, 1.0)
     sprob3.g(g3, sprob3.u0, sprob3.p, 1.0)
-    @test_broken g1 ≈ g2[ind_uidxs, :] ≈ g3
+    @test g1 ≈ g2[ind_uidxs, :] ≈ g3
 end
 
 # Tests simulations for various input types (using X, rn.X, and :X forms).
@@ -284,10 +284,10 @@ let
 
     # Check `ODEProblem` content.
     @test oprob[X1] == 1.0
-    @test_broken oprob[X2] == 2.0
+    @test oprob[X2] == 2.0
     @test oprob.ps[k1] == 0.1
     @test oprob.ps[k2] == 0.2
-    @test_broken oprob.ps[Γ[1]] == 3.0
+    @test oprob.ps[Γ[1]] == 3.0
 
     # Update (normal) problem parameters using `remake`.
     oprob_new = remake(oprob; p = [k1 => 0.3, k2 => 0.4])
@@ -322,7 +322,7 @@ end
     nsol = solve(nprob)
     @test oprob[:X] == sprob[:X] == nprob[:X] == 2.0
     @test osol[:X][1] == ssol[:X][1] == 2.0
-    @test_broken oprob[:X2] == sprob[:X2] == nprob[:X2] == 3.0
+    @test oprob[:X2] == sprob[:X2] == nprob[:X2] == 3.0
     @test osol[:X2][1] == ssol[:X2][1] == 3.0
     #@test oprob.ps[:Γ][1] == sprob.ps[:Γ][1] == nprob.ps[:Γ][1] == 4.0
     @test osol.ps[:Γ][1] == ssol.ps[:Γ][1] == nsol.ps[:Γ][1] == 4.0


### PR DESCRIPTION
## Summary

- Convert seven conservation-law assertions from expected-broken to active tests.
- Record the dependency boundary that corrected the parameter-substitution behavior those assertions exercise.

This branch is rebased directly onto `master` and contains only the conservation-law test change.

## Cause

Catalyst commit `9d3448a6e614f2ddcd7b5c4866a7347266b2b6fd` marked these seven assertions broken on June 29. They now pass on both the current and generated minimum dependency graphs, so `@test_broken` reports seven unexpected-pass errors on clean master.

A public problem-construction probe bisected the original correction to ModelingToolkit commit `1c253adc2aa55934fa110dd664bdf27c4fadc0f1` in #4704, first released in ModelingToolkitBase 1.52.0:

- parent `96275f9cd`: reconstructed observed species `X2 = 0.0`, conservation parameter `Γ = 1.0`;
- correcting commit: `X2 = 2.0`, `Γ = 3.0`.

The change evaluates the operating-point mapping before filling `MTKParameters`, preserving the conservation substitutions these assertions exercise. Catalyst #1506 independently repairs the older MTKBase 1.51 behavior through initialization-equation propagation.

## Local verification

- Julia 1.10.11, clean master, generated minimum graph (MTKBase 1.46.0 / SciMLBase 3.18.0 / OrdinaryDiffEq 7.0.0): 242 passed, 7 unexpected-pass errors, 17 pre-existing broken, exit 1.
- Julia 1.10.11, this branch, the same generated minimum graph: 249 passed, 17 pre-existing broken, 266 total, exit 0.
- Julia 1.10.11 and 1.12.6, current MTKBase 1.53: 249 passed, 17 pre-existing broken, exit 0.
- Julia 1.12.6, MTKBase 1.52.0 / SciMLBase 3.36.0 / Symbolics 7.32.0 / SymbolicUtils 4.40.1: exact `GROUP=Modeling` passed; conservation reported 249 passed and 17 pre-existing broken.
- Runic 1.7 was run on the changed file and repository. It reports pre-existing broad formatting drift; its diff proposes no change to these seven edited assertions, so no unrelated formatting was included.

No assertion was loosened, skipped, deleted, or changed to match buggy output; these seven tests are strengthened from expected-broken to required passing assertions.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.