### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEq,JumpProcesses,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,55 @@
+using Catalyst, BenchmarkTools
+using OrdinaryDiffEq, JumpProcesses, StableRNGs
+
+const SUITE = BenchmarkGroup()
+
+# SIR reaction network
+rn = @reaction_network begin
+    k1, S + I --> 2I
+    k2, I --> R
+end
+
+u0 = [:S => 999, :I => 1, :R => 0]
+tspan = (0.0, 250.0)
+p = [:k1 => 1.0e-4, :k2 => 0.01]
+
+# =============================================================================
+# Model construction
+# =============================================================================
+
+SUITE["model"] = BenchmarkGroup()
+
+SUITE["model"]["reaction_network"] = @benchmarkable @reaction_network begin
+    k1, S + I --> 2I
+    k2, I --> R
+end
+SUITE["model"]["complete"] = @benchmarkable Catalyst.complete($rn)
+
+rn_complete = Catalyst.complete(rn)
+
+# =============================================================================
+# Problem construction
+# =============================================================================
+
+SUITE["problem"] = BenchmarkGroup()
+
+SUITE["problem"]["odeproblem"] = @benchmarkable ODEProblem(
+    $rn_complete, $u0, $tspan, $p
+)
+SUITE["problem"]["jumpproblem"] = @benchmarkable JumpProblem(
+    $rn_complete, $u0, $tspan, $p; aggregator = Direct()
+)
+
+# =============================================================================
+# Solves
+# =============================================================================
+
+SUITE["solve"] = BenchmarkGroup()
+
+odeprob = ODEProblem(rn_complete, u0, tspan, p)
+jprob = JumpProblem(
+    rn_complete, u0, tspan, p; aggregator = Direct(), rng = StableRNG(12345)
+)
+
+SUITE["solve"]["ode_tsit5"] = @benchmarkable solve($odeprob, Tsit5())
+SUITE["solve"]["jump_direct"] = @benchmarkable solve($jprob, SSAStepper())


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~56s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~56s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md