### PR TITLE
Allow documented dependency reexports in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -43,6 +43,7 @@ const DEPENDENCY_OWNED_PUBLIC_NAMES = Tuple(
 run_qa(
     Catalyst;
     explicit_imports = true,
+    reexports_allow = DEPENDENCY_OWNED_PUBLIC_NAMES,
     api_docs_kwargs = (;
         rendered = true,
         ignore = DEPENDENCY_OWNED_PUBLIC_NAMES,


### PR DESCRIPTION
Ignore this PR until it is reviewed by @ChrisRackauckas.

## Summary

- Complete #1501's QA configuration by passing its existing `DEPENDENCY_OWNED_PUBLIC_NAMES` tuple to SciMLTesting's `reexports_allow` keyword.
- Keep the public-reexport audit enabled while explicitly scoping the intentional dependency facade names.

## Root cause

#1501 upgraded the QA environment to SciMLTesting 2.x and introduced an exact tuple of dependency-owned public names for the API-documentation checks. SciMLTesting 2.x also enables its public-reexport audit by default, but that same tuple was not passed to the audit, so the LTS/current/prerelease QA jobs rejected all 309 intentional facade reexports.

This does not set `check_reexports = false` and does not use a wildcard. Any future unapproved Catalyst-owned or dependency-owned reexport outside the computed tuple still fails the audit.

## Validation

- `GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`: 14 passed, 4 broken; package tests passed.
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: 13 passed, 7 broken; package tests passed on 1.12.6.
- `GROUP=QA julia +1.13 --project=. -e 'using Pkg; Pkg.test()'`: 13 passed, 6 broken; package tests passed on 1.13.0-rc1.
- Direct comparison with `SciMLTesting.public_reexports(Catalyst)`: both sets contain 309 sorted, unique names; exact ordered equality is true with no missing or extra names.
- Runic 1.7: `test/qa/qa.jl` passes `--check --diff`.
- `git diff --check`: passed.