### PR TITLE
Test graph edge order without symbolic repr

### DIFF
--- a/test/extensions/graphmakie.jl
+++ b/test/extensions/graphmakie.jl
@@ -149,9 +149,7 @@ let
         k5*B, A --> B
     end
     rxorder = test_edgeorder(rn)
-    edgelabels = [repr(rx.rate) for rx in reactions(rn)]
-    labels = ["k1", "k4", "k5*B(t)", "k2", "Catalyst.hillr(D(t), α, K, n)", "k3"]
-    @test_broken edgelabels[rxorder] == labels
+    @test rxorder == [1, 4, 6, 2, 5, 3]
 
     rs = @reaction_network begin
         ka, Depot --> Central


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- Assert the exact reaction-to-complex-edge permutation returned by `ComplexGraphWrap`.
- Remove the brittle comparison against `repr` strings whose commutative factor order changes across Symbolics versions.
- Keep the adjacent `edgelist[rxorder] == Graphs.edges(img)` assertion unchanged.

## Root cause

Commit `a815230d89c2b21c7f9322545043f922654fc6f1` changed the label-order assertion from `@test` to `@test_broken`. Under the downgrade workflow's outer-Catalyst load order, the equality already passes, so `@test_broken` raises an Unexpected Pass. Under the current standalone Extensions environment, Symbolics prints the same commutative product as `B(t)*k5` rather than `k5*B(t)`, so a literal string assertion cannot be valid in both supported environments.

`edgelabels` is deterministically derived from `reactions(rn)`, while `rxorder` is the mapping under test. Asserting `rxorder == [1, 4, 6, 2, 5, 3]` preserves the complete ordering invariant without coupling the test to symbolic pretty-printing.

## Local validation

- Julia 1.10.11: `GROUP=Extensions julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` — passed, including Graph visualization 25/25 and the full Extensions group.
- Exact outer-Catalyst/inner-extension downgrade reproducer with DiffEqBase 7.2.0 and JumpProcesses 9.26.0 — Graph visualization 25/25.
- Runic 1.7.0 check of the changed assertion — passed.
- A full-tree Runic check was also run; current master has broad pre-existing formatting drift, so no unrelated formatter rewrite is included here.

