### PR TITLE
Bump Catalyst to v16.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "16.2.2"
+version = "16.2.3"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
Bumps `Catalyst` **v16.2.2 → v16.2.3** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Update Catalyst strict QA for SciMLTesting 2.4 (#1522) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)