### PR TITLE
fix: correct spelling mistakes

### DIFF
--- a/docs/src/inverse_problems/global_sensitivity_analysis.md
+++ b/docs/src/inverse_problems/global_sensitivity_analysis.md
@@ -35,7 +35,7 @@ p_setter = setp_oop(oprob_base, [:β, :γ])
 
 # Creates a function that simulates the model an returns the peak number of cases.
 function peak_cases(p)
-    # Updates the ODEProblem with teh proposed parameter set.
+    # Updates the ODEProblem with the proposed parameter set.
     p = p_setter(oprob_base, p)
     oprob = remake(oprob_base; p)
     sol = solve(oprob; maxiters = 100000, verbose = SciMLLogging.None())

--- a/docs/src/inverse_problems/optimization_ode_param_fitting.md
+++ b/docs/src/inverse_problems/optimization_ode_param_fitting.md
@@ -38,11 +38,11 @@ p_setter = setp_oop(oprob_base, [:p, :d])
 
 # A loss function measuring the sum-of-square distance between a simulation and the data.
 function loss(p, (oprob_base, p_setter, t_samples, X_samples))
-    # Updates the ODEProblem with teh proposed parameter set.
+    # Updates the ODEProblem with the proposed parameter set.
     p = p_setter(oprob_base, p)
     oprob = remake(oprob_base; p)
 
-    # Simulate the model. If sucesfull, return sum-of-squares distance as loss.
+    # Simulate the model. If successful, return sum-of-squares distance as loss.
     sol = solve(oprob; saveat = t_samples, verbose = SciMLLogging.None(), maxiters = 10000)
     SciMLBase.successful_retcode(sol) || return Inf
     return sum(abs2, sol[:X] .- X_samples)

--- a/docs/src/inverse_problems/turing_ode_param_fitting.md
+++ b/docs/src/inverse_problems/turing_ode_param_fitting.md
@@ -202,7 +202,7 @@ I_observed[idx] ~ truncated(Normal(sol[:I][idx], σI), 0.0, Inf)
 to create a version of our normal distribution that is truncated at *0* and infinity.
 
 ### [Accessing posterior information](@id turing_parameter_fitting_basic_example_output_interfacing)
-Say that we want to sample a parameter set from the computed posterior distribution. Here, we first use `draw = rand(chain; parameters_only = true)` to sample a random parameter set from teh posterior. next, we can use e.g. `draw[@varname(γ)]` to access the parameter $γ$'s value from that sample.
+Say that we want to sample a parameter set from the computed posterior distribution. Here, we first use `draw = rand(chain; parameters_only = true)` to sample a random parameter set from the posterior. next, we can use e.g. `draw[@varname(γ)]` to access the parameter $γ$'s value from that sample.
 ```@example turing_paramfit
 draw = rand(chain; parameters_only = true)
 draw[@varname(γ)]

--- a/docs/src/model_creation/functional_parameters.md
+++ b/docs/src/model_creation/functional_parameters.md
@@ -34,7 +34,7 @@ bd_model = @reaction_network begin
     d, X --> 0
 end
 
-# Finally we simualte the model normally, but using `spline` as the `pIn` parameter's value.
+# Finally we simulate the model normally, but using `spline` as the `pIn` parameter's value.
 u0 = [:X => 0.5]
 ps = [:d => 2.0, :pIn => spline]
 oprob = ODEProblem(bd_model, u0, tend, ps)

--- a/src/dsl.jl
+++ b/src/dsl.jl
@@ -511,7 +511,7 @@ end
 # Function looping through all reactions, to find undeclared symbols (species or
 # parameters) and assign them to the right category.
 # `stoich_ps` records parameters used in stoichiometries (if these are not declare separately,
-# these are infered to be integers)..
+# these are inferred to be integers)..
 function extract_sps_and_ps(reactions, excluded_syms; requiredec = false)
     # Loops through all reactants and extract undeclared ones as species.
     species = OrderedSet{Union{Symbol, Expr}}()
@@ -1017,7 +1017,7 @@ function expr_contains_pre(expr)
 end
 
 # Read the events (continuous or discrete) provided as options to the DSL. Returns an expression which evaluates to these.
-# Infered parameters that are updated byu the event should be declared using e.g. `@discretes p(t)`.
+# Inferred parameters that are updated byu the event should be declared using e.g. `@discretes p(t)`.
 # `read_events_option!` moves these from `ps_inferred` to `discs_inferred`
 function read_events_option!(options, discs_inferred::Vector, ps_inferred::Vector, discs_declared::Vector, event_type::Symbol)
     # Prepares the events, if required to, converts them to block form.

--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -1007,10 +1007,10 @@ function conservationlaw_errorcheck(rs, pre_varmap)
     vars_with_vals = Set(p[1] for p in pre_varmap)
     missing_cl_vals = filter(sp -> (sp ∉ vars_with_vals) && !MT.hasdefault(sp), conslaw_species(rs))
     isempty(missing_cl_vals) && return
-    error("The system has conservation laws but initial conditions were not provided for these conservation law-invovled species: $(missing_cl_vals).")
+    error("The system has conservation laws but initial conditions were not provided for these conservation law-involved species: $(missing_cl_vals).")
 end
 
-# Returns a vector with all species that are invovled in conservation laws.
+# Returns a vector with all species that are involved in conservation laws.
 # Note: uses Symbolics.get_variables! instead of MT.collect_vars! because
 # the latter fails to extract variables on Julia 1.10 LTS (empty result
 # despite valid input expressions).

--- a/src/reactionsystem_serialisation/serialise_fields.jl
+++ b/src/reactionsystem_serialisation/serialise_fields.jl
@@ -178,7 +178,7 @@ end
 function seri_has_discretes(rn::ReactionSystem)
     return any(_is_discrete(p) for p in get_ps(rn))
 end
-# Temporary function, repalce with better after reply from Aayush.
+# Temporary function, replace with better after reply from Aayush.
 _is_discrete(param) = occursin('(', "$(param)")
 
 # Extract a string which declares the system's discretes. Uses multiline declaration (a

--- a/test/extensions/bifurcation_kit.jl
+++ b/test/extensions/bifurcation_kit.jl
@@ -275,7 +275,7 @@ let
     u0_guess = [:A => 1., :B => 1.]
     p_start = [:k => 2.]
 
-    # Computes bifurcation diagram and checks that it can be sucesfully plotted.
+    # Computes bifurcation diagram and checks that it can be successfully plotted.
     bprob = BifurcationProblem(rn, u0_guess, p_start, :k; plot_var = :A, u0 = [:A => 5., :B => 3.])
     p_span = (0.1, 6.0)
     opts_br = ContinuationPar(dsmin = 0.0001, dsmax = 0.001, ds = 0.0001, max_steps = 10000, p_min = p_span[1], p_max = p_span[2], n_inversion = 4)

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -713,7 +713,7 @@ end
 
 ### Specialised ReactionSystem Fields ###
 
-# Checks that correct bindings and (default) iniital conditions are created and stored in various ways and conversions.
+# Checks that correct bindings and (default) initial conditions are created and stored in various ways and conversions.
 let
     # Declare time differential.
     D = default_time_deriv()
@@ -1054,7 +1054,7 @@ let
     @test issetequal(parameters(rs), [k, b])
 end
 
-# Test parameteric initial conditions.
+# Test parametric initial conditions.
 let
     @parameters d X0
     @species X(t) = X0
@@ -1191,7 +1191,7 @@ let
     @test ModelingToolkitBase.getmetadata(complete(ss_ode_model(complete(rs1))), MiscSystemData, nothing) == nothing
     @test ModelingToolkitBase.getmetadata(complete(ss_ode_model(complete(rs2))), MiscSystemData, nothing) == π
 
-    # Check metadata for `ReactionSystem`s where metadata has been udpated
+    # Check metadata for `ReactionSystem`s where metadata has been updated
     rs1 = ModelingToolkitBase.setmetadata(rs1, MiscSystemData, "Metadata")
     rs2 = ModelingToolkitBase.setmetadata(rs2, MiscSystemData, ones(2, 3))
     @test ModelingToolkitBase.getmetadata(rs1, MiscSystemData, nothing) == "Metadata"
@@ -1283,7 +1283,7 @@ end
 # there are several places in the code where the `reactionsystem_uptodate` function is called, here
 # the code might need adaptation to take the updated reaction system into account.
 let
-    @test_nowarn Catalyst.reactionsystem_uptodate_check() # Will fix this once most things are actually workin.
+    @test_nowarn Catalyst.reactionsystem_uptodate_check() # Will fix this once most things are actually working.
 end
 
 # Test that functions using the incidence matrix properly cache it

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ end
 
         # Tests various miscellaneous features.
         @time @safetestset "API" begin include("miscellaneous_tests/api.jl") end
-        @time @safetestset "Units" begin include("miscellaneous_tests/units.jl") end # `_validate` currently no longer avaiable, awaiting advice.
+        @time @safetestset "Units" begin include("miscellaneous_tests/units.jl") end # `_validate` currently no longer available, awaiting advice.
         @time @safetestset "Compound Species" begin include("miscellaneous_tests/compound_macro.jl") end
         @time @safetestset "Reaction Balancing" begin include("miscellaneous_tests/reaction_balancing.jl") end
 

--- a/test/spatial_modelling/dspace_reaction_systems_space_types.jl
+++ b/test/spatial_modelling/dspace_reaction_systems_space_types.jl
@@ -202,7 +202,7 @@ let
     masked_grid_2d = reshape(masked_grid_1d,8,1)
     masked_grid_3d = reshape(masked_grid_1d,1,8,1)
 
-    # Creaets a base solution to which we will compare all simulations.
+    # Creates a base solution to which we will compare all simulations.
     dsrs_base = DiscreteSpaceReactionSystem(SIR_system, SIR_srs_1, masked_grid_1d)
     oprob_base = ODEProblem(dsrs_base, [:S => S_vals, :I => I_val, :R => R_val], (0.0, 100.0), [:α => α_vals, :β => β_val, :dS => dS_val])
     sol_base = solve(oprob_base, Tsit5(); saveat = 1.0, abstol = 1e-9, reltol = 1e-9)


### PR DESCRIPTION
## What changed
Corrected spelling mistakes in documentation, source comments, and test comments. This is a mechanical hygiene change only; no runtime behavior or public API was changed.

## Verification
- `git diff --check`: passed.
- `typos` over all changed files: passed (`rc=0`).
- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`: completed on the changed branch with 12 passed, 1 failed, and 7 broken. The failure is SciMLTesting `No unapproved public reexports` for `generate_trajectory`, `inverse_laplace`, `laplace`, `laplace_solve_ode`, and `partial_frac_decomposition`; this spelling-only diff does not alter exports.
- `JULIA_DEPOT_PATH=/tmp/catalyst_docs_depot timeout 3600 julia --project=docs docs/make.jl`: reached the one-hour timeout (`rc=124`) after emitting only the headless-display notice; docs success is not claimed.

Please ignore this draft until reviewed by @ChrisRackauckas.