### PR TITLE
Make Reaction type assertions wordsize-agnostic (fixes x86 CI)

### DIFF
--- a/test/reactionsystem_core/reaction.jl
+++ b/test/reactionsystem_core/reaction.jl
@@ -30,10 +30,10 @@ let
         rx6 = Reaction(rate, [X], [x], [n1], [1])
 
         # Check `Reaction` types.
-        @test rx1 isa Reaction{SymbolicT,Int64}
+        @test rx1 isa Reaction{SymbolicT,Int}
         @test rx2 isa Reaction{SymbolicT,Float64}
         @test rx3 isa Reaction{SymbolicT,Any}
-        @test rx4 isa Reaction{SymbolicT,Rational{Int64}}
+        @test rx4 isa Reaction{SymbolicT,Rational{Int}}
         @test rx5 isa Reaction{SymbolicT,Any}
         @test rx6 isa Reaction{SymbolicT,Any}
 


### PR DESCRIPTION
## Summary

The `Modeling` test group's `Reaction Structure` testset asserts `rx1 isa Reaction{SymbolicT,Int64}` and `rx4 isa Reaction{SymbolicT,Rational{Int64}}`. On 32-bit Julia (`ubuntu-latest, x86`), the three-argument `Reaction` constructor builds stoichiometries with `ones(Int, ...)`, and literals like `2//3` produce `Rational{Int32}`, so the actual types are `Reaction{SymbolicT,Int32}` / `Reaction{SymbolicT,Rational{Int32}}` and the assertions fail (10 failures on master).

The fix asserts `Int`/`Rational{Int}`, which is correct on both wordsizes.

#### Test plan
- [x] Verified the failure mode on Julia 1.13.0 x86: `rx1` is `Reaction{SymbolicT,Int32}` (would fail the old assertion)
- [x] Verified `@test rx1 isa Reaction{SymbolicT,Int}` and `@test rx4 isa Reaction{SymbolicT,Rational{Int}}` pass on Julia 1.13.0 x86 for all rate types in the loop
- [x] On 64-bit, `Int === Int64` so the assertions are unchanged

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL