### PR TITLE
Fix SpellCheck: Containes/paraemter and allow oint/Lamba

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,8 @@
 # Catalyst specific
 systemes = "systemes"
 Hass = "Hass"
+oint = "oint"
+Lamba = "Lamba"
 
 # Julia-specific functions
 indexin = "indexin"

--- a/docs/src/model_creation/dsl_advanced.md
+++ b/docs/src/model_creation/dsl_advanced.md
@@ -167,7 +167,7 @@ sol = solve(oprob, Tsit5())
 plot(sol)
 ```
 
-When setting parametric default values these are called [*bindings*](https://docs.sciml.ai/ModelingToolkit/dev/tutorials/initialization/#bindings_and_ics). Bindings act similar to defaults, however, they cannot be override. E.g. in the example above, `X`'s initial condition must be specified through the `X₀` paraemter, and can no longer be provided through the `u0` vector.
+When setting parametric default values these are called [*bindings*](https://docs.sciml.ai/ModelingToolkit/dev/tutorials/initialization/#bindings_and_ics). Bindings act similar to defaults, however, they cannot be override. E.g. in the example above, `X`'s initial condition must be specified through the `X₀` parameter, and can no longer be provided through the `u0` vector.
 
 ### [Designating metadata for species and parameters](@id dsl_advanced_options_species_and_parameters_metadata)
 Catalyst permits the user to define *metadata* for species and parameters. This permits the user to assign additional information to these, which can be used for a variety of purposes. Some Catalyst features depend on using metadata (with each such case describing specifically how this is done). Here we will introduce how to set metadata, and describe some common metadata types. 

--- a/src/Catalyst.jl
+++ b/src/Catalyst.jl
@@ -197,7 +197,7 @@ export iscomplexbalanced, isdetailedbalanced, robustspecies
 # Documented cycle/flux basis helper (public, not exported).
 @public cycles
 
-# Containes the `nullspace` function required for conservation law elimination.
+# Contains the `nullspace` function required for conservation law elimination.
 include("mtk_nullspace_function.jl")
 
 # registers CRN specific functions using Symbolics.jl


### PR DESCRIPTION
SpellCheck-only. `typos` 1.49 (the reusable `spellcheck.yml` pin) fails on master.

## What changed

- Comment typo: `Containes` → `Contains` in `src/Catalyst.jl`
- Docs typo: `paraemter` → `parameter` in `docs/src/model_creation/dsl_advanced.md`
- `.typos.toml`: `oint` (ODE-integrator identifier `spat_setp!(oint::...)`) and `Lamba` (StochasticDiffEq `LambaEM`)

No runtime change. `oint` / `Lamba` are identifiers and algorithm names, not misspellings.

## Verification

`typos` 1.49.0 on the default-branch tree: 46 findings before (41 `oint`, 3 `Lamba`, 1 `Containes`, 1 `paraemter`); exit 0 after.

Did not wait for GitHub Actions.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)