### PR TITLE
Make robustspecies wordsize-agnostic (fix 32-bit Modeling CI on master)

### DIFF
--- a/src/network_analysis.jl
+++ b/src/network_analysis.jl
@@ -1399,7 +1399,7 @@ function robustspecies(rn::ReactionSystem)
 
         # Find the complexes that do not belong to a terminal linkage class
         nonterminal_complexes = deleteat!([1:length(complexes);], vcat(tslcs...))
-        robust_species = Int64[]
+        robust_species = Int[]
 
         for (c_s, c_p) in Combinatorics.combinations(nonterminal_complexes, 2)
             # Check the difference of all the combinations of complexes. The support is the set of indices that are non-zero


### PR DESCRIPTION
> **Note:** This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

`robustspecies` (`src/network_analysis.jl:1402`) built its result as `Int64[]` and then stored it in `NetworkProperties.robustspecies`, which is declared `Vector{Int}` (`src/reactionsystem.jl:121`). On 32-bit Julia `Int == Int32`, so the assignment throws `TypeError: in setfield!, expected Vector{Int32}, got a value of type Vector{Int64}`. This is the same class of bug as https://github.com/SciML/Catalyst.jl/pull/1552; it has been latent since `8b26cb794` ("implement robustness for deficiency one", 2024-06) and only surfaced once the 32-bit Modeling CI lane was added in https://github.com/SciML/Catalyst.jl/pull/1550. The fix is a one-token change, `Int64[]` -> `Int[]`.

Failing master CI job (commit 7e42f3ed5): https://github.com/SciML/Catalyst.jl/actions/runs/34655420896/job/103454181607

## Verification

The existing `test/network_analysis/crn_theory.jl` tests are the discriminating regression test: they error on unmodified master with 32-bit Julia and pass with the fix. Run locally with `julia +1.12~x86` (juliaup, `1.12.7+0.x86.linux.gnu`) and `julia +1.12` (`1.12.7+0.x64.linux.gnu`) via a script that `include`s the test file inside a `@testset`.

**Before the fix, 32-bit Julia 1.12.7 (unmodified master 7e42f3ed5):**
```
Julia 1.12.7, 32-bit, Int = Int32
CRN Theory: Error During Test at .../test/network_analysis/crn_theory.jl:101
  Test threw exception
  Expression: Catalyst.robustspecies(IDHKP_IDH) == [2]
  TypeError: in setfield!, expected Vector{Int32}, got a value of type Vector{Int64}
  Stacktrace:
   [1] setproperty!(nps::Catalyst.NetworkProperties{Int32, ...}, sym::Symbol, x::Vector{Int64})
     @ Catalyst .../src/reactionsystem.jl:137
   [2] robustspecies(rn::ReactionSystem{Catalyst.NetworkProperties{Int32, ...}})
     @ Catalyst .../src/network_analysis.jl:1417
CRN Theory: Error During Test at .../test/network_analysis/crn_theory.jl:114
  Test threw exception
  Expression: Catalyst.robustspecies(EnvZ_OmpR) == [6]
  TypeError: in setfield!, expected Vector{Int32}, got a value of type Vector{Int64}
Test Summary: | Pass  Error  Total     Time
CRN Theory    |   66      2     68  1m08.8s
```

**After the fix, 32-bit Julia 1.12.7:**
```
Julia 1.12.7, 32-bit, Int = Int32
Test Summary: | Pass  Total     Time
CRN Theory    |   68     68  1m34.3s
```

**After the fix, 64-bit Julia 1.12.7** (also 68/68 before the fix, i.e. no behaviour change on 64-bit):
```
Julia 1.12.7, 64-bit, Int = Int64
Test Summary: | Pass  Total     Time
CRN Theory    |   68     68  1m18.7s
```

`typos` over the diff and over `src/network_analysis.jl`: clean. `Runic.main(["--check", "--diff", "src/network_analysis.jl"])`: exit 0, no diff.

## Not verified

- Only `test/network_analysis/crn_theory.jl` was run locally, not the full `Modeling` group or the other test groups (the change is a single literal inside `robustspecies`, which no other file references besides this test and the docs).
- Docs build not run (no docstring or public API change).
- `src/` still contains other explicit `Int64` uses (e.g. `chemistry_functionality.jl:291`, `dsl.jl:577`, and throughout `spatial_reaction_systems/`); I did not audit whether any of those are assigned into `Int`-typed fields. This PR deliberately fixes only the one that fails on master CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_01KjwXuMxmYxyayQcn6tNwRo
