### PR TITLE
Release Catalyst 16.4.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Catalyst"
 uuid = "479239e8-5488-4da2-87a7-35f2df7eef83"
-version = "16.4.1"
+version = "16.4.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
Bumps `Catalyst` 16.4.1 -> 16.4.2 (patch).

Source files changed since 16.4.1:
- `ext/CatalystStructuralIdentifiabilityExtension.jl`
- `ext/CatalystStructuralIdentifiabilityExtension/structural_identifiability_extension.jl`
- `src/network_analysis.jl`

Commits:
- Make Reaction type assertions wordsize-agnostic (#1552)
- Add AirspeedVelocity benchmarking CI (#1553)
- Fix SI extension typing, add mtkcompile support for coupled DAEs, and harden tests (#1554)
- Make robustspecies wordsize-agnostic (#1555)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
