### PR TITLE
Fix test imports after ModelingToolkitBase cleanup

### DIFF
--- a/test/reactionsystem_core/reactionsystem.jl
+++ b/test/reactionsystem_core/reactionsystem.jl
@@ -4,6 +4,7 @@
 using Catalyst, LinearAlgebra, JumpProcesses, OrdinaryDiffEq, StochasticDiffEq, Test
 const MT = ModelingToolkitBase
 using ModelingToolkitBase: Pre, unwrap
+using SymbolicIndexingInterface: SymbolCache
 
 abstract type TestSystemData end
 
@@ -508,7 +509,7 @@ let
     oprob1 = ODEProblem(osys, [u0map; pmap], tspan)
     sts = [B, D, E, C]
     syms = [:B, :D, :E, :C]
-    ofun = ODEFunction(f!; sys = MT.SymbolCache(syms))
+    ofun = ODEFunction(f!; sys = SymbolCache(syms))
     oprob2 = ODEProblem(ofun, u0, tspan, p)
     saveat = tspan[2] / 50
     abstol = 1.0e-10

--- a/test/upstream/mtk_structure_indexing.jl
+++ b/test/upstream/mtk_structure_indexing.jl
@@ -3,7 +3,7 @@
 # Fetch packages
 using Catalyst, JumpProcesses, NonlinearSolve, OrdinaryDiffEq, Plots, SteadyStateDiffEq, StochasticDiffEq, Test
 using SciMLBase
-import ModelingToolkitBase: getp, getu, setp, setu
+import SymbolicIndexingInterface: getp, getu, setp, setu
 
 # Sets rnd number.
 using StableRNGs


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

ModelingToolkitBase 1.66.0 replaced its blanket `using SymbolicIndexingInterface` with explicit owner imports. Catalyst's tests still obtained `SymbolCache`, `getp`, `getu`, `setp`, and `setu` through non-public ModelingToolkitBase bindings, so `SymbolCache` and `getp` became undefined.

Import those names directly from their public owning module, SymbolicIndexingInterface. This changes test imports only; Catalyst's public API and runtime code are unchanged.

## Root cause

The last green Symbolics downstream run used ModelingToolkitBase 1.65.0, while the first failing run used 1.67.0. Isolated version probes narrowed the boundary to 1.66.0:

```text
ModelingToolkitBase 1.65.0
SymbolCache defined=true
getp defined=true

ModelingToolkitBase 1.66.0
SymbolCache defined=false
getp defined=false
```

The introducing commit is [SciML/ModelingToolkit.jl@63f684c](https://github.com/SciML/ModelingToolkit.jl/commit/63f684c451d7eae081ebbf2a8eadd975f25de5fc), which intentionally imports dependency names through their owning modules. The change exposed Catalyst's reliance on accidental reexports; it is not a ModelingToolkitBase regression.

Relevant downstream runs:

- Last green Modeling job (ModelingToolkitBase 1.65.0): https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32024628034/job/95371325061
- Last green Simulation job (ModelingToolkitBase 1.65.0): https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32024628034/job/95371325120
- First observed failing Modeling job (ModelingToolkitBase 1.67.0): https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32557960200/job/96995043523
- Current failing Modeling job (ModelingToolkitBase 1.68.0): https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989739/job/97926455606
- Current failing Simulation job (ModelingToolkitBase 1.68.0): https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989739/job/97926455689

## Failing before

I developed a clean Symbolics upstream/master checkout at `043d7d2b480fc0c58a799f80bef114892be93cdf` into Catalyst, updated the environment, and ran:

```sh
GROUP=Modeling $HOME/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
GROUP=Simulation $HOME/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

The unmodified Catalyst master branch reproduced both CI failures:

```text
ReactionSystem Structure | 137  1  138
ERROR: UndefVarError: `SymbolCache` not defined in `ModelingToolkitBase`

MTK Structure Indexing | 614  60  24  698
ERROR: UndefVarError: `getp` not defined
```

## Passing after

The same commands with this commit applied crossed the exact failing tests and completed their full groups:

```text
ReactionSystem Structure | 419  2  421
Testing Catalyst tests passed

MTK Structure Indexing | 674  24  698
MTK Problem Inputs | 12249  1  12250
Testing Catalyst tests passed
```

Additional validation:

```text
GROUP=QA ... Pkg.test()
Quality Assurance | 13  7  20
Testing Catalyst tests passed

julia +1.12 --project=../formatter-env -m Runic --check --lines=4:7 --lines=508:512 test/reactionsystem_core/reactionsystem.jl
julia +1.12 --project=../formatter-env -m Runic --check --lines=3:7 test/upstream/mtk_structure_indexing.jl
# both exited 0

git diff | typos -
git diff --check
# both exited 0 with no output
```

Julia version:

```text
Julia Version 1.12.7
Commit 6d172b025e4 (2026-08-15 08:05 UTC)
OS: Linux (x86_64-linux-gnu)
CPU: AMD EPYC 7502 32-Core Processor
LLVM: libLLVM-18.1.7 (ORCJIT, znver2)
Threads: 1 default, 1 interactive, 1 GC
```

I did not run `GROUP=Everything`, GPU tests, or docs. This is a test-only import correction with no documentation or public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
