### PR TITLE
Avoid quadratic allocation when collecting reactions and equations from subsystems

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1056,7 +1056,7 @@ function reactions(network)
     rxs = get_rxs(network)
     systems = filter_nonrxsys(network)
     isempty(systems) && (return rxs)
-    return [rxs; reduce(vcat, namespace_reactions.(systems); init = Reaction[])]
+    return [rxs; reduce(vcat, namespace_reactions.(systems))]
 end
 
 """
@@ -1125,7 +1125,7 @@ function MT.equations(sys::ReactionSystem)
     if !isempty(systems)
         eqs = CatalystEqType[
             eqs;
-            reduce(vcat, MT.namespace_equations.(systems); init = CatalystEqType[])
+            reduce(vcat, MT.namespace_equations.(systems))
         ]
         return sort!(eqs; by = eqsortby)
     end


### PR DESCRIPTION
Passing `init` to `reduce(vcat, xs)` in `reactions(network)` and `MT.equations(::ReactionSystem)`opts out of the optimised `reduce` dispatch, resulting in quadratic allocation when dealing with hiearchical models. It is also unnecessary, as both functions return early when `systems` is empty.

Example allocations (MiB) for a system with N subsystems of one reaction pair each:

| N    | `reactions` master | `reactions` this PR | `equations` master | `equations` this PR |
| ---- | ------------------ | ------------------- | ------------------ | ------------------- |
| 1024 | 19.4               | 10.8                | 18.9               | 10.2                |
| 4096 | 189.4              | 43.3                | 187.7              | 40.9                |
| 8192 | 648.2              | 89.6                | 644.7              | 81.7                |

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API