### PR TITLE
Stabilize hybrid jump-diffusion variance test

### DIFF
--- a/test/simulation_and_solving/hybrid_models.jl
+++ b/test/simulation_and_solving/hybrid_models.jl
@@ -1294,7 +1294,8 @@ let
     λ_val = 3.0
     σ_val = 1.0
     T = 10.0
-    n_trials = 500
+    # Brownian trajectories use the task RNG, so use enough samples to stabilize their variance.
+    n_trials = 1500
 
     # Create problem once; the RNG state advances across solves.
     prob = HybridProblem(rn, [:X => 0.0], (0.0, T),


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Increase the Monte Carlo sample count for the Brownian-plus-Poisson variance check from 500 to 1500.
- Preserve both the expected variance formula and the existing 15% relative tolerance.

## Why

The `StableRNG` supplied to `HybridProblem` controls the jump process, while `SRIW1` draws Brownian increments from the task RNG. The sample-variance estimator therefore changes with the outer test RNG. At 500 trials its approximate relative standard error is `sqrt(2 / (500 - 1)) = 6.3%` (and can be slightly larger for the jump-diffusion distribution), so the 15% acceptance band is only about 2.4 standard errors wide.

The outer RNG recorded by `SciML/ModelingToolkit.jl#4793` produced a variance of `33.82356404805082`, just outside the lower bound of `34.0`. Full-file replay reproduced that exact value on both the clean ModelingToolkit base (`f6c5c80d`) and PR head (`bb9b3fdc`). Their resolved dependency graphs were identical after normalizing local paths, including DiffRules 1.16.0, so the failure is independent of that PR.

At 1500 trials the approximate relative standard error falls to 3.7%, putting the unchanged 15% band more than four standard errors away. `git blame` traces the statistical test to `ac967b29`, introduced through #1386.

## Local validation

- Julia 1.12.6, exact recorded failing RNG and dependency graph, full `hybrid_models.jl`: 4218/4218 passed in 15m21.1s.
- Julia 1.12.6, official `GROUP=Hybrid` harness on final rebased head `53e6bacb` against base `730c79ea`: 4218/4218 passed in 21m35.8s; process exit status 0.
- Six 1500-trial task-RNG states passed; observed variance range was 38.32–44.64 for the expected value 40.0 and unchanged accepted range 34.0–46.0.
- Runic 1.7.0 left the modified line range unchanged; `git diff --check` passed. The whole-file Runic check reports pre-existing drift in untouched portions of `hybrid_models.jl`, which this focused PR does not rewrite.
