### PR TITLE
Release Catalyst 16.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "16.4.0"
+version = "16.4.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
Bumps `Catalyst` 16.4.0 -> 16.4.1 (patch).

Source files changed since 16.4.0:
- `ext/CatalystBifurcationKitExtension.jl`
- `ext/CatalystCairoMakieExtension.jl`
- `ext/CatalystGraphMakieExtension.jl`
- `ext/CatalystGraphMakieExtension/graph_makie_extension_spatial_modelling.jl`
- `ext/CatalystGraphMakieExtension/rn_graph_plot.jl`
- `ext/CatalystHomotopyContinuationExtension.jl`
- `ext/CatalystStructuralIdentifiabilityExtension.jl`

Commits:
- Bump the all-julia-packages group across 1 directory with 4 updates (#1531)
- Update Turing requirement from 0.43.5, 0.45, 0.46 to 0.43.5, 0.45, 0.46, 0.47 (#1547)
- Update DataInterpolations requirement from 7.2, 8, 9.4 to 7.2, 8, 9.4, 10.1 (#1548)
- Adopt grouped-tests and add 32-bit Modeling CI lane (#1550)
- Make the QA group scan the package extensions (#1525)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
