### PR TITLE
Fix metadata tests after internal reexport removal

### DIFF
--- a/test/miscellaneous_tests/reactionsystem_serialisation.jl
+++ b/test/miscellaneous_tests/reactionsystem_serialisation.jl
@@ -6,6 +6,8 @@ using Catalyst: get_rxs
 using ModelingToolkitBase: getdefault, getdescription, get_metadata
 using Symbolics: getmetadata
 
+abstract type TestSystemData end
+
 # Creates missing getters for MTK metadata (can be removed once added to MTK).
 getmisc(x) = getmetadata(Symbolics.unwrap(x), ModelingToolkitBase.VariableMisc, nothing)
 getinput(x) = getmetadata(Symbolics.unwrap(x), ModelingToolkitBase.VariableInput, nothing)
@@ -160,8 +162,8 @@ let
         Reaction(d2 + D2, [V2], [], metadata = [:misc => dict_md])
         Reaction(e2 + E2, [W2], [], metadata = [:misc => mat_md])
     ]
-    @named rs2 = ReactionSystem(rxs2, t; metadata = [MiscSystemData => dict_md])
-    @named rs1 = ReactionSystem(rxs1, t; systems = [rs2], metadata = [MiscSystemData => mat_md])
+    @named rs2 = ReactionSystem(rxs2, t; metadata = [TestSystemData => dict_md])
+    @named rs1 = ReactionSystem(rxs1, t; systems = [rs2], metadata = [TestSystemData => mat_md])
     rs = complete(rs1)
 
     # Loads the model and checks that it is correct. Removes the saved file
@@ -209,8 +211,8 @@ let
     @test isequal(Catalyst.getmisc(get_rxs(rs_loaded.rs2)[5]), mat_md)
 
     # Checks that `ReactionSystem` metadata fields are correct.
-    @test isequal(ModelingToolkitBase.getmetadata(rs_loaded, MiscSystemData, nothing), mat_md)
-    @test isequal(ModelingToolkitBase.getmetadata(rs_loaded.rs2, MiscSystemData, nothing), dict_md)
+    @test isequal(ModelingToolkitBase.getmetadata(rs_loaded, TestSystemData, nothing), mat_md)
+    @test isequal(ModelingToolkitBase.getmetadata(rs_loaded.rs2, TestSystemData, nothing), dict_md)
 end
 
 # Checks systems where parameters/species/variables have complicated interdependency are correctly
@@ -339,18 +341,26 @@ let
     ]
 
     # Creates the systems.
-    @named rs_4 = ReactionSystem(eqs_4, t; continuous_events = continuous_events_4,
-                                discrete_events = discrete_events_4, spatial_ivs = sivs,
-                                metadata = [MiscSystemData => "System 4"], systems = [])
-    @named rs_2 = ReactionSystem(eqs_2, t; continuous_events = continuous_events_2,
-                                discrete_events = discrete_events_2, spatial_ivs = sivs,
-                                metadata = [MiscSystemData => "System 2"], systems = [])
-    @named rs_3 = ReactionSystem(eqs_3, t; continuous_events = continuous_events_3,
-                                discrete_events = discrete_events_3, spatial_ivs = sivs,
-                                metadata = [MiscSystemData => "System 3"], systems = [rs_4])
-    @named rs_1 = ReactionSystem(eqs_1, t; continuous_events = continuous_events_1,
-                                discrete_events = discrete_events_1, spatial_ivs = sivs,
-                                metadata = [MiscSystemData => "System 1"], systems = [rs_2, rs_3])
+    @named rs_4 = ReactionSystem(
+        eqs_4, t; continuous_events = continuous_events_4,
+        discrete_events = discrete_events_4, spatial_ivs = sivs,
+        metadata = [TestSystemData => "System 4"], systems = []
+    )
+    @named rs_2 = ReactionSystem(
+        eqs_2, t; continuous_events = continuous_events_2,
+        discrete_events = discrete_events_2, spatial_ivs = sivs,
+        metadata = [TestSystemData => "System 2"], systems = []
+    )
+    @named rs_3 = ReactionSystem(
+        eqs_3, t; continuous_events = continuous_events_3,
+        discrete_events = discrete_events_3, spatial_ivs = sivs,
+        metadata = [TestSystemData => "System 3"], systems = [rs_4]
+    )
+    @named rs_1 = ReactionSystem(
+        eqs_1, t; continuous_events = continuous_events_1,
+        discrete_events = discrete_events_1, spatial_ivs = sivs,
+        metadata = [TestSystemData => "System 1"], systems = [rs_2, rs_3]
+    )
     rs = complete(rs_1)
 
     # Checks that the correct system is saved (both complete and incomplete ones).

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -33,7 +33,7 @@ const LEGACY_DEPENDENCY_REEXPORTS = (
     :AnalysisPoint, :AssignmentAffect, :BS, :BipartiteGraph, :CartesianGrid, :CartesianGridRej, :CasADiCollocation, :CasADiDynamicOptProblem, :Clock, :CompilerOptions, :Connection, :Differential,
     :DiscreteFunction, :DiscreteProblem, :DiscreteSystem, :DynamicOptSolution, :Equation, :EvalAt, :Flow, :Girsanov_transform, :GlobalScope, :Hold, :HomotopyContinuationProblem, :IRStructure,
     :ImplicitDiscreteFunction, :ImplicitDiscreteProblem, :ImplicitDiscreteSystem, :Inequality, :InfiniteOptCollocation, :InfiniteOptDynamicOptProblem, :Initial, :InitializationProblem, :Integral, :IntervalNonlinearFunction, :IntervalNonlinearProblem, :JuMPCollocation,
-    :JuMPDynamicOptProblem, :JumpProblem, :JumpSystem, :LocalScope, :MTKParameters, :MiscSystemData, :MissingGuessValue, :ModelingToolkitBase, :NonlinearFunction, :NonlinearProblem, :NonlinearSystem, :Num,
+    :JuMPDynamicOptProblem, :JumpProblem, :JumpSystem, :LocalScope, :MTKParameters, :MissingGuessValue, :ModelingToolkitBase, :NonlinearFunction, :NonlinearProblem, :NonlinearSystem, :Num,
     :ODEFunction, :ODEProblem, :ODESystem, :OptimizationProblem, :OptimizationSystem, :PDESystem, :ParentScope, :Pre, :PyomoCollocation, :PyomoDynamicOptProblem, :Rewriters, :RuleSet,
     :SDEFunction, :SDEProblem, :SDESystem, :SafeReal, :Sample, :SampleTime, :Shift, :ShiftIndex, :SolverStepClock, :SteadyStateProblem, :Stream, :SymReal,
     :SymScope, :SymStruct, :SymbolicLinearODE, :SymbolicMassActionJump, :SymbolicUtils, :Symbolics, :SymbolicsSparsityDetector, :System, :Term, :TimeDomain, :TreeReal, :UnPack,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -33,7 +33,7 @@ const LEGACY_DEPENDENCY_REEXPORTS = (
     :AnalysisPoint, :AssignmentAffect, :BS, :BipartiteGraph, :CartesianGrid, :CartesianGridRej, :CasADiCollocation, :CasADiDynamicOptProblem, :Clock, :CompilerOptions, :Connection, :Differential,
     :DiscreteFunction, :DiscreteProblem, :DiscreteSystem, :DynamicOptSolution, :Equation, :EvalAt, :Flow, :Girsanov_transform, :GlobalScope, :Hold, :HomotopyContinuationProblem, :IRStructure,
     :ImplicitDiscreteFunction, :ImplicitDiscreteProblem, :ImplicitDiscreteSystem, :Inequality, :InfiniteOptCollocation, :InfiniteOptDynamicOptProblem, :Initial, :InitializationProblem, :Integral, :IntervalNonlinearFunction, :IntervalNonlinearProblem, :JuMPCollocation,
-    :JuMPDynamicOptProblem, :JumpProblem, :JumpSystem, :LocalScope, :MTKParameters, :MissingGuessValue, :ModelingToolkitBase, :NonlinearFunction, :NonlinearProblem, :NonlinearSystem, :Num,
+    :JuMPDynamicOptProblem, :JumpProblem, :JumpSystem, :LocalScope, :MTKParameters, :MiscSystemData, :MissingGuessValue, :ModelingToolkitBase, :NonlinearFunction, :NonlinearProblem, :NonlinearSystem, :Num,
     :ODEFunction, :ODEProblem, :ODESystem, :OptimizationProblem, :OptimizationSystem, :PDESystem, :ParentScope, :Pre, :PyomoCollocation, :PyomoDynamicOptProblem, :Rewriters, :RuleSet,
     :SDEFunction, :SDEProblem, :SDESystem, :SafeReal, :Sample, :SampleTime, :Shift, :ShiftIndex, :SolverStepClock, :SteadyStateProblem, :Stream, :SymReal,
     :SymScope, :SymStruct, :SymbolicLinearODE, :SymbolicMassActionJump, :SymbolicUtils, :Symbolics, :SymbolicsSparsityDetector, :System, :Term, :TimeDomain, :TreeReal, :UnPack,

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -5,6 +5,8 @@ using Catalyst, LinearAlgebra, JumpProcesses, OrdinaryDiffEq, StochasticDiffEq, 
 const MT = ModelingToolkitBase
 using ModelingToolkitBase: Pre, unwrap
 
+abstract type TestSystemData end
+
 # Sets stable rng number.
 using StableRNGs
 rng = StableRNG(12345)
@@ -1165,39 +1167,39 @@ let
     @species X(t)
     @parameters d
     @named rs1 = ReactionSystem([Reaction(d, [X], nothing)], t)
-    @named rs2 = ReactionSystem([Reaction(d, [X], nothing)], t; metadata = [MiscSystemData => π])
+    @named rs2 = ReactionSystem([Reaction(d, [X], nothing)], t; metadata = [TestSystemData => π])
 
     # Check metadata for `ReactionSystem`s.
-    @test ModelingToolkitBase.getmetadata(rs1, MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(rs2, MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(complete(rs1), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(complete(rs2), MiscSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(rs1, TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(rs2, TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(complete(rs1), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(complete(rs2), TestSystemData, nothing) == π
 
     # Check metadata for converted `ReactionSystem`s.
-    @test ModelingToolkitBase.getmetadata(ode_model(complete(rs1)), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(ode_model(complete(rs2)), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(complete(ode_model(complete(rs1))), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(complete(ode_model(complete(rs2))), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(sde_model(complete(rs1)), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(sde_model(complete(rs2)), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(complete(sde_model(complete(rs1))), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(complete(sde_model(complete(rs2))), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(jump_model(complete(rs1)), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(jump_model(complete(rs2)), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(complete(jump_model(complete(rs1))), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(complete(jump_model(complete(rs2))), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(ss_ode_model(complete(rs1)), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(ss_ode_model(complete(rs2)), MiscSystemData, nothing) == π
-    @test ModelingToolkitBase.getmetadata(complete(ss_ode_model(complete(rs1))), MiscSystemData, nothing) == nothing
-    @test ModelingToolkitBase.getmetadata(complete(ss_ode_model(complete(rs2))), MiscSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(ode_model(complete(rs1)), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(ode_model(complete(rs2)), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(complete(ode_model(complete(rs1))), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(complete(ode_model(complete(rs2))), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(sde_model(complete(rs1)), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(sde_model(complete(rs2)), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(complete(sde_model(complete(rs1))), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(complete(sde_model(complete(rs2))), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(jump_model(complete(rs1)), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(jump_model(complete(rs2)), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(complete(jump_model(complete(rs1))), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(complete(jump_model(complete(rs2))), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(ss_ode_model(complete(rs1)), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(ss_ode_model(complete(rs2)), TestSystemData, nothing) == π
+    @test ModelingToolkitBase.getmetadata(complete(ss_ode_model(complete(rs1))), TestSystemData, nothing) == nothing
+    @test ModelingToolkitBase.getmetadata(complete(ss_ode_model(complete(rs2))), TestSystemData, nothing) == π
 
     # Check metadata for `ReactionSystem`s where metadata has been updated
-    rs1 = ModelingToolkitBase.setmetadata(rs1, MiscSystemData, "Metadata")
-    rs2 = ModelingToolkitBase.setmetadata(rs2, MiscSystemData, ones(2, 3))
-    @test ModelingToolkitBase.getmetadata(rs1, MiscSystemData, nothing) == "Metadata"
-    @test ModelingToolkitBase.getmetadata(rs2, MiscSystemData, nothing) == ones(2, 3)
-    @test ModelingToolkitBase.getmetadata(complete(rs1), MiscSystemData, nothing) == "Metadata"
-    @test ModelingToolkitBase.getmetadata(complete(rs2), MiscSystemData, nothing) == ones(2, 3)
+    rs1 = ModelingToolkitBase.setmetadata(rs1, TestSystemData, "Metadata")
+    rs2 = ModelingToolkitBase.setmetadata(rs2, TestSystemData, ones(2, 3))
+    @test ModelingToolkitBase.getmetadata(rs1, TestSystemData, nothing) == "Metadata"
+    @test ModelingToolkitBase.getmetadata(rs2, TestSystemData, nothing) == ones(2, 3)
+    @test ModelingToolkitBase.getmetadata(complete(rs1), TestSystemData, nothing) == "Metadata"
+    @test ModelingToolkitBase.getmetadata(complete(rs2), TestSystemData, nothing) == ones(2, 3)
 end
 
 # Tests u0_map and parameter_map system-level metadata.
@@ -1431,7 +1433,7 @@ let
     discrete_events = (X == 1) => [V ~ V / 2]
 
     # Define metadata
-    metadata = [MiscSystemData => "Comprehensive test system"]
+    metadata = [TestSystemData => "Comprehensive test system"]
 
     # Define initial conditions and parameters
     u0 = Dict([A => 1.0, B => 2.0, C => 3.0, E => 4.0, V => 5.0])

--- a/test/spatial_modelling/dspace_reaction_systems.jl
+++ b/test/spatial_modelling/dspace_reaction_systems.jl
@@ -3,6 +3,8 @@
 # Fetch packages.
 using Catalyst, Graphs, OrdinaryDiffEq, Test
 
+abstract type TestSystemData end
+
 # Fetch test networks.
 include("../spatial_test_networks.jl")
 
@@ -140,7 +142,7 @@ let
         Reaction(kB, [X], [X2], [2], [1])
         Reaction(kD, [X2], [X], [1], [2])
     ]
-    @named rs = ReactionSystem(rxs, t; metadata = [MiscSystemData => "Metadata string"])
+    @named rs = ReactionSystem(rxs, t; metadata = [TestSystemData => "Metadata string"])
     rs = complete(rs)
     tr = @transport_reaction D X2
     dsrs = DiscreteSpaceReactionSystem(rs, [tr], small_2d_cartesian_grid)
@@ -151,7 +153,7 @@ let
     @test isequal(ModelingToolkitBase.get_iv(dsrs), t)
     @test isequal(equations(dsrs), rxs)
     @test isequal(unknowns(dsrs), [X, X2])
-    @test isequal(ModelingToolkitBase.getmetadata(dsrs, MiscSystemData, nothing), "Metadata string")
+    @test isequal(ModelingToolkitBase.getmetadata(dsrs, TestSystemData, nothing), "Metadata string")
     @test isequal(ModelingToolkitBase.get_eqs(dsrs), rxs)
     @test isequal(ModelingToolkitBase.get_unknowns(dsrs), [X, X2])
     @test isequal(ModelingToolkitBase.get_ps(dsrs), [p, d, kB, kD])


### PR DESCRIPTION
## What changed

Catalyst's system-metadata tests used `MiscSystemData`, an internal ModelingToolkitBase type that stopped being accidentally re-exported on ModelingToolkit master. Define test-local metadata key types instead, preserving the tests' actual contract: arbitrary system metadata survives conversion, completion, serialization, and discrete-space construction.

The first ModelingToolkit commit exposing the stale dependency was https://github.com/SciML/ModelingToolkit.jl/commit/735a4e0933d7fb4de8990ebf142ef343e66eb9df.

Ignore this PR until reviewed by @ChrisRackauckas.

## Verification

Failing before the fix, against ModelingToolkit `3fe375e19031102e95c7775c4d8a6aac9895767b` and Catalyst `9a2fa4df60d196f17bf473ed002c7b6cd097e3ca`:

```console
$ GROUP=Misc julia +1.12 --startup-file=no --project=downstream -e 'using Pkg; Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase")); Pkg.develop(PackageSpec(path=".")); Pkg.update(); Pkg.test()'
ReactionSystem Serialisation | 2 pass  1 error  3 total
ERROR: LoadError: UndefVarError: `MiscSystemData` not defined in `Main.var"##ReactionSystem Serialisation#284"`
```

Passing after the fix with the same command/environment:

```console
$ GROUP=Misc ...
ReactionSystem Serialisation | 51 pass  51 total
Testing Catalyst tests passed

$ GROUP=Modeling ...
ReactionSystem Structure | 419 pass  2 broken  421 total
Testing Catalyst tests passed

$ GROUP=Spatial ...
Discrete Space Reaction Systems | 4812 pass  4812 total
Testing Catalyst tests passed
```

The full QA group was also run against current ModelingToolkit master:

```console
$ GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Quality Assurance | 12 pass  1 fail  7 broken  20 total
```

Its sole failure is the independently reproducible clean-master public-reexport baseline for `build_explicit_observed_function` and `generate_control_function`; stale-dependency, compat, ExplicitImports, and API-documentation checks all passed. That separate baseline cluster is not changed or silenced here.

Standalone Catalyst CI also needs to support released ModelingToolkitBase versions where `MiscSystemData` is still exported. After retaining that released-version facade allowance, the exact LTS QA gate passes against MTKB 1.65:

```console
$ GROUP=QA julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Quality Assurance | 14 pass  4 broken  18 total
Testing Catalyst tests passed
```

Runic was applied idempotently to every changed hunk. `git diff --check` and `git diff --unified=0 | awk '/^\\+[^+]/{sub(/^\\+/, ""); print}' | typos -` passed. Documentation was not built because this PR changes only tests and no public API or docstring.

## Baseline CI evidence

The same `MiscSystemData` failure occurs on clean ModelingToolkit master in all three affected Catalyst groups:

- Misc: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364276/job/95331648803
- Modeling: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364276/job/95331648778
- Spatial: https://github.com/SciML/ModelingToolkit.jl/actions/runs/32009364276/job/95331648832

It also appears on both PR CI routes:

- https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030027883/job/95387733614
- https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030027883/job/95387733715
- https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030027883/job/95387733624
- https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030027921/job/95387733382
- https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030027921/job/95387733452
- https://github.com/SciML/ModelingToolkit.jl/actions/runs/32030027921/job/95387733393
