### PR TITLE
Adopt grouped-tests and add 32-bit Modeling CI lane

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,31 +11,12 @@ on:
       - 'docs/**'
 
 concurrency:
-  # Skip intermediate builds: always, but for the master branch.
-  # Cancel intermediate builds: always, but for the master branch.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - Modeling
-          - Simulation
-          - Hybrid
-          - Misc
-          - Spatial
-          - QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
       coverage: false
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,23 @@
+[Modeling]
+versions = ["lts", "1", "pre"]
+
+["Modeling 32-bit"]
+group = "Modeling"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
+[Simulation]
+versions = ["lts", "1", "pre"]
+
+[Hybrid]
+versions = ["lts", "1", "pre"]
+
+[Misc]
+versions = ["lts", "1", "pre"]
+
+[Spatial]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1", "pre"]


### PR DESCRIPTION
## Summary
- Switch Tests to grouped-tests.yml@v1 with test_groups.toml (same groups/versions, coverage still false).
- Add Modeling 32-bit alias (arch=x86) for 32-bit coverage.

## Test plan
- [ ] Existing group×version jobs still run
- [ ] New Modeling x86 job appears
