### PR TITLE
Use SymbolCache through its public owner

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "16.3.0"
+version = "16.3.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/spatial_reaction_systems/spatial_ODE_systems.jl
+++ b/src/spatial_reaction_systems/spatial_ODE_systems.jl
@@ -317,7 +317,7 @@ function build_odefunction(
 
     # Extracts the `Symbol` form for parameters (but not species). Creates and returns the `ODEFunction`.
     paramsyms = [MT.getname(p) for p in parameters(dsrs)]
-    sys = SciMLBase.SymbolCache([], paramsyms, [])
+    sys = SymbolicIndexingInterface.SymbolCache([], paramsyms, [])
     return ODEFunction(f; jac = J, jac_prototype, sys)
 end
 

--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -4,6 +4,7 @@
 using Catalyst, LinearAlgebra, JumpProcesses, OrdinaryDiffEq, StochasticDiffEq, Test
 const MT = ModelingToolkitBase
 using ModelingToolkitBase: Pre, unwrap
+using SymbolicIndexingInterface: SymbolCache
 
 # Sets stable rng number.
 using StableRNGs
@@ -506,7 +507,7 @@ let
     oprob1 = ODEProblem(osys, [u0map; pmap], tspan)
     sts = [B, D, E, C]
     syms = [:B, :D, :E, :C]
-    ofun = ODEFunction(f!; sys = MT.SymbolCache(syms))
+    ofun = ODEFunction(f!; sys = SymbolCache(syms))
     oprob2 = ODEProblem(ofun, u0, tspan, p)
     saveat = tspan[2] / 50
     abstol = 1.0e-10


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Access `SymbolCache` through its public owner, SymbolicIndexingInterface, in Catalyst's spatial ODE conversion and the existing ReactionSystem test. ModelingToolkitBase stopped accidentally re-exporting the name when it replaced blanket imports with explicit public-owner imports, exposing Catalyst's two stale non-owner accesses.

Catalyst is bumped from 16.3.0 to 16.3.1. This PR depends on the independently reviewable clean-master prerequisite fixes:

- https://github.com/SciML/Catalyst.jl/pull/1539
- https://github.com/SciML/Catalyst.jl/pull/1538

## Root cause

The exact dependency source boundary is https://github.com/SciML/ModelingToolkit.jl/commit/63f684c451d7eae081ebbf2a8eadd975f25de5fc. Its explicit-import cleanup correctly stopped exposing `SymbolCache` through ModelingToolkitBase; SymbolicIndexingInterface remains the documented public owner.

The broader migration is tracked at https://github.com/SciML/Catalyst.jl/issues/1541.

## Failing before

On clean current Catalyst master with the current dependency graph, the official Modeling group fails at the existing access:

```text
UndefVarError: `SymbolCache` not defined in `ModelingToolkitBase`
ReactionSystem Structure | 137 pass, 1 error
Testing Catalyst tests failed
```

This is the same failure reproduced by SciMLBase ReleaseTest:

https://github.com/SciML/SciMLBase.jl/actions/runs/32380648173/job/96462736354

## Passing after

With only this focused owner change, the identical Modeling run passes the former failure and reaches the separate `MiscSystemData` prerequisite at 332 passes; Spatial likewise advances to that independent prerequisite after 65 passes. That same-test progression discriminates this fix without weakening either test.

On the combined final tree with the two prerequisite drafts, the full owning gates pass:

```text
GROUP=QA
Quality Assurance | 13 pass, 7 existing broken, 20 total
Testing Catalyst tests passed

GROUP=Modeling
ReactionSystem Structure | 419 pass, 2 existing broken, 421 total
Testing Catalyst tests passed

GROUP=Spatial
Discrete Space Reaction Systems | 4812/4812
ODE Discrete Space Systems Simulations | 502/502
Jump Discrete Space Systems Simulations | 206/206
Discrete Space Simulation Structure Interfacing | 123/123
Testing Catalyst tests passed
```

Runic on the final tree, typos over the three-file diff, and `git diff --check` pass.

## Not verified

Julia LTS/prerelease, GPU paths, and the docs build were not run locally. No docs build is required because this adds no public API or docstring and only replaces non-owner qualification with an existing dependency's public API. Until both prerequisite drafts merge, this PR's standalone Modeling/Spatial/QA CI can still stop at those known independent failures.