### PR TITLE
Import SciMLBase directly in module-qualified tests

### DIFF
--- a/test/dsl/dsl_options.jl
+++ b/test/dsl/dsl_options.jl
@@ -5,6 +5,7 @@
 # Fetch packages.
 using Catalyst, ModelingToolkitBase, OrdinaryDiffEq, Statistics, StochasticDiffEq, Plots, Test
 using Catalyst: symmap_to_varmap
+using SciMLBase
 using Symbolics: unwrap
 
 # Sets stable rng number.

--- a/test/simulation_and_solving/hybrid_models.jl
+++ b/test/simulation_and_solving/hybrid_models.jl
@@ -1,5 +1,6 @@
 # Fetch packages.
 using Catalyst, JumpProcesses, ModelingToolkitBase, OrdinaryDiffEq, Statistics, Test, Random
+using SciMLBase
 using StochasticDiffEq: SRIW1  # For SDE+Jump hybrid problems
 import DiffEqNoiseProcess  # Required for SDEProblem via mtkcompile
 

--- a/test/simulation_and_solving/simulate_ODEs.jl
+++ b/test/simulation_and_solving/simulate_ODEs.jl
@@ -2,6 +2,7 @@
 
 # Fetch packages.
 using Catalyst, OrdinaryDiffEq, Test
+using SciMLBase
 
 # Sets stable rng number.
 using StableRNGs

--- a/test/simulation_and_solving/simulate_SDEs.jl
+++ b/test/simulation_and_solving/simulate_SDEs.jl
@@ -3,6 +3,7 @@
 # Fetch packages.
 using Catalyst, Statistics, StochasticDiffEq, Test
 using Catalyst: getnoisescaling
+using SciMLBase
 
 # Sets stable rng number.
 using StableRNGs

--- a/test/simulation_and_solving/simulate_jumps.jl
+++ b/test/simulation_and_solving/simulate_jumps.jl
@@ -2,6 +2,7 @@
 
 # Fetch packages.
 using Catalyst, JumpProcesses, ModelingToolkitBase, OrdinaryDiffEq, Statistics, Test
+using SciMLBase
 using SymbolicIndexingInterface: setp
 
 # Sets stable rng number.

--- a/test/spatial_modelling/dspace_reaction_systems_ODEs.jl
+++ b/test/spatial_modelling/dspace_reaction_systems_ODEs.jl
@@ -3,6 +3,7 @@
 # Fetch packages.
 using OrdinaryDiffEq
 using Random, Statistics, SparseArrays, Test
+using SciMLBase
 
 # Fetch test networks.
 include("../spatial_test_networks.jl")

--- a/test/spatial_modelling/dspace_reaction_systems_jumps.jl
+++ b/test/spatial_modelling/dspace_reaction_systems_jumps.jl
@@ -2,6 +2,7 @@
 
 # Fetch packages.
 using JumpProcesses, Statistics, SparseArrays, Test
+using SciMLBase
 
 # Fetch test networks.
 include("../spatial_test_networks.jl")

--- a/test/upstream/mtk_structure_indexing.jl
+++ b/test/upstream/mtk_structure_indexing.jl
@@ -2,6 +2,7 @@
 
 # Fetch packages
 using Catalyst, JumpProcesses, NonlinearSolve, OrdinaryDiffEq, Plots, SteadyStateDiffEq, StochasticDiffEq, Test
+using SciMLBase
 import ModelingToolkitBase: getp, getu, setp, setu
 
 # Sets rnd number.


### PR DESCRIPTION
> This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- import `SciMLBase` directly in every test file that uses a module-qualified `SciMLBase.` reference
- remove reliance on dependency re-exports to place the `SciMLBase` module binding in each isolated `SafeTestset`
- cover all eight such test files; `simulate_ODEs.jl` is the currently failing case and the other seven imports are preventive hygiene

This PR targets `master` directly and is independent of #1511 and #1512.

## Root cause

Catalyst's ODE test has called `SciMLBase.successful_retcode` since Catalyst commit `4e617286` without importing `SciMLBase` in that file. Historically, `using OrdinaryDiffEq` made the module binding available transitively.

OrdinaryDiffEq commit `69e8dda5` (parent `b4bae612`) stripped the v7 package down to its minimal re-export shell. With the Catalyst minimum-compatible graph at OrdinaryDiffEq 7.0.0, `using OrdinaryDiffEq` no longer places a `SciMLBase` module binding in the test module. The first module-qualified check therefore raised `UndefVarError: SciMLBase not defined`.

## Validation

Exact minimum-compatible graph on Julia 1.10.11: OrdinaryDiffEq 7.0.0, SciMLBase 3.18.0, DiffEqBase 7.2.0, ModelingToolkitBase 1.46.0, and JumpProcesses 9.26.0.

- clean `master`, `GROUP=Simulation`: ODE simulations had 87 passes and 132 errors (219 total), all from the missing `SciMLBase` binding
- this branch, `GROUP=Simulation`: ODE 219/219, automatic Jacobian 224/224, and SDE 195/195
- this branch, `GROUP=Hybrid`: 4,218/4,218
- this branch, `GROUP=Spatial`: all testsets passed, including affected ODE discrete-space tests 502/502 and jump discrete-space tests 206/206
- focused official-harness run for testsets blocked downstream in their full groups: DSL Options 317 pass / 1 broken / 318 total; MTK Structure Indexing 674 pass / 24 broken / 698 total
- repository audit: exactly eight Julia test files contain `SciMLBase.`, and all eight now import `SciMLBase` directly
- all seven TOML files parse successfully
- `git diff --check` passes

Two unrelated failures on the unmodified exact-minimum graph stop the complete Modeling and Simulation groups after the affected import paths have been validated:

- Events: 62 pass / 1 error / 1 broken; `VectorContinuousCallback` has no `affect_neg!`
- later jump tests: 107 pass / 4 errors; `SSAIntegrator` has no `derivative_discontinuity`

Those callback compatibility boundaries are being reproduced and bisected separately rather than folded into this import-only PR.

Runic checked all 89 Julia files: 15 already conform and 74 have broad pre-existing formatting drift. The eight import additions themselves require no formatting adjustment, so this PR does not mix in repository-wide reformatting.