### PR TITLE
Fix SI extension typing, add mtkcompile support for coupled CRN/DAEs, and harden tests

### DIFF
--- a/docs/src/inverse_problems/structural_identifiability.md
+++ b/docs/src/inverse_problems/structural_identifiability.md
@@ -160,6 +160,23 @@ end
 ```
 contain [conservation laws](@ref conservation_laws) (in this case $Γ = X1 + X2$, where $Γ = X1(0) + X2(0)$ is a constant). Because the presence of such conservation laws makes structural identifiability analysis prohibitively computationally expensive (for all but the simplest of cases), these are automatically eliminated by Catalyst. This is handled internally, and should not be noticeable to the user. The exception is the `make_si_ode` function. For each conservation law, its output will have one ODE removed, and instead have a conservation parameter (of the form `Γ[i]`) added to its equations. This feature can be disabled through the `remove_conserved = false` option.
 
+## [Systems with algebraic equations](@id structural_identifiability_daes)
+`ReactionSystem`s [coupled with algebraic equations](@ref coupled_models_algeqs) must be structurally simplified (using `mtkcompile`) before StructuralIdentifiability can be applied to them. This is done by setting the `mtkcompile = true` option (analogously to how `ODEProblem`s are created from such models):
+```@example structural_identifiability_dae
+using Catalyst, Logging, StructuralIdentifiability # hide
+rs = @reaction_network begin
+    @parameters k c1 c2
+    @variables C(t)
+    @equations begin
+        D(V) ~ k*X - V
+        C ~ (c1 + c2) * X/V
+    end
+    (p/V,d/V), 0 <--> X
+end
+assess_identifiability(rs; measured_quantities = [:X, :V, :C], mtkcompile = true, loglevel = Logging.Error)
+```
+Variables that are eliminated by `mtkcompile` (here `C`, which is defined by an algebraic equation) can still be used in the `measured_quantities` and `funcs_to_check` options, and are still included in the output.
+
 ## [Systems with exponent parameters](@id structural_identifiability_exp_params)
 Structural identifiability cannot currently be applied to systems with parameters (or species) in exponents. E.g. this
 ```julia

--- a/ext/CatalystStructuralIdentifiabilityExtension.jl
+++ b/ext/CatalystStructuralIdentifiabilityExtension.jl
@@ -3,8 +3,8 @@ module CatalystStructuralIdentifiabilityExtension
 # Fetch packages.
 using Catalyst: Catalyst, ReactionSystem, conservationlaw_constants, conservedequations,
     ode_model
-using ModelingToolkitBase: ModelingToolkitBase, System, complete, flatten, parameters,
-    unknowns
+using ModelingToolkitBase: ModelingToolkitBase, System, complete, flatten, observed,
+    parameters, unknowns
 using SymbolicUtils: substitute
 using Symbolics: Equation, @variables
 import DataStructures.OrderedDict

--- a/ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl
+++ b/ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl
@@ -2,7 +2,7 @@
 
 # For a reaction system, list of measured quantities and known parameters, generate a StructuralIdentifiability compatible ODE.
 """
-make_si_ode(rs::ReactionSystem; measured_quantities=observed(rs), known_p = [], ignore_no_measured_warn=false)
+make_si_ode(rs::ReactionSystem; measured_quantities=observed(rs), known_p = [], ignore_no_measured_warn=false, remove_conserved = true, mtkcompile = false)
 
 Creates a reaction rate equation ODE system of the form used within the StructuralIdentifiability.jl package. The output system is compatible with all StructuralIdentifiability functions.
 
@@ -12,6 +12,7 @@ Arguments:
 - `known_p = []`: List of parameters for which their values are assumed to be known.
 - `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
 - `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
+- `mtkcompile = false`: Whether to apply `ModelingToolkitBase.mtkcompile` to the generated ODE `System`. This is required for `ReactionSystem`s coupled with algebraic equations. Variables eliminated by `mtkcompile` (e.g. those defined by algebraic equations) may still be used in `measured_quantities` and `funcs_to_check`.
 
 Example:
 ```julia
@@ -27,10 +28,10 @@ Notes:
 - `measured_quantities` and `known_p` input may also be symbolic (e.g. measured_quantities = [rs.X])
 """
 function Catalyst.make_si_ode(rs::ReactionSystem; measured_quantities = [], known_p = [],
-        ignore_no_measured_warn = false, remove_conserved = true)
+        ignore_no_measured_warn = false, remove_conserved = true, mtkcompile::Bool = false)
     # Creates a MTK ODE System, and a list of measured quantities (there are equations).
     # Gives these to SI to create an SI ode model of its preferred form.
-    osys, conseqs, _, _ = make_osys(rs; remove_conserved)
+    osys, conseqs, _, _ = make_osys(rs; remove_conserved, mtkcompile)
     measured_quantities = make_measured_quantities(rs, measured_quantities, known_p,
         conseqs; ignore_no_measured_warn)
     return SI.mtk_to_si(osys, measured_quantities)[1]
@@ -39,7 +40,7 @@ end
 ### Structural Identifiability Wrappers ###
 
 """
-assess_local_identifiability(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, kwargs...)
+assess_local_identifiability(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, mtkcompile = false, kwargs...)
 
 Applies StructuralIdentifiability.jl's `assess_local_identifiability` function to the reaction rate equation ODE model for the given Catalyst `ReactionSystem`. Automatically converts the `ReactionSystem` to an appropriate ODE `System` and computes structural identifiability,
 
@@ -49,6 +50,7 @@ Arguments:
 - `known_p = []`: List of parameters which values are known.
 - `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
 - `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
+- `mtkcompile = false`: Whether to apply `ModelingToolkitBase.mtkcompile` to the generated ODE `System`. This is required for `ReactionSystem`s coupled with algebraic equations. Variables eliminated by `mtkcompile` (e.g. those defined by algebraic equations) may still be used in `measured_quantities` and `funcs_to_check`.
 
 Example:
 ```julia
@@ -65,21 +67,22 @@ Notes:
 """
 function SI.assess_local_identifiability(rs::ReactionSystem, args...;
         measured_quantities = [], known_p = [], funcs_to_check = Vector(),
-        remove_conserved = true, ignore_no_measured_warn = false, kwargs...)
+        remove_conserved = true, ignore_no_measured_warn = false,
+        mtkcompile::Bool = false, kwargs...)
     # Creates an ODE System, list of measured quantities, and functions to check, of SI's preferred form.
-    osys, conseqs, consconsts, vars = make_osys(rs; remove_conserved)
+    osys, conseqs, consconsts, vars = make_osys(rs; remove_conserved, mtkcompile)
     measured_quantities = make_measured_quantities(rs, measured_quantities, known_p,
         conseqs; ignore_no_measured_warn)
-    funcs_to_check = make_ftc(funcs_to_check, conseqs, vars)
+    funcs_to_check, si_funcs_to_check = make_ftc(funcs_to_check, conseqs, vars)
 
     # Computes identifiability and converts it to a easy to read form.
     out = SI.assess_local_identifiability(osys, args...; measured_quantities,
-        funcs_to_check, kwargs...)
-    return make_output(out, funcs_to_check, consconsts)
+        funcs_to_check = si_funcs_to_check, kwargs...)
+    return make_output(out, funcs_to_check, si_funcs_to_check, consconsts)
 end
 
 """
-assess_identifiability(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, kwargs...)
+assess_identifiability(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, mtkcompile = false, kwargs...)
 
 Applies StructuralIdentifiability.jl's `assess_identifiability` function to a Catalyst `ReactionSystem`. Internally it is converted to an ODE `System`, for which structural identifiability is computed.
 
@@ -89,6 +92,7 @@ Arguments:
 - `known_p = []`: List of parameters which values are known.
 - `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
 - `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
+- `mtkcompile = false`: Whether to apply `ModelingToolkitBase.mtkcompile` to the generated ODE `System`. This is required for `ReactionSystem`s coupled with algebraic equations. Variables eliminated by `mtkcompile` (e.g. those defined by algebraic equations) may still be used in `measured_quantities` and `funcs_to_check`.
 
 Example:
 ```julia
@@ -105,26 +109,24 @@ Notes:
 """
 function SI.assess_identifiability(rs::ReactionSystem, args...;
         measured_quantities = [], known_p = [], funcs_to_check = Vector(),
-        remove_conserved = true, ignore_no_measured_warn = false, kwargs...)
+        remove_conserved = true, ignore_no_measured_warn = false,
+        mtkcompile::Bool = false, kwargs...)
     # Creates an ODE System, list of measured quantities, and functions to check, of SI's preferred form.
-    osys, conseqs, consconsts, vars = make_osys(rs; remove_conserved)
+    osys, conseqs, consconsts, vars = make_osys(rs; remove_conserved, mtkcompile)
     measured_quantities = make_measured_quantities(rs, measured_quantities, known_p,
         conseqs; ignore_no_measured_warn)
-    funcs_to_check = make_ftc(funcs_to_check, conseqs, vars)
+    funcs_to_check, si_funcs_to_check = make_ftc(funcs_to_check, conseqs, vars)
 
-    # Due to MTK changes, an yet to be implemented update is required to handle coupled algebraic equations (https://github.com/SciML/Catalyst.jl/issues/1485).
-    ModelingToolkitBase.has_alg_equations(osys) && error("Structural identifiability analysis is currently no supported for `ReactionSystem`s coupled with algebraic equations. If this feature is useful to you, please raise an issue at https://github.com/SciML/Catalyst.jl/issues.")
-    
     # Computes identifiability and converts it to a easy to read form.
     # The `::System` designation fixes: https://github.com/SciML/StructuralIdentifiability.jl/issues/360,
     # however, the exact mechanisms of this is still not fully clear.
     out = SI.assess_identifiability(osys::System, args...; measured_quantities,
-        funcs_to_check, kwargs...)
-    return make_output(out, funcs_to_check, consconsts)
+        funcs_to_check = si_funcs_to_check, kwargs...)
+    return make_output(out, funcs_to_check, si_funcs_to_check, consconsts)
 end
 
 """
-find_identifiable_functions(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, kwargs...)
+find_identifiable_functions(rs::ReactionSystem, args...; measured_quantities = [], known_p = [], remove_conserved = true, ignore_no_measured_warn=false, mtkcompile = false, kwargs...)
 
 Applies StructuralIdentifiability.jl's `find_identifiable_functions` function to a Catalyst `ReactionSystem`. Internally it is converted to an ODE `System`, for which structurally identifiable functions are computed.
 
@@ -134,6 +136,7 @@ Arguments:
 - `known_p = []`: List of parameters which values are known.
 - `ignore_no_measured_warn = false`: If set to `true`, no warning is provided when the `measured_quantities` vector is empty.
 - `remove_conserved = true`: Whether to eliminate conservation laws when computing the ode (this can reduce runtime of identifiability analysis significantly).
+- `mtkcompile = false`: Whether to apply `ModelingToolkitBase.mtkcompile` to the generated ODE `System`. This is required for `ReactionSystem`s coupled with algebraic equations. Variables eliminated by `mtkcompile` (e.g. those defined by algebraic equations) may still be used in `measured_quantities` and `funcs_to_check`.
 
 Example:
 ```julia
@@ -150,9 +153,9 @@ Notes:
 """
 function SI.find_identifiable_functions(rs::ReactionSystem, args...;
         measured_quantities = [], known_p = [], remove_conserved = true,
-        ignore_no_measured_warn = false, kwargs...)
+        ignore_no_measured_warn = false, mtkcompile::Bool = false, kwargs...)
     # Creates an ODE System, and list of measured quantities, of SI's preferred form.
-    osys, conseqs, consconsts, _ = make_osys(rs; remove_conserved)
+    osys, conseqs, consconsts, _ = make_osys(rs; remove_conserved, mtkcompile)
     measured_quantities = make_measured_quantities(rs, measured_quantities, known_p,
         conseqs; ignore_no_measured_warn)
 
@@ -165,29 +168,55 @@ end
 
 # From a reaction system, creates the corresponding MTK-style ODE System for SI application
 # Also compute the, later needed, conservation law equations and list of system symbols (unknowns and parameters).
-function make_osys(rs::ReactionSystem; remove_conserved = true)
+function make_osys(rs::ReactionSystem; remove_conserved = true, mtkcompile::Bool = false)
     # Creates the ODE System corresponding to the ReactionSystem (expanding functions and flattening it).
     # Creates a list of the systems all symbols (unknowns and parameters).
     if !ModelingToolkitBase.iscomplete(rs)
         error("Identifiability should only be computed for complete systems. A ReactionSystem can be marked as complete using the `complete` function.")
     end
     rs = complete(Catalyst.expand_registered_functions(flatten(rs)))
-    osys = complete(ode_model(rs; remove_conserved))
+    osys = ode_model(rs; remove_conserved)
+    if mtkcompile
+        osys = ModelingToolkitBase.mtkcompile(osys)
+    elseif ModelingToolkitBase.has_alg_equations(rs)
+        error("The input ReactionSystem has algebraic equations. This requires setting `mtkcompile = true`.")
+    else
+        osys = complete(osys)
+    end
     vars = [unknowns(rs); parameters(rs)]
 
     # Computes equations for system conservation laws.
-    # If there are no conserved equations, the `conseqs` variable must still have the `Vector{Pair{Any, Any}}` type.
+    # `conseqs` and `consconsts` must be `Vector{Pair{Any, Any}}`s also when empty.
     if remove_conserved
-        conseqs = [ceq.lhs => ceq.rhs for ceq in conservedequations(rs)]
-        consconsts = [cconst.lhs => cconst.rhs for cconst in conservationlaw_constants(rs)]
-        isempty(conseqs) && (conseqs = Vector{Pair{Any, Any}}[])
-        isempty(consconsts) && (consconsts = Vector{Pair{Any, Any}}[])
+        conseqs = Pair{Any, Any}[ceq.lhs => ceq.rhs for ceq in conservedequations(rs)]
+        consconsts = Pair{Any, Any}[cconst.lhs => cconst.rhs
+                                    for cconst in conservationlaw_constants(rs)]
     else
-        conseqs = Vector{Pair{Any, Any}}[]
-        consconsts = Vector{Pair{Any, Any}}[]
+        conseqs = Pair{Any, Any}[]
+        consconsts = Pair{Any, Any}[]
     end
 
+    # Variables eliminated by `mtkcompile` (e.g. algebraic variables) are no longer unknowns of
+    # `osys`, so any reference to them in measured quantities or functions to check must be
+    # replaced by the corresponding observed expression.
+    mtkcompile && append!(conseqs, observed_subs(osys, conseqs))
+
     return osys, conseqs, consconsts, vars
+end
+
+# Creates substitution rules for the observed variables of `osys` (skipping those already
+# covered by `conseqs`). Observed equations may depend on each other, so rules are expanded
+# until they only contain unknowns and parameters of `osys`.
+function observed_subs(osys, conseqs)
+    obs = Pair{Any, Any}[eq.lhs => eq.rhs
+                         for eq in observed(osys)
+                         if !any(ceq -> isequal(ceq[1], eq.lhs), conseqs)]
+    for _ in 1:length(obs)
+        expanded = Pair{Any, Any}[lhs => substitute(rhs, obs) for (lhs, rhs) in obs]
+        all(isequal(e[2], o[2]) for (e, o) in zip(expanded, obs)) && break
+        obs = expanded
+    end
+    return obs
 end
 
 # Creates a list of measured quantities of a form that SI can read.
@@ -214,22 +243,25 @@ end
 
 # Creates the functions that we wish to check for identifiability.
 # If no `funcs_to_check` are given, defaults to checking identifiability for all unknowns and parameters.
-# Also, for conserved equations, replaces these in (creating a system without conserved quantities).
+# Returns both the functions as requested by the user and the versions passed to SI, in which
+# conserved quantities (and other eliminated variables) have been substituted away.
 # E.g. for `X1 <--> X2`, replaces `X2` with `Γ[1] - X2`.
 # Removing conserved quantities makes SI's algorithms much more performant.
 function make_ftc(funcs_to_check, conseqs, vars)
     isempty(funcs_to_check) && (funcs_to_check = vars)
-    return vector_subs(funcs_to_check, conseqs)
+    return funcs_to_check, vector_subs(funcs_to_check, conseqs)
 end
 
 # Processes the outputs to a better form.
-# Replaces conservation law equations back in the output (so that e.g. Γ are not displayed).
-# Sorts the output according to their input order (defaults to the `[unknowns; parameters]` order).
-function make_output(out, funcs_to_check, consconsts)
-    funcs_to_check = vector_subs(funcs_to_check, consconsts)
-    out = OrderedDict(zip(vector_subs(keys(out), consconsts), values(out)))
-    sortdict = Dict(ftc => i for (i, ftc) in enumerate(funcs_to_check))
-    return sort!(out; by = x -> sortdict[x])
+# SI keys its output by the functions it was given (`si_funcs_to_check`). These are mapped back
+# to the user-requested functions (`funcs_to_check`), so that e.g. Γ or eliminated variables
+# are not displayed, and sorted according to their input order.
+function make_output(out, funcs_to_check, si_funcs_to_check, consconsts)
+    si_keys = vector_subs(si_funcs_to_check, consconsts)
+    out_keys = vector_subs(keys(out), consconsts)
+    key_to_idx = Dict(k => i for (i, k) in enumerate(si_keys))
+    return OrderedDict(funcs_to_check[key_to_idx[k]] => v
+    for (k, v) in zip(out_keys, values(out)))
 end
 
 # For a vector of expressions and a conservation law, substitutes the law into every equation.

--- a/test/extensions/structural_identifiability.jl
+++ b/test/extensions/structural_identifiability.jl
@@ -15,7 +15,7 @@ function sym_dict(dict_in)
         sym_key = Symbol(key)
         sym_key = Symbol(replace(String(sym_key), "(t)" => ""))
         dict_out[sym_key] = dict_in[key]
-    end    
+    end
     return dict_out
 end
 
@@ -24,7 +24,7 @@ end
 
 # Tests for Goodwin model (model with both global, local, and non identifiable components).
 # Tests for system using Catalyst function (in this case, Michaelis-Menten function)
-let 
+@testset "Goodwin oscillator (Michaelis-Menten)" begin
     # Identifiability analysis for Catalyst model.
     goodwind_oscillator_catalyst = @reaction_network begin
         (mmr(P,pₘ,1), dₘ), 0 <--> M
@@ -61,13 +61,13 @@ let
     @test isequal(collect(keys(gi_1)), [unknowns(goodwind_oscillator_catalyst); parameters(goodwind_oscillator_catalyst)])
     @test isequal(collect(values(gi_1)), [:globally, :nonidentifiable, :globally, :globally, :globally, :nonidentifiable, :locally, :nonidentifiable, :locally])
     @test isequal(collect(keys(li_1)), [unknowns(goodwind_oscillator_catalyst); parameters(goodwind_oscillator_catalyst)])
-    @test isequal(collect(values(li_1)), [1, 0, 1, 1, 1, 0, 1, 0, 1]) 
+    @test isequal(collect(values(li_1)), [1, 0, 1, 1, 1, 0, 1, 0, 1])
 end
 
 # Tests on a made-up reaction network with mix of identifiable and non-identifiable components.
 # Tests for symbolics input.
 # Tests using known_p argument.
-let 
+@testset "Chain network with known_p and symbolic measured quantities" begin
     # Identifiability analysis for Catalyst model.
     rs_catalyst = @reaction_network begin
         (p1, d), 0 <--> X1
@@ -110,14 +110,14 @@ let
     @test isequal(collect(keys(gi_1)),[unknowns(rs_catalyst); parameters(rs_catalyst)])
     @test isequal(collect(values(gi_1)),[:nonidentifiable, :globally, :globally, :nonidentifiable, :nonidentifiable, :nonidentifiable, :nonidentifiable, :globally, :globally, :globally])
     @test isequal(collect(keys(li_1)),[unknowns(rs_catalyst); parameters(rs_catalyst)])
-    @test isequal(collect(values(li_1)),[0, 1, 1, 0, 0, 0, 0, 1, 1, 1])  
+    @test isequal(collect(values(li_1)),[0, 1, 1, 0, 0, 0, 0, 1, 1, 1])
 end
 
 # Tests on a made-up reaction network with mix of identifiable and non-identifiable components.
 # Tests for system with conserved quantity.
 # Tests for symbolics known_p
 # Tests using an equation for measured quantity.
-let 
+@testset "Conserved binding pair (composite measured quantity)" begin
     # Identifiability analysis for Catalyst model.
     rs_catalyst = @reaction_network begin
         p, 0 --> X1
@@ -170,7 +170,7 @@ let
 end
 
 # Tests that various inputs types work.
-let 
+@testset "Input type variations (Symbol vs symbolic)" begin
     goodwind_oscillator_catalyst = @reaction_network begin
         (mmr(P,pₘ,1), dₘ), 0 <--> M
         (pₑ*M,dₑ), 0 <--> E
@@ -205,7 +205,7 @@ let
 end
 
 # Tests for hierarchical model with conservation laws at both top and internal levels.
-let
+@testset "Hierarchical system with nested conservation laws" begin
     # Identifiability analysis for Catalyst model.
     rs1 = @network_component rs1 begin
         (k1, k2), X1 <--> X2
@@ -259,7 +259,7 @@ end
 
 # Tests directly on reaction systems with known identifiability structures.
 # Test provided by Alexander Demin.
-let
+@testset "Direct tests on small networks" begin
     rs = @reaction_network begin
         k1, x1 --> x2
     end
@@ -316,8 +316,9 @@ end
 ### Other Tests ###
 
 # Checks that identifiability can be assessed for coupled CRN/DAE systems.
+# DAE systems (with algebraic equations) require `mtkcompile = true`.
 # `remove_conserved = false` is used to remove info print statement from log.
-let
+@testset "Coupled CRN/DAE" begin
     rs = @reaction_network begin
         @parameters k c1 c2
         @variables C(t)
@@ -327,42 +328,115 @@ let
         end
         (p/V,d/V), 0 <--> X
     end
-    @unpack p, d, k, c1, c2 = rs
-    
+    @unpack C, p, d, k, c1, c2 = rs
+    remove_conserved = false
+    mtkcompile = true
+
+    # Without `mtkcompile = true` an informative error is thrown.
+    @test_throws ErrorException assess_identifiability(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved)
+    @test_throws ErrorException assess_local_identifiability(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved)
+    @test_throws ErrorException find_identifiable_functions(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved)
+
     # Tests identifiability assessment when all unknowns are measured.
-    # Note: Due to MTK changes, an yet to be implemented update is required to handle coupled algebraic equations. https://github.com/SciML/Catalyst.jl/issues/1485
-    @test_broken begin gi_1 = assess_identifiability(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved)
-        li_1 = assess_local_identifiability(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved)
-        ifs_1 = find_identifiable_functions(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved)
-        @test sym_dict(gi_1) == Dict([:X => :globally, :C => :globally, :V => :globally, :k => :globally, 
-                        :c1 => :nonidentifiable, :c2 => :nonidentifiable, :p => :globally, :d => :globally])
-        @test sym_dict(li_1) == Dict([:X => 1, :C => 1, :V => 1, :k => 1, :c1 => 0, :c2 => 0, :p => 1, :d => 1])
-        @test issetequal(ifs_1, [d, p, k, c1 + c2])
-    end
-    
-    # Tests identifiability assessment when only variables are measured. 
+    # `C` is eliminated by `mtkcompile` but should still be usable as a measured quantity and appear in the output.
+    gi_1 = assess_identifiability(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved, mtkcompile)
+    li_1 = assess_local_identifiability(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved, mtkcompile)
+    ifs_1 = find_identifiable_functions(rs; measured_quantities = [:X, :V, :C], loglevel, remove_conserved, mtkcompile)
+    @test isequal(collect(keys(gi_1)), [unknowns(rs); parameters(rs)])
+    @test isequal(collect(keys(li_1)), [unknowns(rs); parameters(rs)])
+    @test sym_dict(gi_1) == Dict([:X => :globally, :C => :globally, :V => :globally, :k => :globally,
+                      :c1 => :nonidentifiable, :c2 => :nonidentifiable, :p => :globally, :d => :globally])
+    @test sym_dict(li_1) == Dict([:X => 1, :C => 1, :V => 1, :k => 1, :c1 => 0, :c2 => 0, :p => 1, :d => 1])
+    @test issetequal(ifs_1, [d, p, k, c1 + c2])
+
+    # Tests identifiability assessment when only variables are measured.
     # Checks that a parameter in an equation can be set as known.
-    # Note: Due to MTK changes, an yet to be implemented update is required to handle coupled algebraic equations. https://github.com/SciML/Catalyst.jl/issues/1485
-    @test_broken begin gi_2 = assess_identifiability(rs; measured_quantities = [:V, :C], known_p = [:c1], loglevel, remove_conserved)
-        li_2 = assess_local_identifiability(rs; measured_quantities = [:V, :C], known_p = [:c1], loglevel, remove_conserved)
-        ifs_2 = find_identifiable_functions(rs; measured_quantities = [:V, :C], known_p = [:c1], loglevel, remove_conserved)
-        @test sym_dict(gi_2) == Dict([:X => :nonidentifiable, :C => :globally, :V => :globally, :k => :nonidentifiable, 
-                        :c1 => :globally, :c2 => :nonidentifiable, :p => :nonidentifiable, :d => :globally])
-        @test sym_dict(li_2) == Dict([:X => 0, :C => 1, :V => 1, :k => 0, :c1 => 1, :c2 => 0, :p => 0, :d => 1])
-        @test issetequal(ifs_2, [d, c1, k*p, c1*p + c2*p])
-    end
+    gi_2 = assess_identifiability(rs; measured_quantities = [:V, :C], known_p = [:c1], loglevel, remove_conserved, mtkcompile)
+    li_2 = assess_local_identifiability(rs; measured_quantities = [:V, :C], known_p = [:c1], loglevel, remove_conserved, mtkcompile)
+    ifs_2 = find_identifiable_functions(rs; measured_quantities = [:V, :C], known_p = [:c1], loglevel, remove_conserved, mtkcompile)
+    @test sym_dict(gi_2) == Dict([:X => :nonidentifiable, :C => :globally, :V => :globally, :k => :nonidentifiable,
+                      :c1 => :globally, :c2 => :nonidentifiable, :p => :nonidentifiable, :d => :globally])
+    @test sym_dict(li_2) == Dict([:X => 0, :C => 1, :V => 1, :k => 0, :c1 => 1, :c2 => 0, :p => 0, :d => 1])
+    @test issetequal(ifs_2, [d, c1, k*p, c1*p + c2*p])
+
+    # Eliminated variables can be used in `funcs_to_check` (also within expressions).
+    gi_3 = assess_identifiability(rs; measured_quantities = [:V, :C], funcs_to_check = [C, C*c1, c1], loglevel, remove_conserved, mtkcompile)
+    @test isequal(collect(keys(gi_3)), [C, C*c1, c1])
+    @test collect(values(gi_3)) == [:globally, :nonidentifiable, :nonidentifiable]
 end
 
 # Checks that identifiability functions cannot be applied to non-complete `ReactionSystems`s.
-let 
+@testset "Incomplete ReactionSystems raise" begin
     # Create model.
     incomplete_network = @network_component begin
         (p, d), 0 <--> X
     end
     measured_quantities = [:X]
-    
+
     # Computes bifurcation diagram.
     @test_throws Exception assess_identifiability(incomplete_network; measured_quantities, loglevel)
     @test_throws Exception assess_local_identifiability(incomplete_network; measured_quantities, loglevel)
     @test_throws Exception find_identifiable_functions(incomplete_network; measured_quantities, loglevel)
+end
+
+# Covers the `funcs_to_check` kwarg: when the caller passes a custom vector of
+# expressions, the extension must route them through `make_ftc` and return an
+# identifiability verdict keyed on exactly those expressions (and no others).
+@testset "funcs_to_check kwarg" begin
+    rs = complete(@reaction_network begin
+        p, 0 --> X           # open network: no conservation law
+        d, X --> 0
+    end)
+    @unpack p, d = rs
+    out = assess_identifiability(rs; measured_quantities = [:X],
+                                 funcs_to_check = [p, d, p / d], loglevel)
+    @test length(out) == 3
+    @test all(v -> v == :globally, values(out))
+end
+
+# Covers the `ignore_no_measured_warn` kwarg and the corresponding @warn path.
+# `known_p` is passed so SI has something non-empty to feed mtk_to_si; the
+# warning path only cares that the explicit `measured_quantities` kwarg is
+# empty.
+@testset "measured_quantities warning" begin
+    rs = complete(@reaction_network begin
+        p, 0 --> X           # open network; picked to avoid upstream Issue 1
+        d, X --> 0
+    end)
+    # Default: warning fires when `measured_quantities` is empty.
+    @test_logs (:warn, r"No measured quantity") match_mode=:any make_si_ode(rs; known_p = [:p])
+    # Opt-out: no warning when `ignore_no_measured_warn = true`.
+    @test_logs min_level=Logging.Warn make_si_ode(rs; known_p = [:p],
+                                                 ignore_no_measured_warn = true)
+end
+
+# Regression: `make_osys` must return `Vector{Pair{Any, Any}}` for `conseqs` and
+# `consconsts` in every branch, matching the type guarantee stated in the comment
+# above the branch. Previously the empty-branch path produced
+# `Vector{Vector{Pair{Any, Any}}}` (a nested empty vector) which silently leaked
+# into downstream callers that inspect or append to the vector.
+@testset "make_osys return type invariants" begin
+    ext = Base.get_extension(Catalyst, :CatalystStructuralIdentifiabilityExtension)
+
+    # Network with no conservation laws.
+    rs_open = complete(@reaction_network begin
+        p, 0 --> X
+        d, X --> 0
+    end)
+    for rc in (true, false)
+        _, conseqs, consconsts, _ = ext.make_osys(rs_open; remove_conserved = rc)
+        @test conseqs    isa Vector{Pair{Any, Any}}
+        @test consconsts isa Vector{Pair{Any, Any}}
+    end
+
+    # Network with a conservation law. The type invariant must hold regardless
+    # of whether conservation laws were removed.
+    rs_closed = complete(@reaction_network begin
+        k1, x1 --> x2
+    end)
+    for rc in (true, false)
+        _, conseqs, consconsts, _ = ext.make_osys(rs_closed; remove_conserved = rc)
+        @test conseqs    isa Vector{Pair{Any, Any}}
+        @test consconsts isa Vector{Pair{Any, Any}}
+    end
 end


### PR DESCRIPTION
> **Note:** This PR should be ignored until reviewed by @ChrisRackauckas.

Rebase and completion of https://github.com/SciML/Catalyst.jl/pull/1462 (by @devmotion) onto current master. Fixes https://github.com/SciML/Catalyst.jl/issues/1485.

## What changed and why

- **Type fix in `make_osys`**: `Vector{Pair{Any, Any}}[]` was a typo producing `Vector{Vector{Pair{Any, Any}}}`. The `conseqs`/`consconsts` vectors are now built as `Pair{Any, Any}[...]` comprehensions in every branch, so the type is the same whether or not the network has conservation laws.
- **Coupled CRN/DAE support**: `make_si_ode`, `assess_identifiability`, `assess_local_identifiability`, and `find_identifiable_functions` gain a `mtkcompile::Bool = false` kwarg (same convention as `ODEProblem`). Systems with algebraic equations error informatively unless it is set. Variables eliminated by `mtkcompile` (e.g. `C` in the test model, defined by `C ~ (c1 + c2)*X/V`) are substituted by their observed expressions in `measured_quantities` and `funcs_to_check`, and mapped back to the user's symbols in the output. This is the part of #1485 that was still open after #1462.
- **`make_output`** maps SI's output keys back to the user-requested functions by index instead of re-substituting and sorting, which is what makes the eliminated-variable round trip work.
- **Tests**: `let` blocks become named `@testset`s (so one failure no longer hides the rest), the `@test_broken` coupled CRN/DAE test is restored as a real test with `mtkcompile = true` (including `C` in measured quantities and in `funcs_to_check`), and new testsets cover the `funcs_to_check` and `ignore_no_measured_warn` kwargs and the `make_osys` return types.
- **Docs**: new "Systems with algebraic equations" section on the structural identifiability page.

**Intentionally not carried over from #1462:** the `src/network_analysis.jl` and `src/reactionsystem_conversions.jl` changes (removing the `Γ => missing` default and adding `add_cl_bindings`). Maintainers asked in that thread that the core conservation-law handling stay as is, and StructuralIdentifiability has since fixed the `missing`-binding handling on its side (the extension env now resolves SI v0.5.32 and the tests pass without any `src/` change).

## Verification

Julia 1.12.7, `test/extensions` environment (`StructuralIdentifiability v0.5.32`, `ModelingToolkitBase` per the resolved manifest).

**With this PR** (the SI extension testset via `@safetestset`):
```
Test Summary:                        | Pass  Total      Time
Structural Identifiability Extension |   64     64  17m20.2s
```

**Same test file against master's extension code** (worktree at `e4fec2157`), showing the new tests discriminate:
```
Coupled CRN/DAE: Error During Test at test/extensions/structural_identifiability.jl:321
  Got exception outside of a @test
  Structural identifiability analysis is currently no supported for `ReactionSystem`s coupled with algebraic equations. ...
make_osys return type invariants: Test Failed at test/extensions/structural_identifiability.jl:428
  Expression: conseqs isa Vector{Pair{Any, Any}}
...
Test Summary:                                                 | Pass  Fail  Error  Total     Time
Structural Identifiability Extension                          |   44    10      1     55  6m47.6s
  Coupled CRN/DAE                                             |    1     2      1      4     4.4s
  make_osys return type invariants                            |          8             8
```
(On master, `assess_local_identifiability`/`find_identifiable_functions` throw SI's `DomainError` for DAEs rather than an `ErrorException`, hence the 2 fails in that testset.)

- `typos` over the changed files: clean.
- JuliaFormatter (sciml style) applied to the added lines of the extension file only. The rest of that file (and `test/`, which is formatter-ignored) is left as on master to keep this a behavior-only diff.
- Docs build: full `docs/make.jl` build ran to completion on Julia 1.12.7 (no example errors; only the usual missing-docs / size-threshold warnings). The new section renders and its `@example` output shows `C(t) => :globally`.

## CI status
- Extensions Tests pass on Julia 1, lts, and pre; all Modeling/Simulation/Hybrid/Misc/Spatial/QA jobs pass on x64.
- `Modeling (julia 1, x86)` fails in `test/network_analysis/crn_theory.jl` (`robustspecies`: `TypeError: in setfield!, expected Vector{Int32}, got a value of type Vector{Int64}`). This is pre-existing: the same job fails identically on master at 7e42f3ed5 (https://github.com/SciML/Catalyst.jl/actions/runs/34655420896/job/103454181607). This PR touches no `src/` file. Fixed separately in https://github.com/SciML/Catalyst.jl/pull/1555.
- The two `benchmark` jobs from the new AirspeedVelocity workflow were cancelled (not by this PR).

## Not verified
- Only Julia 1.12.7 was run locally; lts/pre coverage comes from CI.
- The other extension testsets (BifurcationKit, HomotopyContinuation, GraphMakie, ...) and the main `Pkg.test()` groups were not re-run; no `src/` file is touched.

## Things a reviewer may want to push back on
- `mtkcompile` defaults to `false` and errors on DAEs rather than auto-enabling, to mirror `ODEProblem`. Auto-enabling would be a one-line change.
- `observed_subs` expands observed equations by repeated substitution (bounded by the number of observed equations). This is the only new logic in the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01KjwXuMxmYxyayQcn6tNwRo
