### PR TITLE
Fix docs cleanup shell quoting

### DIFF
--- a/.github/workflows/DocsCleanup.yml
+++ b/.github/workflows/DocsCleanup.yml
@@ -26,7 +26,7 @@ jobs:
               git config user.email "documenter@juliadocs.github.io"
               git rm -rf "${preview_dir}"
               git commit -m "delete preview"
-              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git branch gh-pages-new "$(echo "delete history" | git commit-tree "HEAD^{tree}")"
               git push --force origin gh-pages-new:gh-pages
           fi
         env:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Quote the commit ID returned by `git commit-tree` before passing it to `git branch`.
- Quote the `HEAD^{tree}` revision expression.
- Remove the repo-wide actionlint `SC2046` and `SC1083` findings without changing cleanup behavior.

## Root cause

The faulty cleanup workflow was introduced in `b840ebc9b5d7e8f65391338504420f7e7e0b6569` (`Create DocsCleanup.yml`). Direct history inspection confirms the file is absent from its parent and is introduced with the unquoted command substitution and revision expression.

## Local verification

- `actionlint` from the repository root: passed.
- `git diff --check`: passed.
- Executed the exact rewritten command in a temporary Git repository and verified the created branch has the same tree as `HEAD` and commit subject `delete history`: passed.
- Repo-wide Runic remains red on a clean detached checkout of current `origin/master` (`ae55024af9289d201b353d27859b29909a5e3bde`); this is a widespread pre-existing formatting failure and is intentionally excluded from this focused workflow PR.