### PR TITLE
Qualify Optimisers ADAM in oscillation docs

### DIFF
--- a/docs/src/inverse_problems/examples/ode_fitting_oscillation.md
+++ b/docs/src/inverse_problems/examples/ode_fitting_oscillation.md
@@ -86,7 +86,7 @@ function optimize_p(pinit, tend,
     # optimize for the parameters that minimize the loss
     optf = OptimizationFunction(loss, AutoZygote())
     optprob = OptimizationProblem(optf, pinit, (set_p, prob, sample_times, sample_vals))
-    sol = solve(optprob, ADAM(0.1); maxiters = 100)
+    sol = solve(optprob, Optimisers.ADAM(0.1); maxiters = 100)
 
     # return the parameters we found
     return sol.u


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Qualify `ADAM` through its public owner, `Optimisers`, in the oscillation parameter-fitting example. `OptimizationOptimisers` 0.3.22 stopped re-exporting Optimisers' symbols, so the formerly bare `ADAM` name no longer resolves during the docs build.

This is a one-line documentation example fix with no dependency or public API change.

## Regression boundary

The boundary is `OptimizationOptimisers` 0.3.21 to 0.3.22:

- With 0.3.21, `using OptimizationOptimisers; ADAM(0.1)` constructs the optimizer.
- With 0.3.22, the same command raises `UndefVarError: ADAM not defined in Main` and identifies `Optimisers` as the owner.

The introducing commit is https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af, which replaced `@reexport using Optimisers` with `using Optimisers; export Optimisers`. The failing Catalyst docs environment resolved `OptimizationOptimisers` 0.3.22 and `Optimisers` 0.4.9.

## Failing before

On pristine Catalyst master (`30d95daca4f5fc619df7d2d6c23ab9a1e1339d32`), I ran:

```sh
GKSwstype=100 xvfb-run -a julia --project=docs --color=no --code-coverage=user docs/make.jl
```

After dependency instantiation, the build exited 1:

```text
Error: failed to run `@example` block in docs/src/inverse_problems/examples/ode_fitting_oscillation.md:98-100
UndefVarError: `ADAM` not defined in `Main.__atexample__named__pe_osc_example`
ERROR: LoadError: `makedocs` encountered an error [:example_block] -- terminating build before rendering.
```

## Passing after

The same full docs command completed with exit 0 and reached HTML rendering:

```text
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="16.3.0"` for inventory from ../Project.toml
```

I also extracted and executed every named example block from the changed page in one Julia process:

```sh
awk '/^```@example pe_osc_example/{inside=1; next} /^```/{if(inside){inside=0; print ""}; next} inside{print}' docs/src/inverse_problems/examples/ode_fitting_oscillation.md | xvfb-run -a julia --project=docs -
```

This completed with exit 0. The owner API was checked directly: `Base.isexported(Optimisers, :ADAM)` returned `true`, and `Optimisers.ADAM(0.1)` constructed successfully.

Additional local checks:

```text
GROUP=QA julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
Quality Assurance | 13 pass, 7 broken, 20 total, 9m12.0s
Testing Catalyst tests passed

julia --startup-file=no --project=../formatter-env -m Runic --check docs/src/inverse_problems/examples/ode_fitting_oscillation.md
exit 0

typos --format brief docs/src/inverse_problems/examples/ode_fitting_oscillation.md
exit 0

git diff --check
exit 0
```

GPU and downstream jobs were not run locally; this docs-only change does not exercise those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
